### PR TITLE
Fix noarch errors. Fix sub-recipe problems.

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -122,8 +122,11 @@ def build(recipe,
 
             # Temporarily reset os.environ to avoid leaking env vars to
             # conda-build, and explicitly provide `env` to `run()`
+            # we explicitly point to the meta.yaml, in order to keep
+            # conda-build from building all subdirectories
             with utils.sandboxed_env(_env):
-                cmd = CONDA_BUILD_CMD + build_args + channel_args + [recipe]
+                cmd = CONDA_BUILD_CMD + build_args + channel_args + \
+                      [os.path.join(recipe, 'meta.yaml')]
                 logger.debug('command: %s', cmd)
                 with utils.Progress():
                     p = utils.run(cmd, env=os.environ)

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -103,7 +103,7 @@ conda config --add channels file://{self.container_staging}  > /dev/null 2>&1
 conda build {self.conda_build_args} {self.container_recipe}/meta.yaml 2>&1
 
 # Identify the output package
-OUTPUT=$(conda build {self.container_recipe} --output 2> /dev/null)
+OUTPUT=$(conda build {self.container_recipe}/meta.yaml --output 2> /dev/null)
 
 # Some args to conda-build make it run and exit 0 without creating a package
 # (e.g., -h or --skip-existing), so check to see if there's anything to copy

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -91,13 +91,16 @@ conda install conda-build={self.conda_build_version} conda={self.conda_version} 
 #
 # Note that if the directory didn't exist on the host, then the staging area
 # will exist in the container but will be empty.  Channels expect at least
-# a linux-64 directory within that directory, so we make sure it exists before
-# adding the channel.
+# a linux-64 and noarch directory within that directory, so we make sure it
+# exists before adding the channel.
 mkdir -p {self.container_staging}/linux-64
+mkdir -p {self.container_staging}/noarch
 conda config --add channels file://{self.container_staging}  > /dev/null 2>&1
 
-# The actual building....
-conda build {self.conda_build_args} {self.container_recipe} 2>&1
+# The actual building...
+# we explicitly point to the meta.yaml, in order to keep
+# conda-build from building all subdirectories
+conda build {self.conda_build_args} {self.container_recipe}/meta.yaml 2>&1
 
 # Identify the output package
 OUTPUT=$(conda build {self.container_recipe} --output 2> /dev/null)
@@ -108,15 +111,14 @@ OUTPUT=$(conda build {self.container_recipe} --output 2> /dev/null)
 if [[ -e $OUTPUT ]]; then
 
     # Copy over the recipe from where the container built it to the mounted
-    # conda-bld dir from the host. Since docker containers are Linux, we assume
-    # here that we want the linux-64 arch.
-    cp $OUTPUT {self.container_staging}/linux-64
+    # conda-bld dir from the host. The arch will be either linux-64 or noarch.
+    cp $OUTPUT {self.container_staging}/{arch}
 
     # Ensure permissions are correct on the host.
     HOST_USER={self.user_info[uid]}
-    chown $HOST_USER:$HOST_USER {self.container_staging}/linux-64/$(basename $OUTPUT)
+    chown $HOST_USER:$HOST_USER {self.container_staging}/{arch}/$(basename $OUTPUT)
 
-    conda index {self.container_staging}/linux-64 > /dev/null 2>&1
+    conda index {self.container_staging}/{arch} > /dev/null 2>&1
 fi
 """
 
@@ -363,7 +365,7 @@ class RecipeBuilder(object):
         shutil.rmtree(build_dir)
         return p
 
-    def build_recipe(self, recipe_dir, build_args, env):
+    def build_recipe(self, recipe_dir, build_args, env, noarch=False):
         """
         Build a single recipe.
 
@@ -380,6 +382,9 @@ class RecipeBuilder(object):
         env : dict
             Environmental variables
 
+        noarch: bool
+            Has to be set to true if this is a noarch build
+
         Note that the binds are set up automatically to match the expectations
         of the build script, and will use the currently-configured
         self.container_staging and self.container_recipe.
@@ -394,7 +399,8 @@ class RecipeBuilder(object):
         # Write build script to tempfile
         build_dir = os.path.realpath(tempfile.mkdtemp())
         with open(os.path.join(build_dir, 'build_script.bash'), 'w') as fout:
-            fout.write(self.build_script_template.format(self=self))
+            fout.write(self.build_script_template.format(
+                self=self, arch='noarch' if noarch else 'linux-64'))
         build_script = fout.name
         logger.debug('DOCKER: Container build script: \n%s', open(fout.name).read())
 

--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -222,6 +222,20 @@ def should_be_noarch(recipe, meta, df):
         }
 
 
+def should_not_be_noarch(recipe, meta, df):
+    deps = _get_deps(meta)
+    if (
+        ('gcc' in deps) or
+        meta.get('build', {}).get('skip', False)
+    ) and (
+        'noarch' in meta.get('build', {})
+    ):
+        return {
+            'should_not_be_noarch': True,
+            'fix': 'remove "build: noarch" section',
+        }
+
+
 registry = (
     in_other_channels,
 
@@ -238,4 +252,5 @@ registry = (
     uses_setuptools,
     has_windows_bat_file,
     # should_be_noarch,
+    should_not_be_noarch
 )

--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -209,6 +209,9 @@ def should_be_noarch(recipe, meta, df):
     if (
         ('gcc' not in deps) and
         ('python' in deps) and
+        # This will also exclude recipes with skip sections
+        # which is a good thing, because noarch also implies independence of
+        # the python version.
         not _has_preprocessing_selector(recipe)
     ) and (
         'noarch' not in meta.get('build', {})

--- a/docs/source/linting.rst
+++ b/docs/source/linting.rst
@@ -124,10 +124,12 @@ Reason for failing: The package should be labelled as ``noarch``.
 
 Rationale: A ``noarch`` package should be created for pure Python packages, data packages, or
 packages that do not require compilation. With this a single ``noarch`` package can be
-used across multiple platforms, which saves on build time and saves on storage
-space on the bioconda channel.
+used across multiple platforms and (in case of Python) Python versions, which saves
+on build time and saves on storage space on the bioconda channel.
 
 How to resolve: For pure Python packages, add ``noarch: python`` to the ``build`` section.
+**Don't do this if your Python package has a command line interface**, as these are not
+independent of the Python version!
 For other generic packages (like a data package), add ``noarch: generic`` to the ``build`` section.
 See `here <https://www.continuum.io/blog/developer-blog/condas-new-noarch-packages>`_ for
 more details.

--- a/docs/source/linting.rst
+++ b/docs/source/linting.rst
@@ -134,6 +134,18 @@ For other generic packages (like a data package), add ``noarch: generic`` to the
 See `here <https://www.continuum.io/blog/developer-blog/condas-new-noarch-packages>`_ for
 more details.
 
+`should_not_be_noarch`
+~~~~~~~~~~~~~~~~~~~~~~
+Reason for failing: The package should **not** be labelled as ``noarch``.
+
+Rationale: The package defines gcc as a dependency, or it contains a build/skip
+section. In both cases, this means that there should be platform specific
+versions of this package. This also holds for skipping Python versions, because
+``noarch: python`` also implies that the resulting package will work with **all**
+Python versions. This is typically not the case if you skip a Python version.
+
+How to resolve: Remove the ``noarch`` statement.
+
 `uses_git_url`
 ~~~~~~~~~~~~~~
 Reason for failing: The source section uses a git URL.


### PR DESCRIPTION
1. Fix noarch building (use correct output folder in the container) (see PR bioconda/bioconda-recipes#5014).
2. Keep conda from building subdirectories by explicitly specifying meta.yaml (see PR bioconda/bioconda-recipes#5011).