### PR TITLE
Constrain filtered recipes to those where the meta.yaml file exists.

### DIFF
--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -131,7 +131,7 @@ def lint(recipe_folder, config, packages="*", cache=None, list_funcs=False,
         if not modified:
             logger.info('No recipe modified according to git, exiting.')
             return
-        recipes = [os.path.dirname(f) for f in modified if os.path.basename(f) == 'meta.yaml']
+        recipes = [os.path.dirname(f) for f in modified if os.path.basename(f) == 'meta.yaml' and os.path.exists(f)]
         logger.info('Recipes with modified meta.yaml files according to git: {}'.format('\n '.join(recipes)))
 
     report = linting.lint(


### PR DESCRIPTION
In other words, if a recipe is considered modified because it has been deleted in a PR, we don't want to lint it.