### PR TITLE
handle cases when notes is a list

### DIFF
--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -175,6 +175,7 @@ def setup(*args):
         # Format the README
         notes = metadata.get_section('extra').get('notes', '')
         if notes:
+            if isinstance(notes,list): notes = "\n".join(notes)
             notes = 'Notes\n-----\n\n' + notes
         summary = metadata.get_section('about').get('summary', '')
         summaries.append(summary)


### PR DESCRIPTION

docs generation is [currently failing](https://travis-ci.org/bioconda/bioconda-utils/jobs/188950019):
```
Exception occurred:
  File "/home/travis/build/bioconda/bioconda-utils/docs/source/generate_docs.py", line 178, in setup
    notes = 'Notes\n-----\n\n' + notes
TypeError: Can't convert 'list' object to str implicitly
[.......]
make: *** [html] Error 1
```

this commit adds a check to handle the cases when `notes` is a list.

but perhaps more concerning is that the builds are marked as "successful" even when the doc generation fails, is this intentional ?
pinging @daler 