### PR TITLE
Optionally push linting comments to github.

### DIFF
--- a/bioconda_utils/github_integration.py
+++ b/bioconda_utils/github_integration.py
@@ -11,6 +11,30 @@ def _n(x):
     return x
 
 
+def push_comment(user, repo, pull_request_number, msg):
+    """
+    Expects GITHUB_TOKEN to exist as an env var, and uses it to authenticate.
+
+    user : str
+
+    repo : str
+
+    pull_request_number : int
+
+    msg : Markdown-formatted message
+    """
+
+    if 'GITHUB_TOKEN' not in os.environ:
+        raise ValueError("GITHUB_TOKEN not defined as an env var")
+
+    g = github.Github(os.environ['GITHUB_TOKEN'])
+    user = g.get_user(user)
+    repo = user.get_repo(repo)
+    pr = repo.get_pull(pull_request_number)
+    
+    return pr.create_issue_comment(msg)
+
+
 def update_status(user, repo, commit, state, context=None, description=None,
                   target_url=None):
     """

--- a/bioconda_utils/linting.py
+++ b/bioconda_utils/linting.py
@@ -246,3 +246,12 @@ def lint(packages, config, df, exclude=None, registry=None):
         return report
     else:
         return
+
+
+def markdown_report(report=None):
+    if report is None:
+        tmpl = utils.jinja.get_template("lint_success.md")
+        return tmpl.render()
+    else:
+        tmpl = utils.jinja.get_template("lint_failure.md")
+        return tmpl.render(report=report)

--- a/bioconda_utils/templates/lint_failure.md
+++ b/bioconda_utils/templates/lint_failure.md
@@ -1,0 +1,11 @@
+## Linting
+
+The following problems have been found
+
+{% for recipe, failed in report.failed_tests.iteritems() -%}
+| Recipe       | failed checks |
+| ------------ | ------------- |
+{% for check in failed -%}
+| {{ recipe }} | [{{ check }}](https://bioconda.github.io/linting.html#{{ check }}) |
+{%- endfor %}
+{%- endfor %}

--- a/bioconda_utils/templates/lint_success.md
+++ b/bioconda_utils/templates/lint_success.md
@@ -1,0 +1,3 @@
+## Linting
+
+Your recipes are in an excellent condition.

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -22,8 +22,15 @@ from distutils.version import LooseVersion
 from conda_build import api
 from conda_build.metadata import MetaData
 import yaml
+from jinja2 import Environment, PackageLoader, select_autoescape
 
 logger = logging.getLogger(__name__)
+
+
+jinja = Environment(
+    loader=PackageLoader('bioconda_utils', 'templates'),
+    autoescape=select_autoescape(['html', 'xml'])
+)
 
 
 @contextlib.contextmanager

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
             ],
         )
     ],
-    install_requires=["argh", "networkx", "pydotplus", "pyyaml", "requests<2.11", "jsonschema", "pandas", "colorlog"],
+    install_requires=["argh", "networkx", "pydotplus", "pyyaml", "requests<2.11", "jsonschema", "pandas", "colorlog", "jinja2"],
     entry_points={"console_scripts": [
         "bioconda-utils = bioconda_utils.cli:main",
         "bioconductor_skeleton = bioconda_utils.bioconductor_skeleton:main"


### PR DESCRIPTION
This PR implements the pushing of comments with lints to github. The new functionality is intended to run via our new buildkite setup, not via travis (although it would work for travis as well, as long as the build comes from the main repo).