### PR TITLE
Docker with indexing

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -256,8 +256,8 @@ def build(recipe,
         typically you'd want to bump the build number rather than force
         a build.
     """
-    print("Building/testing", recipe, "for environment:")
-    print(*('\t{}={}'.format(*i) for i in sorted(env)), sep="\n")
+    print("Building/testing", recipe, "for environment:", end=' ')
+    print(*('{}={};'.format(*i) for i in sorted(env)))
     build_args = []
     if testonly:
         build_args.append("--test")
@@ -303,6 +303,7 @@ def build(recipe,
                    check=True,
                    universal_newlines=True,
                    env=merged_env(env))
+            sp.run(['conda', 'index'] + index_dirs, check=True, stdout=out)
             return True
         except sp.CalledProcessError as e:
             if e.stdout is not None:
@@ -385,7 +386,7 @@ def test_recipes(recipe_folder,
           len(recipes), "recipes).")
 
     if docker is not None:
-        print('Pulling docker image...')
+        print('Pulling docker image...', end='')
         docker.pull('continuumio/conda_builder_linux:latest')
         print('Done.')
 
@@ -403,7 +404,6 @@ def test_recipes(recipe_folder,
                              testonly,
                              force,
                              docker=docker)
-            conda_index(config)
 
     if not testonly:
         # upload builds
@@ -437,13 +437,6 @@ def test_recipes(recipe_folder,
                             else:
                                 raise e
     return success
-
-
-def conda_index(config):
-    if config['index_dirs']:
-        sp.run(['conda', 'index'] + config['index_dirs'],
-               check=True,
-               stdout=sp.PIPE)
 
 
 def get_blacklist(blacklists):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     description="Utilities for building and managing conda packages",
     license="MIT",
     packages=["bioconda_utils"],
-    install_requires=["argh", "networkx", "pydotplus", "pyyaml", "conda_build"],
+    install_requires=["argh", "networkx", "pydotplus", "pyyaml", "conda_build", "docker-py"],
     entry_points={"console_scripts": ["bioconda-utils = bioconda_utils.cli:main"]},
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
#4 didn't index the build dirs, so in a single `bioconda-utils` invocation, later recipes wouldn't see earlier-built recipes. I couldn't figure out a good way of sending the both the build command and the index command to the same container, so I split out the container-building and container-running into separate subfunctions.

This now indexes the build dir(s) correctly with or without `--docker` mode. Note that both linux-64 and osx-64 dirs are indexed even in the docker for consistency. Hopefully we can use the non-docker version for building on osx.

(also added some minor tweaks for log output)