### PR TITLE
Enable build ids

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -71,10 +71,13 @@ def build(recipe,
         "BUILD START %s, env: %s",
         recipe, ';'.join(['='.join(map(str, i)) for i in sorted(_env.items())])
     )
+
     # --no-build-id is needed for some very long package names that triggers the 89 character limits
     # this option can be removed as soon as all packages are rebuild with the 255 character limit
     # Moreover, --no-build-id will block us from using parallel builds in conda-build 2.x
-    build_args = ["--no-build-id"]
+    # build_args = ["--no-build-id"]
+
+    build_args = []
     if testonly:
         build_args.append("--test")
     else:

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -805,6 +805,7 @@ class Progress:
     def progress(self):
         while not self.stop:
             print(".", end="")
+            sys.stdout.flush()
             time.sleep(60)
         print("")
 

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -640,7 +640,7 @@ def filter_recipes(recipes, env_matrix, channels=None, force=False):
     try:
         for i, recipe in enumerate(sorted(recipes)):
             perc = (i + 1) / nrecipes * 100
-            print(template.format(i + 1, nrecipes, perc, recipe))
+            print(template.format(i + 1, nrecipes, perc, recipe), end='')
             targets = set()
             for env in env_matrix:
                 pkg = built_package_path(recipe, env)
@@ -648,11 +648,13 @@ def filter_recipes(recipes, env_matrix, channels=None, force=False):
                     targets.update([Target(pkg, env)])
             if targets:
                 yield recipe, targets
+            print(end='\r')
     except sp.CalledProcessError as e:
         logger.debug(e.stdout)
         logger.error(e.stderr)
         exit(1)
-    print(flush=True)
+    finally:
+        print(flush=True)
 
 
 def get_blacklist(blacklists, recipe_folder):


### PR DESCRIPTION
An attempt to fix the apparently interleaved build logs on travis that only happens on osx.