### PR TITLE
Control conda versions

### DIFF
--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -50,7 +50,13 @@ logger = logging.getLogger(__name__)
      ignored.''')
 @arg('--conda-build-version',
      help='''Version of conda-build to use if building
-     in a docker container. Has no effect otherwise.''')
+     in a docker container. Has no effect otherwise. Default is to use env var
+     BIOCONDA_CONDA_BUILD_VERSION; if that does not exist then use %s'''
+     % docker_utils.DEFAULT_CONDA_BUILD_VERSION)
+@arg('--conda-version',
+     help='''Version of conda to use if building in a docker container. Has no
+     effect otherwise. Default is to use env var BIOCONDA_CONDA_VERSION; if that does
+     not exist then use %s''' % docker_utils.DEFAULT_CONDA_VERSION)
 @arg('--quick', help='''To speed up filtering, do not consider any recipes that
      are > 2 days older than the latest commit to master branch.''')
 @arg('--disable-travis-env-vars', action='store_true', help='''By default, any
@@ -66,7 +72,8 @@ def build(recipe_folder,
           mulled_test=False,
           build_script_template=None,
           pkg_dir=None,
-          conda_build_version=docker_utils.DEFAULT_CONDA_BUILD_VERSION,
+          conda_build_version=None,
+          conda_version=None,
           quick=False,
           disable_travis_env_vars=False,
           ):
@@ -94,6 +101,7 @@ def build(recipe_folder,
             pkg_dir=pkg_dir,
             use_host_conda_bld=use_host_conda_bld,
             conda_build_version=conda_build_version,
+            conda_version=conda_version,
         )
     else:
         docker_builder = None

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -97,6 +97,8 @@ mkdir -p {self.container_staging}/linux-64
 conda config --add channels file://{self.container_staging}
 
 # The actual building....
+echo "Using conda version $(conda --version)"
+echo "Using conda-build version $(conda build --version)"
 conda build {self.conda_build_args} {self.container_recipe}
 
 # Identify the output package
@@ -204,8 +206,8 @@ class RecipeBuilder(object):
         build_script_template=BUILD_SCRIPT_TEMPLATE,
         dockerfile_template=DOCKERFILE_TEMPLATE,
         use_host_conda_bld=False,
-        conda_build_version=DEFAULT_CONDA_BUILD_VERSION,
-        conda_version=DEFAULT_CONDA_VERSION,
+        conda_build_version=None,
+        conda_version=None,
         pkg_dir=None,
     ):
         """
@@ -256,6 +258,15 @@ class RecipeBuilder(object):
             Otherwise, use `pkg_dir` as a common host directory used across
             multiple runs of this RecipeBuilder object.
 
+        conda_build_version, conda_version: str or None
+            These arguments control the versions of conda and conda-build that
+            will be installed just prior to building. If None, looks for
+            environment vars BIOCONDA_CONDA_BUILD_VERSION and BIOCONDA_CONDA_VERSION
+            respectively. If these don't exist, the uses
+            `docker_utils.DEFAULT_CONDA_BUILD_VERSION` and
+            `docker_utils.DEFAULT_CONDA_VERSION`. This argument overrides the
+            environment vars.
+
         pkg_dir : str or None
             Specify where packages should appear on the host.
 
@@ -282,7 +293,15 @@ class RecipeBuilder(object):
         self.conda_build_args = ""
         self.build_script_template = build_script_template
         self.dockerfile_template = dockerfile_template
+
+        if conda_build_version is None:
+            conda_build_version = os.environ.get(
+                'BIOCONDA_CONDA_BUILD_VERSION', DEFAULT_CONDA_BUILD_VERSION)
         self.conda_build_version = conda_build_version
+
+        if conda_version is None:
+            conda_version = os.environ.get(
+                'BIOCONDA_CONDA_VERSION', DEFAULT_CONDA_VERSION)
         self.conda_version = conda_version
 
         uid = os.getuid()

--- a/pip-test-requirements.txt
+++ b/pip-test-requirements.txt
@@ -1,3 +1,3 @@
 pytest
-pytest-capturelog
+pytest-catchlog
 pytest-cov

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -697,7 +697,7 @@ class TestSubdags(object):
     def test_subdags_more_than_recipes(self, caplog, recipes_fixture):
         with utils.temp_env({'SUBDAGS': '5', 'SUBDAG': '4'}):
             self._build(recipes_fixture)
-        assert 'Nothing to be done' in caplog.records()[-1].getMessage()
+        assert 'Nothing to be done' in caplog.records[-1].getMessage()
 
 
 def test_zero_packages():


### PR DESCRIPTION
This PR makes it easier to control conda and conda-build versions, via env vars or the CLI. This will let us add

```yaml
global:
  - BIOCONDA_CONDA_VERSION=4.2.15
  - BIOCONDA_CONDA_BUILD_VERSION=2.0.7
```
to `bioconda-recipes/.travis.yaml` so that there is an obvious place to set the versions.