### PR TITLE
Fix mulled-test fails on uppercase in top dir name

### DIFF
--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -115,7 +115,7 @@ def test_package(
 
     spec = get_image_name(path)
 
-    extra_channels = ['file:/{0}'.format(conda_bld_dir)]
+    extra_channels = ['file://{0}'.format(conda_bld_dir)]
     if channels is None:
         channels = []
     if isinstance(channels, str):


### PR DESCRIPTION
Running `bioconda build recipes --docker --mulled-test...` with `CONDA_ROOT=/Users/username/.biocondaenv` fails within the mulled build when `/users/username` can't be found (note missing capitalization).

The cause is that the directory is passed from `pkg_test.py` through the various layers (galaxy, involucro, docker, etc) as a file URI: `file://Users/username/.biocondaenv/conda-bld`. This URI is incorrect, as it references the file `/username/.biocondaenv/conda-bld` on the host `Users`.

Somewhere within `conda-build`, the hostname portion is normalized and looses its capitalization, which then leads to the file-not-found condition.

Correct usages of the file URI are dropping the authority field entirely (`file:/Users/username`), setting the hostname explicitly (`file://localhost/Users/username`) or giving it implicitly (`file:///localhost/Users/username`). 

Since `conda-build` does not recognize URIs of the `file:/absolute/path` form as URIs, the patch uses the `///` form. 
