### PR TITLE
mulled-build exit checks

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -125,6 +125,7 @@ def build(recipe,
 
     res = pkg_test.test_package(pkg_path)
 
+    # TODO remove the second clause once new galaxy-lib has been released.
     if (res.returncode == 0) and (res.stdout.find('Unexpected exit code') == -1):
         logger.info("BIOCONDA TEST SUCCESS %s, %s", recipe, utils.envstr(env))
         logger.debug('STDOUT:\n%s', res.stdout)

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -126,11 +126,11 @@ def build(recipe,
     res = pkg_test.test_package(pkg_path)
 
     if res.returncode == 0:
+        if res.stdout.find('Unexpected exit code') != -1:
+            return False
         logger.info("BIOCONDA TEST SUCCESS %s, %s", recipe, utils.envstr(env))
         logger.debug('STDOUT:\n%s', res.stdout)
         logger.debug('STDERR:\n%s', res.stderr)
-        if res.stdout.find('Unexpected exit code') != -1:
-            return False
         return True
     else:
         logger.error('BIOCONDA TEST FAILED: %s, %s', recipe, utils.envstr(env))

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -125,17 +125,15 @@ def build(recipe,
 
     res = pkg_test.test_package(pkg_path)
 
-    if res.returncode == 0:
-        if res.stdout.find('Unexpected exit code') != -1:
-            return False
+    if (res.returncode == 0) and (res.stdout.find('Unexpected exit code') == -1):
         logger.info("BIOCONDA TEST SUCCESS %s, %s", recipe, utils.envstr(env))
         logger.debug('STDOUT:\n%s', res.stdout)
         logger.debug('STDERR:\n%s', res.stderr)
         return True
     else:
         logger.error('BIOCONDA TEST FAILED: %s, %s', recipe, utils.envstr(env))
-        logger.debug('STDOUT:\n%s', res.stdout)
-        logger.debug('STDERR:\n%s', res.stderr)
+        logger.error('STDOUT:\n%s', res.stdout)
+        logger.error('STDERR:\n%s', res.stderr)
         return False
 
 


### PR DESCRIPTION
xrefs:

- https://github.com/bioconda/bioconda-recipes/pull/2973
- https://github.com/bioconda/bioconda-recipes/issues/2957

and probably others I can't find at the moment. Several fixes here: the mulled-build failure detection (based string in stderr) was happening *after* the logger reported success, which was confusing. Second, by returning False right away, we didn't have a chance to log the errors within `build()`. And third, the logger level for reporting those mulled-build errors was set to debug rather than error.

ping @bgruening, @mvdbeek, @martin-mann 