### PR TITLE
Print build/test output to log in real time

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -134,7 +134,7 @@ def build(
                       [os.path.join(recipe, 'meta.yaml')]
                 logger.debug('command: %s', cmd)
                 with utils.Progress():
-                    p = utils.run(cmd, env=os.environ)
+                    utils.logging_run(cmd, logger, env=os.environ)
 
             build_success = True
 
@@ -161,7 +161,7 @@ def build(
     base_image = 'bioconda/extended-base-image' if use_base_image else None
 
     try:
-        res = pkg_test.test_package(pkg_path, base_image=base_image)
+        pkg_test.test_package(pkg_path, base_image=base_image)
 
         logger.info("TEST SUCCESS %s, %s", recipe, utils.envstr(_env))
         mulled_image = pkg_test.get_image_name(pkg_path)

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -371,8 +371,8 @@ class RecipeBuilder(object):
         Separate out the pull step to provide additional logging info
         """
         logger.info('DOCKER: Pulling docker image %s', self.image)
-        p = utils.run(['docker', 'pull', self.image])
-        logger.debug('DOCKER: stdout+stderr:\n%s', p.stdout)
+        utils.logging_run(['docker', 'pull', self.image],
+                          logger, logging.DEBUG)
         logger.info('DOCKER: Done pulling image')
 
     def _build_image(self):
@@ -426,7 +426,7 @@ class RecipeBuilder(object):
 
         try:
             with utils.Progress():
-                p = utils.run(cmd)
+                p = utils.logging_run(cmd, logger, logging.DEBUG)
         except sp.CalledProcessError as e:
             logger.error(
                 'DOCKER FAILED: Error building docker container %s. ',
@@ -499,7 +499,7 @@ class RecipeBuilder(object):
 
         logger.debug('DOCKER: cmd: %s', cmd)
         with utils.Progress():
-            p = utils.run(cmd)
+            p = utils.logging_run(cmd, logger)
         return p
 
     def cleanup(self):

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -144,6 +144,6 @@ def test_package(
         env["DEST_BASE_IMAGE"] = base_image
     with tempfile.TemporaryDirectory() as d:
         with utils.Progress():
-            p = utils.run(cmd, env=env, cwd=d)
+            p = utils.logging_run(cmd, logging, env=env, cwd=d)
 
     return p


### PR DESCRIPTION
This patch restores the "log output in real time" behavior of plain unwrapped `conda build`, maintaining the log message format and the explicit `decode` call.

Seeing immediately what is going on, and having STDERR and STDOUT interleaved _without_ buffering helps immensely when writing recipes:
 - It will often reduce the length of the development cycle.
 - Knowing that "yes, it is still compiling" at a glance helps against the frustration of "waiting". 
 - Inspecting the output of build and test stages is useful even if they succeeded. (Actually, success of the build stage is ultimately determined by the test, so output should have been dumped on failed tests also). 
 - The buffered interleaving resulted in a peculiar mixup of blocks of STDOUT and STDERR, making it impossible to determine the chronological order in which each line of output was printed. 