### PR TITLE
return empty list instead of None

### DIFF
--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -55,7 +55,7 @@ def select_recipes(packages, git_range, recipe_folder, config_filename, config, 
         modified = utils.modified_recipes(git_range, recipe_folder, config_filename)
         if not modified:
             logger.info('No recipe modified according to git, exiting.')
-            return
+            return []
 
         # Recipes with changed `meta.yaml` or `build.sh` files
         changed_recipes = [


### PR DESCRIPTION

currently if the PR doesn't modify any recipe the build throws a exception:
```python
16:20:27 BIOCONDA INFO No recipe modified according to git, exiting.
Traceback (most recent call last):
  File "/anaconda/bin/bioconda-utils", line 11, in <module>
    load_entry_point('bioconda-utils==0.10.0', 'console_scripts', 'bioconda-utils')()
  File "/anaconda/lib/python3.5/site-packages/bioconda_utils/cli.py", line 385, in main
    argh.dispatch_commands([build, dag, dependent, lint])
  File "/anaconda/lib/python3.5/site-packages/argh-0.26.2-py3.5.egg/argh/dispatching.py", line 328, in dispatch_commands
  File "/anaconda/lib/python3.5/site-packages/argh-0.26.2-py3.5.egg/argh/dispatching.py", line 174, in dispatch
  File "/anaconda/lib/python3.5/site-packages/argh-0.26.2-py3.5.egg/argh/dispatching.py", line 277, in _execute_command
  File "/anaconda/lib/python3.5/site-packages/argh-0.26.2-py3.5.egg/argh/dispatching.py", line 260, in _call
  File "/anaconda/lib/python3.5/site-packages/bioconda_utils/cli.py", line 177, in lint
    registry=registry,
  File "/anaconda/lib/python3.5/site-packages/bioconda_utils/linting.py", line 230, in lint
    for recipe in recipes:
TypeError: 'NoneType' object is not iterable
```
ping @daler 