### PR TITLE
Remove check for the case of having multiple recipes for the same package name.

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -310,13 +310,6 @@ def get_dag(recipes, config, blacklist=None, restrict=True):
         if name not in blacklist:
             name2recipe[name].update([recipe])
 
-    for k, v in name2recipe.items():
-        if len(v) != 1:
-            raise ValueError(
-                "Multiple recipes identified for the same package:\n"
-                "package={0}, recipes={0}"
-                .format(k, v))
-
     def get_inner_deps(dependencies):
         for dep in dependencies:
             name = dep.split()[0]


### PR DESCRIPTION
This is common, because we sometimes store multiple versions of the same recipe in subdirectories.
Hence, it should not fail.

The regression was introduced in PR #114. This change should not affect the main benefit of that PR. Since we still use a set, there cannot be multiple builds of the same recipe.