### PR TITLE
Resolve symlinks in tempdir path

### DIFF
--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -388,7 +388,7 @@ class RecipeBuilder(object):
         self.conda_build_args = build_args
 
         # Write build script to tempfile
-        build_dir = tempfile.mkdtemp()
+        build_dir = os.path.realpath(tempfile.mkdtemp())
         with open(os.path.join(build_dir, 'build_script.bash'), 'w') as fout:
             fout.write(self.build_script_template.format(self=self))
         build_script = fout.name


### PR DESCRIPTION
On OSX /var is a symlink to /private/var. This causes problems for
mounting in Docker unless the symlinks are resolved first. See:

* https://docs.docker.com/docker-for-mac/osxfs/#/namespaces
* https://forums.docker.com/t/getting-mounts-denied-on-previously-working-container-after-upgrading-to-v1-12-0-beta18-3-gec40b14/17546/8
* https://forums.docker.com/t/docker-for-mac-beta-does-not-handle-symlinks-when-mounting-volumes/10955/9