### PR TITLE
cleanup

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -4,6 +4,7 @@ beautifulsoup4=4.4.1=py35_0
 conda=4.2.9=py35_0
 conda-build=2.0.7=py35_0
 galaxy-lib=16.10.9=py35_0
+jinja2=2.9.6=py35_0
 jsonschema=2.5.1=py35_0
 networkx=1.11=py35_0
 pyaml=15.8.2=py35_0

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -273,9 +273,9 @@ def test_get_deps():
                 - two
     """, from_string=True)
     r.write_recipes()
-    assert list(utils.get_deps(r.recipe_dirs['two'])) == ['one']
-    assert list(utils.get_deps(r.recipe_dirs['three'], build=True)) == ['one']
-    assert list(utils.get_deps(r.recipe_dirs['three'], build=False)) == ['two']
+    assert list(utils.get_deps(r.recipe_dirs['two'], config={})) == ['one']
+    assert list(utils.get_deps(r.recipe_dirs['three'], config={}, build=True)) == ['one']
+    assert list(utils.get_deps(r.recipe_dirs['three'], config={}, build=False)) == ['two']
 
 
 def test_env_matrix():


### PR DESCRIPTION
**Note: this replaces #95 with a cleaner diff to master and with all conflicts between #95 and master resolved.**

This PR is a pass through the code to make it work better with our increasing reliance on jinja templating and pinning more stuff in the env_matrix. Specifically, many functions now require a `config` argument so that the meta.yaml will be properly rendered. Often this results in a generator of rendered metadata dicts (one for each unique environment). In some cases I'm still not sure how to handle generators of recipes.

While I was working on that I made some additional changes/fixes and have rolled them into this PR:

- pin to a recent jinja2 version

- linting pays attention to blacklisting

- remove the now-defunct `--quick` option to build, which has been replaced by the `--git-range` args.

- add `--force` to lint, so that its behavior is now more consistent with build

- new `utils.bump_build_number` function, along with a tweak to how YAML files are loaded. This is in preparation for fixing lint issues. For example, replace all the `perl-threaded` deps with `perl`, and then bump the build number for any recipes that were changed. Note that some code had to be modified to work with plain dicts returned by the new parsing rather than conda_build MetaData objects.

- various docstrings and comment clarifications