### PR TITLE
Update install requirements to include pygithub.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
             ],
         )
     ],
-    install_requires=["argh", "networkx", "pydotplus", "pyyaml", "requests", "jsonschema", "pandas", "colorlog", "jinja2"],
+    install_requires=["argh", "networkx", "pydotplus", "pyyaml", "requests", "jsonschema", "pandas", "colorlog", "jinja2", "pygithub"],
     entry_points={"console_scripts": [
         "bioconda-utils = bioconda_utils.cli:main",
         "bioconductor_skeleton = bioconda_utils.bioconductor_skeleton:main"


### PR DESCRIPTION
Without this bioconda-utils has unmet requirements when installed according to the README and in a fresh Anaconda installation, and a subsequent simulate-travis.py run errors out.