### PR TITLE
split tests and docs into separate travis-ci jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ env:
   - MINICONDA_VER="4.2.12"
 
   matrix:
-    - BIOCONDA_UTILS_TEST_TYPE=pytest
+    - BIOCONDA_UTILS_TEST_TYPE=pytest_docker
+    - BIOCONDA_UTILS_TEST_TYPE=pytest_not_docker
     - BIOCONDA_UTILS_TEST_TYPE=docs
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ services:
 install: ./travis-setup.sh
 before_script:
 - export PATH=/opt/involucro:/anaconda/bin:$PATH
-script:
-    - py.test test/ -v
-    - ./build-docs.sh 2>&1 | grep -v "nonlocal image URI found" | grep -v "reading sources..." | grep -v "writing output..."
+script: ./travis-run.sh
 env:
   global:
   - secure: lg+4gQIIVs7hII4v2Jx9n8dt3zyX9dlAqN8/DNCbHk4u/iJPSVHIk5IhBChjhbU8Eg4Zg2jL2kwTHg2t0W6auZZTWxfznH4enVQP2fRzjHsKBib/ksr41yeI0Mjsybivf5sdjjR8ewQ0ZwJpMF7RFkir38uJAIyDamm9tsVO71KHLLCkSnQ7lxnJpZfUyL4zCW6lo7UZGXOlFi1ZPdWIpAiY1ge1nfsaOjuUn5G5uKcdWMnrAm9E7MVxIz+vyP4iJMemoCotr0FrWfj4SjCYQURIDPHBpzdorBu2+JaE+9pJR3kt0EgGAuZBP41anKn0806Csh7Ar1bPfp7ORum32Ml7yMaqFSAT8I5F5n35olR72QppiHoVCNmU0zPCGrAWhNBaBs/hMjwm8KFF6iAC00N8RMGYKNH6oF7psDRyGSJjJjeqwvsuXJCkT5zyvvg6fraLfzhmeGY2OmYe4hrNkAMco+dJOV0bfyR6rnerFOdu+9i/ytRuwcMxcClZEdklSlsFz/+MzJubL9va+Y4I7RHIRyUyu69BwgiL0Af7Q50cHEl1iSCedyVYiQRQgJGDNI9UAm2cc4Wibj8N6UMkLh76ApUs/zENnPJcopzbH/r5epIpu1y826nEXtfrm3NM0Rg6XDA8rcqzEsGI/JQGGJr+l4LgUy6lPCAqISJWazs=
@@ -19,6 +17,8 @@ env:
 
 matrix:
   fast_finish: true
+  - BIOCONDA_UTILS_TEST_TYPE=pytest
+  - BIOCONDA_UTILS_TEST_TYPE=docs
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,13 @@ env:
   - ENCRYPTION_LABEL=4abdd40b7eaf
   - MINICONDA_VER="4.2.12"
 
+  matrix:
+    - BIOCONDA_UTILS_TEST_TYPE=pytest
+    - BIOCONDA_UTILS_TEST_TYPE=docs
+
+
 matrix:
   fast_finish: true
-  - BIOCONDA_UTILS_TEST_TYPE=pytest
-  - BIOCONDA_UTILS_TEST_TYPE=docs
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -5,16 +5,22 @@
 ![](https://raw.githubusercontent.com/bioconda/bioconda-recipes/master/logo/bioconda_monochrome_small.png
  "Bioconda")
 
-Utilities for building and managing
+`bioconda-utils` is a set of utilities for building and managing
 [bioconda](https://github.com/bioconda/bioconda-recipes) recipes.
 
-Installation:
+Since `bioconda-utils` is tightly coupled to `bioconda-recipes`, it is
+strongly recommended that `bioconda-utils` be set up and used according to the
+instructions at https://bioconda.github.io/contribute-a-recipe.html. This will
+ensure that your local setup matches that used to build recipes on travis-ci as
+closely as possible.
 
-First, note that `bioconda-utils` requires both python3 and `conda-build` pre-installed.
-This means that you likely need to have installed conda via the `miniconda3` bundle.
+However, if you would like to test in a standalone manner or help develop
+bioconda-utils, you can install requirements via conda into your root conda
+environment and then install the package:
 
-```
-pip install git+https://github.com/bioconda/bioconda-utils.git
+```bash
+conda install --file bioconda_utils/bioconda_utils-requirements.txt -c bioconda -c conda-forge
+python setup.py install
 ```
 
 See the help for the `bioconda-utils` command-line interface for details:
@@ -22,32 +28,3 @@ See the help for the `bioconda-utils` command-line interface for details:
 ```
 bioconda-utils -h
 ```
-
-## Changelog
-
-- recipes can be built in a docker container or by the system conda-build using the same infrastructure
-- improved log files for easy grepping (e.g., `grep BIOCONDA log`)
-- given a subdag of recipes to build, if one recipe fails then other recipes
-  that depend on it will be skipped (and noted in the log).
-- uses the API from conda 2.0+ and in general works with the latest conda-build
-  versions (instead of maintaining our own branch)
-- test suite for the build tools
-- documentation
-- each built package can now be tested in an isolated busybox container thanks
-  to `mulled-build` and `involucro`. This will catch issues where a recipe fails
-  to specify libs (e.g., libgcc) in the run dependencies.
-- the `mulled-build` testing also means we get per-package docker containers for free
-
-
-## Developer notes
-
-New version of conda-build? Update `DEFAULT_CONDA_BUILD_VERSION` in
-[`docker_utils.py`](bioconda_utils/docker_utils.py) which is the version used
-for docker containers, and the version spec in
-[`conda-requirements.txt`](conda-requirements.txt) which is used to set up the
-system environment and will therefore be used for non-docker builds (primarily
-OSX but will also be used for Linux if `--docker` is not provided to
-`bioconda-utils build`).
-
-For example see [#24](https://github.com/bioconda/bioconda-utils/pull/24/files).
-

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -52,14 +52,14 @@ BUILD_DOCS_FROM_BRANCH="master"
 # ----------------------------------------------------------------------------
 
 # Stop early (and descriptively)
-if [[ $TRAVIS_BRANCH != $BUILD_DOCS_FROM_BRANCH ]]; then
-    echo "Not building docs because not on branch '$BUILD_DOCS_FROM_BRANCH'"
-    exit 0
-fi
-if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
-    echo "This is a pull request, so not building docs"
-    exit 0
-fi
+# if [[ $TRAVIS_BRANCH != $BUILD_DOCS_FROM_BRANCH ]]; then
+#     echo "Not building docs because not on branch '$BUILD_DOCS_FROM_BRANCH'"
+#     exit 0
+# fi
+# if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
+#     echo "This is a pull request, so not building docs"
+#     exit 0
+# fi
 if [[ $TRAVIS_OS_NAME != "linux" ]]; then
     echo "OS is not Linux, so not building docs"
     exit 0

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -52,14 +52,6 @@ BUILD_DOCS_FROM_BRANCH="master"
 # ----------------------------------------------------------------------------
 
 # Stop early (and descriptively)
-if [[ $TRAVIS_BRANCH != $BUILD_DOCS_FROM_BRANCH ]]; then
-    echo "Not building docs because not on branch '$BUILD_DOCS_FROM_BRANCH'"
-    exit 0
-fi
-if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
-    echo "This is a pull request, so not building docs"
-    exit 0
-fi
 if [[ $TRAVIS_OS_NAME != "linux" ]]; then
     echo "OS is not Linux, so not building docs"
     exit 0
@@ -98,6 +90,15 @@ git add .nojekyll
 # committing with no changes results in exit 1, so check for that case first.
 if git diff --quiet; then
     echo "No changes to push -- exiting cleanly"
+    exit 0
+fi
+
+if [[ $TRAVIS_BRANCH != $BUILD_DOCS_FROM_BRANCH ]]; then
+    echo "Not pushing docs because not on branch '$BUILD_DOCS_FROM_BRANCH'"
+    exit 0
+fi
+if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
+    echo "This is a pull request, so not pushing docs"
     exit 0
 fi
 

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -52,14 +52,14 @@ BUILD_DOCS_FROM_BRANCH="master"
 # ----------------------------------------------------------------------------
 
 # Stop early (and descriptively)
-# if [[ $TRAVIS_BRANCH != $BUILD_DOCS_FROM_BRANCH ]]; then
-#     echo "Not building docs because not on branch '$BUILD_DOCS_FROM_BRANCH'"
-#     exit 0
-# fi
-# if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
-#     echo "This is a pull request, so not building docs"
-#     exit 0
-# fi
+if [[ $TRAVIS_BRANCH != $BUILD_DOCS_FROM_BRANCH ]]; then
+    echo "Not building docs because not on branch '$BUILD_DOCS_FROM_BRANCH'"
+    exit 0
+fi
+if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
+    echo "This is a pull request, so not building docs"
+    exit 0
+fi
 if [[ $TRAVIS_OS_NAME != "linux" ]]; then
     echo "OS is not Linux, so not building docs"
     exit 0

--- a/docs/source/contrib-setup.rst
+++ b/docs/source/contrib-setup.rst
@@ -34,16 +34,16 @@ Clone the main repo::
 
     git clone https://github.com/bioconda/bioconda-recipes.git
 
+
+You can now move on to installing requirements (next section).
+
 Using a fork
 ++++++++++++
 
-
-    git clone
-You can now move on to installing requirements (next section).
-
 If you do not yet have push access, then create a `fork
 <https://help.github.com/articles/fork-a-repo/>`_ of `bioconda-recipes on
-GitHub <https://github.com/bioconda/bioconda-recipes>`_ and clone it locally::
+GitHub <https://github.com/bioconda/bioconda-recipes>`_. Then clone it
+locally::
 
     git clone https://github.com/<USERNAME>/bioconda-recipes.git
 

--- a/docs/source/contribute-a-recipe.rst
+++ b/docs/source/contribute-a-recipe.rst
@@ -4,19 +4,14 @@ Contributing a recipe
 The following steps are done for each recipe or batch of recipes you'd like to
 contribute.
 
-Update repo
-~~~~~~~~~~~
+1. Update repo
+~~~~~~~~~~~~~~
 
 If you're using a fork (set up as :ref:`above <github-setup>`):
 
 .. code-block:: bash
 
     git checkout master
-
-    # if you cloned the original repo
-    git pull origin master
-
-    # if you're on a fork
     git pull upstream master
 
 If you're using a clone:
@@ -26,8 +21,8 @@ If you're using a clone:
     git checkout master
     git pull origin master
 
-Build an isolated conda installation with dependencies
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2. Build an isolated conda installation with dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the top level of the bioconda-recipes repo, run:
 
@@ -35,27 +30,30 @@ In the top level of the bioconda-recipes repo, run:
 
     ./simulate-travis.py --bootstrap /tmp/miniconda --overwrite
 
-This does not need root access. It will create a conda installation in
-``/tmp/miniconda`` that is separate from any Python or conda you might already
-have on your system. It w`ill overwrite any existing installation there. It
-will set up the proper channel order and install ``bioconda-utils`` and its
-dependencies into that installation. Finally, it will write a config file at
-``~/.config/bioconda/config.yml`` to persistently store the location of this
-new installation so that subsequent calls to ``simulate-travis.py`` will use it
-with no further configuration.
+This will:
 
-This operation runs relatively quickly, so you might consider running it every
-time you build and test a new recipe to ensure tests on travis-ci go as
-smoothly as possible.
+- create a conda installation in ``/tmp/miniconda`` that is separate from any
+  Python or conda you might already have on your system. No root privileges are
+  needed.
+- set up the proper channel order
+- install ``bioconda-utils`` and its dependencies into that installation
+- write a config file at ``~/.config/bioconda/config.yml`` to persistently
+  store the location of this new installation so that subsequent calls to
+  ``simulate-travis.py`` will use it with no further configuration.
+
 
 .. note::
+
+    This operation runs relatively quickly, so you might consider running it every
+    time you build and test a new recipe to ensure tests on travis-ci go as
+    smoothly as possible.
 
     If you are running into particularly difficult-to-troubleshoot issues, try
     removing the installation directory completely and then re-installing using
     the ``--bootstrap`` argument.
 
-Write a recipe
-~~~~~~~~~~~~~~
+3. Write a recipe
+~~~~~~~~~~~~~~~~~
 
 Check out a new branch (here the branch is arbitrarily named "my-recipe"):
 
@@ -73,8 +71,8 @@ bioconda-specific policies.
 
 .. _test-locally:
 
-Test locally
-~~~~~~~~~~~~
+4. Test locally
+~~~~~~~~~~~~~~~
 
 To test the recipe in a way more representative of the travis-ci environment,
 use the ``simulate-travis.py`` script in the top-level directory of the repo.
@@ -145,8 +143,8 @@ consume lots of resources::
     See :ref:`reading-logs` for tips on finding the information you need from
     log files.
 
-Push changes, wait for tests to pass, submit pull request
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5. Push changes, wait for tests to pass, submit pull request
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Push your changes to your fork or to the main repo (if using a clone) to GitHub::
 
     git push origin my-recipe
@@ -168,14 +166,14 @@ feel free to merge your recipe once the tests pass.
 
 At this point, Travis-CI will test your contribution in full.
 
-Use your new recipe
-~~~~~~~~~~~~~~~~~~~
+6. Use your new recipe
+~~~~~~~~~~~~~~~~~~~~~~
 When the PR is merged with the master branch, travis-ci will again do the
 builds but at the end will upload the packages to anaconda.org. Once this
 completes, and as long as the channels are set up as described in
 :ref:`set-up-channels`, your new package is installable by anyone using::
 
-    conda install -c conda-forge -c bioconda my-package-name
+    conda install my-package-name
 
 It is recommended that users set up channels as described in
 :ref:`set-up-channels` to ensure that packages and dependencies are handled

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -6,15 +6,14 @@ set +u
 [[ -z $BIOCONDA_UTILS_TEST_TYPE ]] && BIOCONDA_UTILS_TEST_TYPE="all"
 set -u
 
-case $BIOCONDA_UTILS_TEST_TYPE in
-    pytest)
-        py.test test/ -v
-        ;;
-    docs)
-        ./build-docs.sh 2>&1 | grep -v "nonlocal image URI found" | grep -v "reading sources..." | grep -v "writing output..."
-        ;;
-    all)
-        py.test test/ -v
-        ./build-docs.sh 2>&1 | grep -v "nonlocal image URI found" | grep -v "reading sources..." | grep -v "writing output..."
-        ;;
-esac
+if [ $BIOCONDA_UTILS_TEST_TYPE == 'pytest' ] || [ $BIOCONDA_UTILS_TEST_TYPE == 'all' ]; then
+
+  py.test test/ -v
+
+fi
+
+if [ $BIOCONDA_UTILS_TEST_TYPE == 'docs' ] || [ $BIOCONDA_UTILS_TEST_TYPE == 'all' ]; then
+
+  ./build-docs.sh 2>&1 | grep -v "nonlocal image URI found" | grep -v "reading sources..." | grep -v "writing output..."
+
+fi

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+set +u
+[[ -z $BIOCONDA_UTILS_TEST_TYPE ]] && BIOCONDA_UTILS_TEST_TYPE="all"
+set -u
+
+case $BIOCONDA_UTILS_TEST_TYPE in
+    pytest)
+        py.test test/ -v
+        ;;
+    docs)
+        ./build-docs.sh 2>&1 | grep -v "nonlocal image URI found" | grep -v "reading sources..." | grep -v "writing output..."
+        ;;
+    all)
+        py.test test/ -v
+        ./build-docs.sh 2>&1 | grep -v "nonlocal image URI found" | grep -v "reading sources..." | grep -v "writing output..."
+        ;;
+esac

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -6,9 +6,15 @@ set +u
 [[ -z $BIOCONDA_UTILS_TEST_TYPE ]] && BIOCONDA_UTILS_TEST_TYPE="all"
 set -u
 
-if [ $BIOCONDA_UTILS_TEST_TYPE == 'pytest' ] || [ $BIOCONDA_UTILS_TEST_TYPE == 'all' ]; then
+if [ $BIOCONDA_UTILS_TEST_TYPE == 'pytest_docker' ] || [ $BIOCONDA_UTILS_TEST_TYPE == 'all' ]; then
 
-  py.test test/ -v
+  py.test test/ -v -k "docker"
+
+fi
+
+if [ $BIOCONDA_UTILS_TEST_TYPE == 'pytest_not_docker' ] || [ $BIOCONDA_UTILS_TEST_TYPE == 'all' ]; then
+
+  py.test test/ -v -k "not docker"
 
 fi
 


### PR DESCRIPTION
travis-ci is timing out on master branch when running tests and then building docs. This splits the tests and docs into separate tasks in the matrix.