### PR TITLE
Add malformed tests check

### DIFF
--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -143,6 +143,16 @@ def missing_tests(recipe, meta, df):
             }
 
 
+def malformed_tests(recipe, meta, df):
+    if 'test' in meta:
+        # will cause mulled to fail
+        if any("'" in line for line in meta['test']):
+            return {
+                'single_quote_in_tests': True,
+                'fix': 'use double quotes or move to separate test file'
+            }
+
+
 def missing_hash(recipe, meta, df):
     # could be a meta-package if no source section or if None
     try:
@@ -278,6 +288,7 @@ registry = (
 
     # disabling for now until we get better per-OS version detection
     # already_in_bioconda,
+    malformed_tests,
     missing_tests,
     missing_home,
     missing_license,

--- a/test/test_linting.py
+++ b/test/test_linting.py
@@ -213,6 +213,28 @@ def test_missing_tests():
         ''')
 
 
+def test_single_quote_in_tests():
+    run_lint(
+        func_name='bad_tests',
+        should_pass=['''
+        bad_tests:
+          meta.yaml: |
+            package:
+              name: missing_tests
+              version: "0.1"
+            test:
+              commands: "ls"
+        '''],
+        should_fail='''
+        missing_tests:
+          meta.yaml: |
+            package:
+              name: missing_tests
+              version: "0.1"
+          test: "ls | grep '[]'"
+        ''')
+
+
 def test_missing_hash():
     run_lint(
         func_name='missing_hash',


### PR DESCRIPTION
Currently, if you have a single quote in your test command, it'll break the bioconda build because of shell escaping.  Not sure if the upstream will fix this (or if a fix is really worth it, given that you can always put your test in a test file), but the error is confusing to the user.  This PR adds a single_quote_in_tests check to the linter.

Aside - I haven't been able to get the test suite to run yet (not sure how to let anaconda for python3 and python2 exist).  But I'm hoping Travis will run 'em for me :)