### PR TITLE
fix test to handle cases where GITHUB_TOKEN is already set

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -676,7 +676,7 @@ def test_string_or_float_to_integer_python():
     assert f(27) == f('27') == f(2.7) == f('2.7') == 27
 
 
-def test_rendering_sandboxing():
+def test_rendering_sandboxing(caplog):
     r = Recipes(
         """
         one:
@@ -697,15 +697,34 @@ def test_rendering_sandboxing():
         'BUILDKITE_TOKEN': 'asdf',
     }
 
-    # recipe for "one" should fail because GITHUB_TOKEN is not a jinja var.
-    with pytest.raises(SystemExit) as excinfo:
+    # If GITHUB_TOKEN is already set in the bash environment, then we get
+    # a message on stdout+stderr (this is the case on travis-ci).
+    #
+    # However if GITHUB_TOKEN is not already set in the bash env (e.g., when
+    # testing locally), then we get a SystemError.
+    #
+    # In both cases we're passing in the `env` dict, which does contain
+    # GITHUB_TOKEN.
+
+    if 'GITHUB_TOKEN' in os.environ:
         res = build.build(
             recipe=r.recipe_dirs['one'],
             recipe_folder='.',
             env=env,
-            mulled_test=False
+            mulled_test=False,
         )
-    assert "'GITHUB_TOKEN' is undefined" in str(excinfo.value)
+        assert ("Undefined Jinja2 variables remain (['GITHUB_TOKEN']).  "
+                "Please enable source downloading and try again.") in caplog.text
+    else:
+        # recipe for "one" should fail because GITHUB_TOKEN is not a jinja var.
+        with pytest.raises(SystemExit) as excinfo:
+            res = build.build(
+                recipe=r.recipe_dirs['one'],
+                recipe_folder='.',
+                env=env,
+                mulled_test=False
+            )
+        assert "'GITHUB_TOKEN' is undefined" in str(excinfo.value)
 
     r = Recipes(
         """


### PR DESCRIPTION
@nsoranzo turns out conda-build handles rendering differently based on whether the env var is already set or not. This PR makes the test handle both cases. I haven't worked out exactly why the error is different depending on the situation, but in both cases the env is properly sandboxed.