### PR TITLE
support for bioconda-recipes #5227

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -7,7 +7,6 @@ from . import utils
 from . import docker_utils
 from . import pkg_test
 from . import upload
-from conda_build import api
 
 logger = logging.getLogger(__name__)
 
@@ -26,15 +25,16 @@ def purge():
                     utils.get_free_space())
 
 
-def build(recipe,
-          recipe_folder,
-          env,
-          testonly=False,
-          mulled_test=True,
-          force=False,
-          channels=None,
-          docker_builder=None,
-    ):
+def build(
+    recipe,
+    recipe_folder,
+    env,
+    testonly=False,
+    mulled_test=True,
+    force=False,
+    channels=None,
+    docker_builder=None,
+):
     """
     Build a single recipe for a single env
 
@@ -71,8 +71,8 @@ def build(recipe,
     # Clean provided env and exisiting os.environ to only allow whitelisted env
     # vars
     _env = {}
-    _env.update({k:str(v) for k, v in os.environ.items() if utils.allowed_env_var(k)})
-    _env.update({k:str(v) for k, v in dict(env).items() if utils.allowed_env_var(k)})
+    _env.update({k: str(v) for k, v in os.environ.items() if utils.allowed_env_var(k)})
+    _env.update({k: str(v) for k, v in dict(env).items() if utils.allowed_env_var(k)})
 
     logger.info(
         "BUILD START %s, env: %s",

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -331,6 +331,9 @@ def lint(recipe_folder, config, packages="*", cache=None, list_funcs=False,
      in a docker container. Has no effect otherwise.''')
 @arg('--anaconda-upload', action='store_true', help='''After building recipes, upload
      them to Anaconda. This requires $ANACONDA_TOKEN to be set.''')
+@arg('--keep-image', action='store_true', help='''After building recipes, the
+     created Docker image is removed by default to save disk space. Use this
+     argument to disable this behavior.''')
 def build(recipe_folder,
           config,
           packages="*",
@@ -345,6 +348,7 @@ def build(recipe_folder,
           conda_build_version=docker_utils.DEFAULT_CONDA_BUILD_VERSION,
           anaconda_upload=False,
           mulled_upload_target=None,
+          keep_image=False,
     ):
     setup_logger(loglevel)
 
@@ -389,6 +393,7 @@ def build(recipe_folder,
             pkg_dir=pkg_dir,
             use_host_conda_bld=use_host_conda_bld,
             conda_build_version=conda_build_version,
+            keep_image=keep_image,
         )
     else:
         docker_builder = None

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -2,14 +2,11 @@
 
 import sys
 import os
-import subprocess as sp
-from functools import partial
 import shlex
 import logging
 from colorlog import ColoredFormatter
 from collections import defaultdict
 
-import yaml
 import argh
 from argh import arg
 import networkx as nx
@@ -43,8 +40,6 @@ logger = logging.getLogger(__name__)
 
 
 def setup_logger(loglevel):
-    LEVEL = getattr(logging, loglevel.upper())
-    #logging.basicConfig(level=LEVEL, format='%(levelname)s:%(name)s:%(message)s')
     l = logging.getLogger('bioconda_utils')
     l.propagate = False
     l.setLevel(getattr(logging, loglevel.upper()))
@@ -61,8 +56,8 @@ def select_recipes(packages, git_range, recipe_folder, config_filename, config, 
         # Recipes with changed `meta.yaml` or `build.sh` files
         changed_recipes = [
             os.path.dirname(f) for f in modified
-            if os.path.basename(f) in ['meta.yaml', 'build.sh']
-            and os.path.exists(f)
+            if os.path.basename(f) in ['meta.yaml', 'build.sh'] and
+            os.path.exists(f)
         ]
         logger.info('Recipes to consider according to git: \n{}'.format('\n '.join(changed_recipes)))
     else:
@@ -81,7 +76,7 @@ def select_recipes(packages, git_range, recipe_folder, config_filename, config, 
             logger.debug('blacklisted: %s', recipe)
             continue
         if git_range:
-            if not recipe in changed_recipes:
+            if recipe not in changed_recipes:
                 continue
         _recipes.append(recipe)
         logger.debug(recipe)
@@ -109,12 +104,12 @@ def duplicates(
     strict_build=False,
     dryrun=False,
     remove=False,
-    url=False):
+    url=False
+):
     """
     Detect packages in bioconda that have duplicates in the other defined
     channels.
     """
-    config_filename = config
     config = utils.load_config(config)
 
     channels = config['channels']
@@ -139,9 +134,12 @@ def duplicates(
                              '--strict-build.')
         fn = '{}-{}-{}.tar.bz2'.format(*spec)
         name, version = spec[:2]
-        subcmd = ['remove', '-f',
-               '{channel}/{name}/{version}/{fn}'.format(
-               name=name, version=version, fn=fn, channel=target_channel)]
+        subcmd = [
+            'remove', '-f',
+            '{channel}/{name}/{version}/{fn}'.format(
+                name=name, version=version, fn=fn, channel=target_channel
+            )
+        ]
         if dryrun:
             print('anaconda', *subcmd)
         else:
@@ -296,7 +294,6 @@ def lint(recipe_folder, config, packages="*", cache=None, list_funcs=False,
                 user, repo, pull_request, msg)
 
 
-
 @arg('recipe_folder', help='Path to top-level dir of recipes.')
 @arg('config', help='Path to yaml file specifying the configuration')
 @arg(
@@ -334,22 +331,23 @@ def lint(recipe_folder, config, packages="*", cache=None, list_funcs=False,
 @arg('--keep-image', action='store_true', help='''After building recipes, the
      created Docker image is removed by default to save disk space. Use this
      argument to disable this behavior.''')
-def build(recipe_folder,
-          config,
-          packages="*",
-          git_range=None,
-          testonly=False,
-          force=False,
-          docker=None,
-          loglevel="info",
-          mulled_test=False,
-          build_script_template=None,
-          pkg_dir=None,
-          conda_build_version=docker_utils.DEFAULT_CONDA_BUILD_VERSION,
-          anaconda_upload=False,
-          mulled_upload_target=None,
-          keep_image=False,
-    ):
+def build(
+    recipe_folder,
+    config,
+    packages="*",
+    git_range=None,
+    testonly=False,
+    force=False,
+    docker=None,
+    loglevel="info",
+    mulled_test=False,
+    build_script_template=None,
+    pkg_dir=None,
+    conda_build_version=docker_utils.DEFAULT_CONDA_BUILD_VERSION,
+    anaconda_upload=False,
+    mulled_upload_target=None,
+    keep_image=False,
+):
     setup_logger(loglevel)
 
     cfg = utils.load_config(config)
@@ -371,8 +369,9 @@ def build(recipe_folder,
 
         packages = list(
             set(
-                [os.path.dirname(os.path.relpath(f, recipe_folder))
-                 for f in modified
+                [
+                    os.path.dirname(os.path.relpath(f, recipe_folder))
+                    for f in modified
                 ]
             )
         )

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -116,11 +116,13 @@ if [[ -e $OUTPUT ]]; then
     # conda-bld dir from the host. The arch will be either linux-64 or noarch.
     cp $OUTPUT {self.container_staging}/{arch}
 
+    conda index {self.container_staging}/{arch} > /dev/null 2>&1
+
     # Ensure permissions are correct on the host.
     HOST_USER={self.user_info[uid]}
     chown $HOST_USER:$HOST_USER {self.container_staging}/{arch}/$(basename $OUTPUT)
+    chown $HOST_USER:$HOST_USER {self.container_staging}/{arch}/{{repodata.json,repodata.json.bz2,.index.json}}
 
-    conda index {self.container_staging}/{arch} > /dev/null 2>&1
 fi
 """
 

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -213,6 +213,7 @@ class RecipeBuilder(object):
         conda_build_version=DEFAULT_CONDA_BUILD_VERSION,
         conda_version=DEFAULT_CONDA_VERSION,
         pkg_dir=None,
+        keep_image=False,
     ):
         """
         Class to handle building a custom docker container that can be used for
@@ -281,6 +282,11 @@ class RecipeBuilder(object):
 
             In all cases, `pkg_dir` will be mounted to `container_staging` in
             the container.
+
+        keep_image : bool
+            By default, the built docker image will be removed when done,
+            freeing up storage space.  Set keep_image=True to disable this
+            behavior.
         """
         self.image = image
         self.tag = tag
@@ -290,6 +296,7 @@ class RecipeBuilder(object):
         self.dockerfile_template = dockerfile_template
         self.conda_build_version = conda_build_version
         self.conda_version = conda_version
+        self.keep_image = keep_image
 
         # To address issue #5027:
         #
@@ -354,7 +361,8 @@ class RecipeBuilder(object):
         self._build_image()
 
     def __del__(self):
-        self.cleanup()
+        if not self.keep_image:
+            self.cleanup()
 
     def _pull_image(self):
         """

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -50,8 +50,6 @@ import subprocess as sp
 import tempfile
 import pwd
 import grp
-import argparse
-from io import BytesIO
 from textwrap import dedent
 import pkg_resources
 
@@ -460,7 +458,6 @@ class RecipeBuilder(object):
                 self=self, pkg=pkg, arch='noarch' if noarch else 'linux-64'))
         build_script = fout.name
         logger.debug('DOCKER: Container build script: \n%s', open(fout.name).read())
-
 
         # Build the args for env vars. Note can also write these to tempfile
         # and use --env-file arg, but using -e seems clearer in debug output.

--- a/bioconda_utils/linting.py
+++ b/bioconda_utils/linting.py
@@ -92,7 +92,6 @@ def get_meta(recipe, config):
         Config YAML or dict
     """
     cfg = utils.load_config(config)
-    env_matrix = cfg['env_matrix']
 
     # TODO: Currently just uses the first env. Should turn this into
     # a generator.

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -74,12 +74,13 @@ def get_image_name(path):
     return spec
 
 
-def test_package(path,
-                 name_override=None,
-                 channels=["conda-forge", "defaults"],
-                 mulled_args="",
-                 base_image=None
-    ):
+def test_package(
+    path,
+    name_override=None,
+    channels=["conda-forge", "defaults"],
+    mulled_args="",
+    base_image=None
+):
     """
     Tests a built package in a minimal docker container.
 
@@ -120,7 +121,7 @@ def test_package(path,
     if isinstance(channels, str):
         channels = [channels]
     extra_channels.extend(channels)
-    channel_args = ['--extra-channels',','.join(extra_channels)]
+    channel_args = ['--extra-channels', ','.join(extra_channels)]
 
     tests = get_tests(path)
     logger.debug('Tests to run: %s', tests)
@@ -145,4 +146,4 @@ def test_package(path,
         with utils.Progress():
             p = utils.run(cmd, env=env, cwd=d)
 
-    return p 
+    return p

--- a/bioconda_utils/upload.py
+++ b/bioconda_utils/upload.py
@@ -4,6 +4,7 @@ import logging
 from . import utils
 logger = logging.getLogger(__name__)
 
+
 def anaconda_upload(package, token=None, label=None):
     """
     Upload a package to anaconda.

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -16,16 +16,14 @@ import networkx as nx
 import requests
 from jsonschema import validate
 import datetime
-import tempfile
 from distutils.version import LooseVersion
 import time
 import threading
 
-from conda_build.exceptions import UnableToParse
 from conda_build import api
 from conda_build.metadata import MetaData
 import yaml
-from jinja2 import Environment, PackageLoader, select_autoescape
+from jinja2 import Environment, PackageLoader
 
 logger = logging.getLogger(__name__)
 
@@ -608,7 +606,7 @@ def newly_unblacklisted(config_file, recipe_folder, git_range):
     current = get_blacklist(
         yaml.load(
             file_from_commit(git_range[1], config_file))['blacklists'],
-            recipe_folder)
+        recipe_folder)
     results = previous.difference(current)
     logger.info('Recipes newly unblacklisted:\n%s', '\n'.join(list(results)))
     return results
@@ -701,7 +699,8 @@ def filter_recipes(recipes, env_matrix, channels=None, force=False):
                                          pkg)
                             return False
 
-        assert not pkg.endswith("_.tar.bz2"), ("rendered path {} does not "
+        assert not pkg.endswith("_.tar.bz2"), (
+            "rendered path {} does not "
             "contain a build number and recipe does not "
             "define skip for this environment. "
             "This is a conda bug.".format(pkg))
@@ -860,7 +859,7 @@ def modified_recipes(git_range, recipe_folder, config_file):
     # run the command using shell=True to get the shell to expand globs.
     shell = False
     p = run(['git', '--version'])
-    matches = re.match(r'^git version (?P<version>[\d\.]*)(?:.*)$',p.stdout)
+    matches = re.match(r'^git version (?P<version>[\d\.]*)(?:.*)$', p.stdout)
     git_version = matches.group("version")
     if git_version < LooseVersion('2'):
         logger.warn(

--- a/docs/source/contrib-setup.rst
+++ b/docs/source/contrib-setup.rst
@@ -1,20 +1,42 @@
-
 One-time setup
 --------------
-
 
 .. _github-setup:
 
 Git and GitHub (one-time setup)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Decide whether you'll work on a clone or a fork.
+
+Choose a clone if:
+
+- You are a bioconda team member (post on `issue #1
+  <https://github.com/bioconda/bioconda-recipes/issues/1>`_ if you'd like to
+  join). Team members have write access to branches other than the master
+  branch.
+
+- You want to have other team members make changes directly to your branch
+
+Choose a fork if:
+
+- you are not yet a member of the bioconda team
+- you expect to do lots of testing or lots of troubleshooting. This will allow
+  you to use your own quota on travis-ci, so your builds will likely happen
+  faster and you won't be consuming limited bioconda quota.
+
+Using a clone
++++++++++++++
+
+Clone the main repo::
+
+    git clone https://github.com/bioconda/bioconda-recipes.git
+
+Using a fork
+++++++++++++
+
 - Create a `fork <https://help.github.com/articles/fork-a-repo/>`_ of
   `bioconda-recipes on GitHub <https://github.com/bioconda/bioconda-recipes>`_
-  and clone it locally. Even if you are a member of the bioconda team with push
-  access, using your own fork will allow testing of your recipes on travis-ci
-  using your own account's free resources without consuming resources allocated
-  by travis-ci to the `bioconda` group. This makes the tests go faster for
-  everyone::
+  and clone it locally::
 
     git clone https://github.com/<USERNAME>/bioconda-recipes.git
 
@@ -28,29 +50,13 @@ Git and GitHub (one-time setup)
     git remote add upstream https://github.com/bioconda/bioconda-recipes.git
 
 
-Install conda and Docker (one-time setup)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Install Docker (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Installing `Docker <https://www.docker.com/>`_ is optional, but allows you to
+simulate most closely the Travis-CI tests.
 
-Currently, you need to install the requirements (see below) into the root
-conda environment which must be a Python 3 environment.
-
-1. Install `conda <http://conda.pydata.org/miniconda.html>`_. The Python
-   3 version is required.
-
-2. Install `conda-build <https://conda.io/docs/building/recipe.html>`_. Note
-   that the installation must be done from the root `conda` environment, so you
-   will need to `source deactivate` your current environment. If you'd like to
-   read an extensive discussion about `conda` and root vs default environments,
-   check out `this discussion <https://github.com/conda/conda/issues/1145>`_
-
-3. Install `Docker <https://www.docker.com/>`_. (optional, but allows you to
-   simulate most closely the Travis-CI tests).
-
-Please note that it is also required to build *any* recipe prior to using the
-`simulate-travis.py` command as explained :ref:`here <test-locally>`.
-
-Request to be added to the bioconda team
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Request to be added to the bioconda team (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 While not required, you can be added to the bioconda by posting in `Issue #1
 <https://github.com/bioconda/recipes/issues/1>`_. Members of the bioconda team
 can merge their own recipes once tests pass, though we ask that first-time

--- a/docs/source/contribute-a-recipe.rst
+++ b/docs/source/contribute-a-recipe.rst
@@ -4,35 +4,55 @@ Contributing a recipe
 The following steps are done for each recipe or batch of recipes you'd like to
 contribute.
 
-Update repo and requirements
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Update repo
+~~~~~~~~~~~
 
-1. Before starting, it's best to update your fork with any changes made
-   recently to the upstream bioconda repo. Assuming you've set up your fork as
-   :ref:`above <github-setup>`:
+If you're using a fork (set up as :ref:`above <github-setup>`):
 
 .. code-block:: bash
 
     git checkout master
     git pull upstream master
 
-2. Set up the channel order and install the versions of dependencies
-   currently used in the master branch. The channel order should generally stay
-   the same and the dependencies are not likely to change much, but this
-   ensures that the local environment most closely resembles the build
-   environment on travis-ci:
+If you're using a clone:
 
 .. code-block:: bash
 
-    ./simulate-travis.py --set-channel-order
-    ./simulate-travis.py --install-requirements
+    git checkout master
+    git pull origin master
 
+Build an isolated conda installation with dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the top level of the bioconda-recipes repo, run:
+
+.. code-block:: bash
+
+    ./simulate-travis.py --bootstrap /tmp/miniconda --overwrite
+
+This does not need root access. It will create a conda installation in
+``/tmp/miniconda`` that is separate from any Python or conda you might already
+have on your system. It w`ill overwrite any existing installation there. It
+will set up the proper channel order and install ``bioconda-utils`` and its
+dependencies into that installation. Finally, it will write a config file at
+``~/.config/bioconda/config.yml`` to persistently store the location of this
+new installation so that subsequent calls to ``simulate-travis.py`` will use it
+with no further configuration.
+
+This operation runs relatively quickly, so you might consider running it every
+time you build and test a new recipe to ensure tests on travis-ci go as
+smoothly as possible.
+
+.. note::
+
+    If you are running into particularly difficult-to-troubleshoot issues, try
+    removing the installation directory completely and then re-installing using
+    the ``--bootstrap`` argument.
 
 Write a recipe
 ~~~~~~~~~~~~~~
 
-
-Check out a new branch in your fork (here the branch is arbitrarily named "my-recipe"):
+Check out a new branch (here the branch is arbitrarily named "my-recipe"):
 
 .. code-block:: bash
 
@@ -50,59 +70,70 @@ bioconda-specific policies.
 
 Test locally
 ~~~~~~~~~~~~
-To make sure your recipe works, there are several options. The quickest, but
-not necessarily most complete, is to run conda-build directly::
-
-    conda build <recipe-dir>
-
-.. note ::
-
-    All ``conda`` and ``simulate-travis.py`` must be run from the root
-    environment of ``conda``, not an environment within ``conda``, as they
-    import ``conda`` within Python which is only allowed in the root environment.
-
 
 To test the recipe in a way more representative of the travis-ci environment,
-use the `simulate-travis.py` script in the top-level directory of the repo.
-Currently, it is mandatory to build any recipe *before* using
-`simulate-travis.py` for the first time. `simulate-travis.py` reads the config
-files in the repo and sets things up as closely as possible to how the builds
-will be run on travis-ci. It should be run from the top-level dir of the repo.
-Any arguments are passed on to the `bioconda-utils build` command, so check
-`bioconda-utils build -h` for help and more options.
+use the ``simulate-travis.py`` script in the top-level directory of the repo.
 
-Some example commands:
-
-This tests everything, using the installed conda-build. It will check all
-recipes to see what needs to be built and so it is the most comprehensive::
-
-    ./simulate-travis.py
+``simulate-travis.py`` reads the config files in the repo and sets things up as
+closely as possible to how the builds will be run on travis-ci. It should be
+run from the top-level dir of the repo.  See ``simulate-travis.py -h`` for
+details; below are some example uses.
 
 .. note::
 
-    If you haven't installed all the dependencies already, you can install them
-    with `./simulate-travis.py --install-requirements`
+    Previously, it was mandatory to build any recipe *before* using
+    `simulate-travis.py` for the first time. Recent changes should have fixed
+    this, but if you see errors related to a directory not being found in the
+    docker container, try building any recipe locally with conda-build. If you used
+    using the ``--bootstrap`` method described above, make sure you call
+    conda-build from that path explicitly, e.g.::
 
-Same thing but using `--docker`. If you're on OSX and have docker installed
-(and running!), you can use this to test the recipe under Linux::
+        /tmp/miniconda/bin/conda-build recipes/snakemake
 
-    ./simulate-travis.py --docker
 
-Use the `--quick` option which will just check recipes that have changed since
-the last commit to master branch or that have been newly removed from any
-configured blacklists. This can help speed up the recipe filter stage which can
-take 5 mins to thoroughly check 1500+ recipes. Note that this will not find
-cases where a pinned version (e.g., `{ CONDA_BOOST }`) has been changed::
+Example commands
+++++++++++++++++
+The following commands assume you have run ``./simulate-travis.py --bootstrap
+/tmp/miniconda``.
 
-    ./simulate-travis.py --docker --quick
+Recommended usage: build and test recipes with commits that have changed since
+the master branch in a Docker container, and then run independent tests with
+``mulled-build``.  This most closely replicates the work performed on
+travis-ci::
+
+    ./simulate-travis.py
+
+Same as above, but also test recipes that have changes not yet committed to git::
+
+    ./simulate-travis.py --git-range HEAD
+
+Same as above, but disable the use of Docker when building packages and disable
+the stringent ``mulled-build`` tests. Therefore even if this command passes it
+still might fail on travis-ci, but it is useful for cases where Docker is
+unavailable::
+
+    ./simulate-travis.py --git-range HEAD --disable-docker
+
+By default, packages whose version and build number match an existing package
+in the bioconda channel will not be built.
 
 To specify exactly which packages you want to try building, use the
 `--packages` argument. Note that the arguments to `--packages` can be globs and
 are of package *names* rather than *paths* to recipe directories. For example,
 to consider all R and Bioconductor packages::
 
-    ./simulate-travis.py --docker --package r-* bioconductor-*
+    ./simulate-travis.py --packages r-* bioconductor-*
 
+However if those packages already exist in the bioconda channel, they will not
+be built. To force a package::
+
+    ./simulate-travis.py --packages snakemake --force
+
+To force **all** packages (warning, this will *rebuild all packages* and will
+consume lots of resources::
+
+    # You probably don't want to run this.
+    # ./simulate-travis.py --force
 
 .. seealso::
 
@@ -111,51 +142,35 @@ to consider all R and Bioconductor packages::
 
 Push changes, wait for tests to pass, submit pull request
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Before pushing your changes to your fork on github, it's best to merge any
-changes that have happened recently on the upstream master branch. See
-`sycncing a fork <https://help.github.com/articles/syncing-a-fork/>`_ for
-details, or:
-
-.. code-block:: bash
-
-    git fetch upstream
-
-    # syncs the fork's master branch with upstream
-    git checkout master
-    git merge upstream/master
-
-    # merges those changes into the recipe's branch
-    git checkout my-recipe
-    git merge master
-
-
-Push your changes to your fork on github::
+Push your changes to your fork or to the main repo (if using a clone) to GitHub::
 
     git push origin my-recipe
 
+If using a fork, watch the Travis-CI logs by going to travis-ci.org and finding
+your fork of bioconda-recipes. Keep making changes on your fork and pushing
+them until the travis-ci builds pass. When they pass, create a `pull request
+<https://help.github.com/articles/about-pull-requests/>`_ on the main bioconda
+repo for your changes.
 
-and watch the Travis-CI logs by going to travis-ci.org and finding your fork of
-bioconda-recipes. Keep making changes on your fork and pushing them until the
-travis-ci builds pass.
+If using a clone, you will have to open a pull request to get the tests to run.
+The travis-ci tests intentionally short-circuit when not on a pull request to
+save on resources.
 
-Open a `pull request <https://help.github.com/articles/about-pull-requests/>`_
-on the bioconda-recipes repo. If it's your first recipe or the recipe is doing
-something non-standard, please ask `@bioconda/core` for a review.
+Make and push changes as needed to get the tests to pass. If it's your first
+recipe or the recipe is doing something non-standard, please
+ask `@bioconda/core` for a review. If you are a member of the bioconda team,
+feel free to merge your recipe once the tests pass.
 
 Use your new recipe
 ~~~~~~~~~~~~~~~~~~~
-
 When the PR is merged with the master branch, travis-ci will again do the
-builds but at the end will upload the packages to anaconda.org. Once the merge
-build completes, your new package is installable by anyone using::
+builds but at the end will upload the packages to anaconda.org. Once this
+completes, and as long as the channels are set up as described in
+:ref:`set-up-channels`, your new package is installable by anyone using::
 
-    conda install my-package-name -c bioconda
+    conda install -c conda-forge -c bioconda my-package-name
 
-You should recommend to your users that they set up the same channel order as
-used by bioconda to ensure that all dependencies are correctly met, by doing
-the following::
-
-    conda config --add channels defaults
-    conda config --add channels conda-forge
-    conda config --add channels bioconda
+It is recommended that users set up channels as described in
+:ref:`set-up-channels` to ensure that packages and dependencies are handled
+correctly, and that they create an isolated environment when installing using
+``conda create -n env-name-here``.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ bioinformatics software. Bioconda consists of:
 
 - a `repository of recipes <https://github.com/bioconda/bioconda-recipes>`_ hosted on GitHub
 - a `build system <https://github.com/bioconda/bioconda-utils>`_ that turns these recipes into conda packages
-- a `repository of >2400 bioinformatics packages
+- a `repository of >2700 bioinformatics packages
   <https://anaconda.org/bioconda/>`_ ready to use with ``conda install``
 - Over 250 contributors that add, modify, update and maintain the recipes
 
@@ -68,8 +68,9 @@ order** so that the priority is set correctly (that is, bioconda is highest
 priority).
 
 The `conda-forge` channel contains many general-purpose packages not already
-found in the `defaults` channel. The `r` channel is only included due to backward compatibility.
-It is not mandatory, but without `r`-packages compiled against R 3.3.1 might not work.
+found in the `defaults` channel. The `r` channel is only included due to
+backward compatibility.  It is not mandatory, but without the `r` channel
+packages compiled against R 3.3.1 might not work.
 
 
 ::
@@ -128,7 +129,7 @@ Core
 
 Others
 ------
-Bioconda has over 120 contributors, see `here <https://github.com/bioconda/bioconda-recipes/graphs/contributors>`_.
+Bioconda has over 250 contributors, see `here <https://github.com/bioconda/bioconda-recipes/graphs/contributors>`_.
 
 ----
 


### PR DESCRIPTION
This incorporates the changes in #153.

- paths to conda respect CONDARC
- do recipe filtering first, and only build docker container if there's something to build
- optionally keep docker image when testing
- fix some permission issues from the docker container (changes to the build script used in the docker container)
- pep8 cleanup
- overhaul docs to reflect the new changes