### PR TITLE
enable tests with PREFIX in the docker tests

### DIFF
--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -44,6 +44,10 @@ def get_tests(path):
 
     tests = ' && '.join(tests)
     tests = tests.replace('$R ', 'Rscript ')
+    # this is specific to involucro, the way how we build our containers
+    tests = tests.replace('$PREFIX', '/usr/local/')
+    tests = tests.replace('${PREFIX}', '/usr/local/')
+
     return tests
 
 


### PR DESCRIPTION
Replace $PREFIX with /usr/local
This is the location of the file inside of Docker

ping @ThomasWollmann