### PR TITLE
Custom base image definition via meta.yaml.

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -10,7 +10,7 @@ networkx=1.11=py35_0
 pyaml=15.8.2=py35_0
 pydotplus=2.0.2=py35_0
 python=3.5.2=0
-requests=2.13.0=py35_0
+requests=2.11.0=py35_0
 sphinx=1.5.*
 docutils=0.12.*
 sphinx_rtd_theme=0.1.9

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -142,7 +142,7 @@ def build(recipe,
         'TEST START via mulled-build %s, %s',
         recipe, utils.envstr(_env))
 
-    res = pkg_test.test_package(pkg_path)
+    res = pkg_test.test_package(pkg_path, base_image=)
 
     # TODO remove the second clause once new galaxy-lib has been released.
     if (res.returncode == 0) and ('Unexpected exit code' not in res.stdout):

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -142,7 +142,7 @@ def build(recipe,
         'TEST START via mulled-build %s, %s',
         recipe, utils.envstr(_env))
 
-    base_image = utils.load_meta(recipe, env)['extra']['container']['base']
+    base_image = utils.load_meta(recipe, env).get('extra/container/base', None)
 
     res = pkg_test.test_package(pkg_path, base_image=base_image)
 

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -142,7 +142,9 @@ def build(recipe,
         'TEST START via mulled-build %s, %s',
         recipe, utils.envstr(_env))
 
-    res = pkg_test.test_package(pkg_path, base_image=)
+    base_image = utils.load_meta(recipe, env)['extra']['container']['base']
+
+    res = pkg_test.test_package(pkg_path, base_image=base_image)
 
     # TODO remove the second clause once new galaxy-lib has been released.
     if (res.returncode == 0) and ('Unexpected exit code' not in res.stdout):

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -77,7 +77,8 @@ def get_image_name(path):
 def test_package(path,
                  name_override=None,
                  channels=["r", "defaults", "conda-forge"],
-                 mulled_args=""
+                 mulled_args="",
+                 base_image=None
     ):
     """
     Tests a built package in a minimal docker container.
@@ -98,6 +99,9 @@ def test_package(path,
         Mechanism for passing arguments to the mulled-build command. They will
         be split with shlex.split and passed to the mulled-build command. E.g.,
         mulled_args="--dry-run --involucro-path /opt/involucro"
+
+    base_image : None | str
+        Specify custom base image. Busybox is used in the default case.
 
     """
 
@@ -133,4 +137,8 @@ def test_package(path,
     cmd += channel_args
     cmd += shlex.split(mulled_args)
     logger.debug('mulled-build command: %s' % cmd)
-    return utils.run(cmd)
+
+    env = {}
+    if base_image is not None:
+        env["DEST_BASE_IMAGE"] = base_image
+    return utils.run(cmd, env=env)

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -141,4 +141,4 @@ def test_package(path,
     env = os.environ.copy()
     if base_image is not None:
         env["DEST_BASE_IMAGE"] = base_image
-    return utils.run(cmd, env=env)
+    return utils.run(cmd, env=env, cwd='/tmp')

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -138,7 +138,7 @@ def test_package(path,
     cmd += shlex.split(mulled_args)
     logger.debug('mulled-build command: %s' % cmd)
 
-    env = {}
+    env = os.environ.copy()
     if base_image is not None:
         env["DEST_BASE_IMAGE"] = base_image
     return utils.run(cmd, env=env)

--- a/test/test_pkg_test.py
+++ b/test/test_pkg_test.py
@@ -35,7 +35,7 @@ one:
       version: 0.1
     test:
       commands:
-        - "ls - la"
+        - "ls -la"
     extra:
       container:
         base: "debian:latest"

--- a/test/test_pkg_test.py
+++ b/test/test_pkg_test.py
@@ -77,5 +77,5 @@ def test_pkg_test_custom_base_image():
     """
     Running a mulled-build test with a custom base image.
     """
-    built_package = _build_pkg(RECIPE_CUSTOM_BASE)
+    build_package = _build_pkg(RECIPE_CUSTOM_BASE)
     res = pkg_test.test_package(build_package, base_image='debian:latest')

--- a/test/test_pkg_test.py
+++ b/test/test_pkg_test.py
@@ -14,18 +14,36 @@ from bioconda_utils import build
 # https://github.com/bioconda/bioconda-utils/issues/31)
 #
 
-def _build_pkg():
-    r = Recipes(dedent(
-        """
-        one:
-          meta.yaml: |
-            package:
-              name: one
-              version: 0.1
-            test:
-              commands:
-                - "ls -la"
-        """), from_string=True)
+
+RECIPE_ONE = dedent("""
+one:
+  meta.yaml: |
+    package:
+      name: one
+      version: 0.1
+    test:
+      commands:
+        - "ls -la"
+""")
+
+
+RECIPE_CUSTOM_BASE = dedent("""
+two:
+  meta.yaml: |
+    package:
+      name: two
+      version: 0.1
+    test:
+      commands:
+        - "ls - la"
+    extra:
+      container:
+        base: "debian:latest"
+""")
+
+
+def _build_pkg(recipe):
+    r = Recipes(recipe, from_string=True)
     r.write_recipes()
     env_matrix = list(utils.EnvMatrix(tmp_env_matrix()))[0]
     recipe = r.recipe_dirs['one']
@@ -40,16 +58,24 @@ def _build_pkg():
 
 def test_pkg_test():
     """
-    Running a mulled-build test shouldn't cause any errors
+    Running a mulled-build test shouldn't cause any errors.
     """
-    built_package = _build_pkg()
+    built_package = _build_pkg(RECIPE_ONE)
     res = pkg_test.test_package(built_package)
 
 
 def test_pkg_test_mulled_build_error():
     """
-    Make sure calling mulled-build with the wrong arg fails correctly
+    Make sure calling mulled-build with the wrong arg fails correctly.
     """
-    built_package = _build_pkg()
+    built_package = _build_pkg(RECIPE_ONE)
     with pytest.raises(sp.CalledProcessError):
         res = pkg_test.test_package(built_package, mulled_args='--wrong-arg')
+
+
+def test_pkg_test_custom_base_image():
+    """
+    Running a mulled-build test with a custom base image.
+    """
+    built_package = _build_pkg(RECIPE_CUSTOM_BASE)
+    res = pkg_test.test_package(build_package)

--- a/test/test_pkg_test.py
+++ b/test/test_pkg_test.py
@@ -28,10 +28,10 @@ one:
 
 
 RECIPE_CUSTOM_BASE = dedent("""
-two:
+one:
   meta.yaml: |
     package:
-      name: two
+      name: one
       version: 0.1
     test:
       commands:

--- a/test/test_pkg_test.py
+++ b/test/test_pkg_test.py
@@ -78,4 +78,4 @@ def test_pkg_test_custom_base_image():
     Running a mulled-build test with a custom base image.
     """
     built_package = _build_pkg(RECIPE_CUSTOM_BASE)
-    res = pkg_test.test_package(build_package)
+    res = pkg_test.test_package(build_package, base_image='debian:latest')

--- a/test/test_pkg_test.py
+++ b/test/test_pkg_test.py
@@ -15,6 +15,9 @@ from bioconda_utils import build
 #
 
 
+SKIP_OSX = os.environ.get('TRAVIS_OS_NAME') == 'osx'
+
+
 RECIPE_ONE = dedent("""
 one:
   meta.yaml: |
@@ -56,6 +59,7 @@ def _build_pkg(recipe):
     return built_package
 
 
+@pytest.mark.skipif(SKIP_OSX, reason='skipping on osx')
 def test_pkg_test():
     """
     Running a mulled-build test shouldn't cause any errors.
@@ -64,6 +68,7 @@ def test_pkg_test():
     res = pkg_test.test_package(built_package)
 
 
+@pytest.mark.skipif(SKIP_OSX, reason='skipping on osx')
 def test_pkg_test_mulled_build_error():
     """
     Make sure calling mulled-build with the wrong arg fails correctly.
@@ -73,6 +78,7 @@ def test_pkg_test_mulled_build_error():
         res = pkg_test.test_package(built_package, mulled_args='--wrong-arg')
 
 
+@pytest.mark.skipif(SKIP_OSX, reason='skipping on osx')
 def test_pkg_test_custom_base_image():
     """
     Running a mulled-build test with a custom base image.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -84,13 +84,16 @@ def single_build(request, recipes_fixture):
     env_matrix = list(utils.EnvMatrix(tmp_env_matrix()))[0]
     if request.param:
         docker_builder = docker_utils.RecipeBuilder(use_host_conda_bld=True)
+        mulled_test = True
     else:
         docker_builder = None
+        mulled_test = False
     build.build(
         recipe=recipes_fixture.recipe_dirs['one'],
         recipe_folder='.',
         docker_builder=docker_builder,
         env=env_matrix,
+        mulled_test=mulled_test,
     )
     built_package = recipes_fixture.pkgs['one']
     yield built_package
@@ -107,12 +110,15 @@ def multi_build(request, recipes_fixture):
     """
     if request.param:
         docker_builder = docker_utils.RecipeBuilder(use_host_conda_bld=True)
+        mulled_test = True
     else:
         docker_builder = None
+        mulled_test = False
     build.build_recipes(
         recipe_folder=recipes_fixture.basedir,
         docker_builder=docker_builder,
         config={},
+        mulled_test=mulled_test,
     )
     built_packages = recipes_fixture.pkgs
     yield built_packages
@@ -185,6 +191,7 @@ def test_single_build_only(single_build):
     assert os.path.exists(single_build)
 
 
+@pytest.mark.skipif(SKIP_DOCKER_TESTS, reason='skipping on osx')
 def test_single_build_with_post_test(single_build):
     pkg_test.test_package(single_build)
 


### PR DESCRIPTION
This PR allows to define a custom base image for mulled via
```
extra:
  container:
    base: "<baseimage>"
```