### PR TITLE
Fix for --quick and channel filtering

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -146,6 +146,7 @@ def build_recipes(
     docker_builder=None,
     label=None,
     disable_upload=False,
+    check_channels=None,
     quick=False,
 ):
     """
@@ -186,6 +187,11 @@ def build_recipes(
     disable_upload :  bool
         If True, do not upload the package. Useful for testing.
 
+    check_channels : list
+        Channels to check to see if packages already exist in them. If None,
+        then defaults to the highest-priority channel (that is,
+        `config['channels'][-1]`)
+
     quick : bool
         Speed up recipe filtering by only checking those that are reasonably
         new.
@@ -194,6 +200,9 @@ def build_recipes(
     config = utils.load_config(config)
     env_matrix = utils.EnvMatrix(config['env_matrix'])
     blacklist = utils.get_blacklist(config['blacklists'], recipe_folder)
+
+    if check_channels is None:
+        check_channels = config['channels'][-1]
 
     logger.info('blacklist: %s', ', '.join(sorted(blacklist)))
 
@@ -233,7 +242,7 @@ def build_recipes(
     logger.info('Filtering recipes')
     recipe_targets = dict(
         utils.filter_recipes(
-            recipes, env_matrix, config['channels'], force=force)
+            recipes, env_matrix, check_channels, force=force)
     )
     recipes = list(recipe_targets.keys())
 

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -202,7 +202,7 @@ def build_recipes(
     blacklist = utils.get_blacklist(config['blacklists'], recipe_folder)
 
     if check_channels is None:
-        check_channels = config['channels'][-1]
+        check_channels = config['channels'][-1:]
 
     logger.info('blacklist: %s', ', '.join(sorted(blacklist)))
 

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -415,7 +415,8 @@ def newly_unblacklisted(config_file, recipe_folder):
     logger.debug('Examining master branch config file')
     curr = get_blacklist(
         yaml.load(open(config_file))['blacklists'], recipe_folder)
-    p = run(['git', 'show', 'master:{}'.format(config_file)])
+    p = run(['git', 'fetch', 'origin', 'master'])
+    p = run(['git', 'show', 'FETCH_HEAD:{}'.format(config_file)])
     prev = set()
     for bl in yaml.load(p.stdout)['blacklists']:
         p = run(['git', 'show', 'master:{}'.format(bl)])
@@ -430,7 +431,8 @@ def newly_unblacklisted(config_file, recipe_folder):
 
 def changed_since_master(recipe_folder):
     "Return filenames changed since master branch"
-    p = run(['git', 'diff', 'master', '--name-only'])
+    p = run(['git', 'fetch', 'origin', 'master'])
+    p = run(['git', 'diff', 'FETCH_HEAD', '--name-only'])
     return [
         os.path.dirname(os.path.relpath(i, recipe_folder))
         for i in p.stdout.splitlines(False)

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -419,7 +419,7 @@ def newly_unblacklisted(config_file, recipe_folder):
     p = run(['git', 'show', 'FETCH_HEAD:{}'.format(config_file)])
     prev = set()
     for bl in yaml.load(p.stdout)['blacklists']:
-        p = run(['git', 'show', 'master:{}'.format(bl)])
+        p = run(['git', 'show', 'FETCH_HEAD:{}'.format(bl)])
         tmp = tempfile.NamedTemporaryFile(delete=False).name
         with open(tmp, 'w') as fout:
             fout.write(p.stdout)


### PR DESCRIPTION
This PR uses `git fetch origin master` and `git diff FETCH_HEAD` for more portable comparisons with master branch than `git show master:filename`. This now works on travis-ci which uses a detached head in its cloned git repos. This allows the `--quick` option to work on travis-ci as well as locally.

The `--quick` option does not enable or disable recipes for building. That's the job of `filter_recipes`. Rather, `--quick` just reduces the set of recipes that are considered by `filter_recipes` to just those that have recently changed.

The other item in this PR: previously, a recipe would be filtered out if its build string (name-version-build) was already found in one of the configured channels (bioconda, conda-forge, defaults, r). This is not what we want though, because this precludes using bioconda to replace an existing package in another channel. So the fix is to only filter out recipes that already exist in bioconda channel. This lets us do things like build our own version of autoconf.

