### PR TITLE
Whitelist MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -43,6 +43,7 @@ ENV_VAR_WHITELIST = [
     'PATH',
     'LC_*',
     'LANG',
+    'MACOSX_DEPLOYMENT_TARGET'
 ]
 
 


### PR DESCRIPTION
Such that we can set it in our global travis configuration.