### PR TITLE
Allow building inside docker container via the flag --docker.

### DIFF
--- a/bioconda_utils/example_config.yaml
+++ b/bioconda_utils/example_config.yaml
@@ -1,8 +1,5 @@
 env_matrix: ../scripts/env_matrix.yml
 blacklists:
     - r-blacklist
-index_dirs:
-  - /anaconda/conda-bld/linux-64
-  - /anaconda/conda-bld/osx-64
 #setup:
 #  - pip install git+https://github.com/bioconda/conda-build.git@reintroduce-skip-existing

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -406,7 +406,6 @@ def test_recipes(recipe_folder,
                              testonly,
                              force,
                              docker=docker)
-            conda_index(config)
 
     if not testonly:
         # upload builds
@@ -440,13 +439,6 @@ def test_recipes(recipe_folder,
                             else:
                                 raise e
     return success
-
-
-def conda_index(config):
-    if config['index_dirs']:
-        sp.run(['conda', 'index'] + config['index_dirs'],
-               check=True,
-               stdout=sp.PIPE)
 
 
 def get_blacklist(blacklists):

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -14,6 +14,9 @@ from conda_build.metadata import MetaData
 import yaml
 
 
+DOCKER_IMAGE = "continuumio/conda_builder_linux:5.11-5.2-0-1"
+
+
 def flatten_dict(dict):
     for key, values in dict.items():
         if isinstance(values, str) or not isinstance(values, Iterable):
@@ -271,7 +274,7 @@ def build(recipe,
         env = dict(env)
         env["ABI"] = 4
         container = docker.create_container(
-            image="continuumio/conda_builder_linux:latest",
+            image=DOCKER_IMAGE,
             volumes=["/home/dev/recipes", "/opt/miniconda"],
             environment=env,
             command="bash /opt/share/internal_startup.sh "
@@ -386,7 +389,7 @@ def test_recipes(recipe_folder,
 
     if docker is not None:
         print('Pulling docker image...')
-        docker.pull('continuumio/conda_builder_linux:latest')
+        docker.pull(DOCKER_IMAGE)
         print('Done.')
 
     success = True

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     description="Utilities for building and managing conda packages",
     license="MIT",
     packages=["bioconda_utils"],
-    install_requires=["argh", "networkx", "pydotplus", "pyyaml", "conda_build"],
+    install_requires=["argh", "networkx", "pydotplus", "pyyaml", "conda_build", "docker-py"],
     entry_points={"console_scripts": ["bioconda-utils = bioconda_utils.cli:main"]},
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
@bioconda/core, please check this out and post your opinion.
This PR integrates docker building into bioconda-utils itself. This has two advantages:

1. With our SUBDAG setup in travis, we have to launch the build process for each subdags. Previously, even empty subdags have triggered the docker image pull. Now, we can decide to pull the image only if the subdag is not empty. This should provide a nice speedup.
2. It becomes easier to manually build packages within the docker image. All you need to do is to add the flag --docker. Thanks to the way the image is build, it can share the `conda-bld` directory with the host, so that the package will be available on the host system.

# Important note:
I decided to switch to the docker image `continuumio/conda_builder_linux` from @msarahan. As far as I know, this image is used to build the official default channel. My hope is that this is the first step towards everbody using a common build environment. This also means that we don't have to maintain our own image anymore.