### PR TITLE
Bioconductor skeleton improvements

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -595,12 +595,17 @@ class BioCProjectPage(object):
         """
 
         version_placeholder = '{{ version }}'
+        package_placeholder = '{{ name }}'
 
-        def sub_placeholder(x):
-            return x.replace(self.version, version_placeholder)
+        def sub_placeholders(x):
+            return (
+                x
+                .replace(self.version, version_placeholder)
+                .replace(self.package, package_placeholder)
+            )
 
         url = [
-           sub_placeholder(u) for u in
+           sub_placeholders(u) for u in
             [self.bioconductor_tarball_url,
              self.bioconductor_annotation_data_url,
              self.bioconductor_experiment_data_url,
@@ -617,13 +622,13 @@ class BioCProjectPage(object):
         d = OrderedDict((
             (
                 'package', OrderedDict((
-                    ('name', 'bioconductor-' + self.package.lower()),
-                    ('version', version_placeholder),
+                    ('name', 'bioconductor-{{ name|lower}}'),
+                    ('version', '{{ version }}'),
                 )),
             ),
             (
                 'source', OrderedDict((
-                    ('fn', self.tarball_basename.replace(self.version, '{{ version }}')),
+                    ('fn', '{{ name }}_{{ version }}.tar.gz'),
                     ('url', url),
                     ('sha256', self.sha256),
                 )),
@@ -666,7 +671,11 @@ class BioCProjectPage(object):
         rendered = pyaml.dumps(d).decode('utf-8')
         rendered = rendered.replace('GCC_PLACEHOLDER', 'gcc  # [linux]')
         rendered = rendered.replace('LLVM_PLACEHOLDER', 'llvm  # [osx]')
-        rendered = '{% set version="' + self.version + '" %}\n\n' + rendered
+        rendered = (
+            '{% set version="' + self.version + '" %}\n' +
+            '{% set name="' + self.package + '" %}\n\n' +
+            rendered
+        )
         tmp = tempfile.NamedTemporaryFile(delete=False).name
         with open(tmp, 'w') as fout:
             fout.write(rendered)

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 import logging
 import requests
 from colorlog import ColoredFormatter
+from . import utils
 
 logging.getLogger("requests").setLevel(logging.WARNING)
 
@@ -491,7 +492,7 @@ class BioCProjectPage(object):
                 self._parse_dependencies(self.depends)
             )
         )
-
+        specific_r_version = False
         versions = {}
         for name, version in version_specs:
             if name in versions:
@@ -522,6 +523,10 @@ class BioCProjectPage(object):
             if version:
                 version = " " + version
 
+            # Some packages define a minimum version of R. In that case, we add
+            # the dependency `r-base` for that version. Otherwise, R is
+            # implied, and we make sure that r-base is added as a dependency at
+            # the end.
             if name.lower() == 'r':
 
                 # Had some issues with CONDA_R finding the right version if "r"
@@ -530,13 +535,8 @@ class BioCProjectPage(object):
                 #
 
                 # # "r >=2.5" rather than "r-r >=2.5"
-                # specific_r_version = True
-                # results.append(name.lower() + version)
-                # results.append('r')
-
-                # UPDATE: we're using `r-base` as the base R dependency, which
-                # is added below for all R packages, so pass for now.
-                pass
+                specific_r_version = True
+                results.append(name.lower() + '-base' + version)
 
             else:
                 results.append(prefix + name.lower() + version)
@@ -545,7 +545,8 @@ class BioCProjectPage(object):
                 self.depends_on_gcc = True
 
         # Add R itself
-        results.append('r-base')
+        if not specific_r_version:
+            results.append('r-base')
         self._dependencies = results
         return self._dependencies
 
@@ -592,8 +593,14 @@ class BioCProjectPage(object):
         templating or the `$R` in the test commands, and replace the text once
         the yaml is written.
         """
+
+        version_placeholder = '{{ version }}'
+
+        def sub_placeholder(x):
+            return x.replace(self.version, version_placeholder)
+
         url = [
-            u for u in
+           sub_placeholder(u) for u in
             [self.bioconductor_tarball_url,
              self.bioconductor_annotation_data_url,
              self.bioconductor_experiment_data_url,
@@ -611,12 +618,12 @@ class BioCProjectPage(object):
             (
                 'package', OrderedDict((
                     ('name', 'bioconductor-' + self.package.lower()),
-                    ('version', self.version),
+                    ('version', version_placeholder),
                 )),
             ),
             (
                 'source', OrderedDict((
-                    ('fn', self.tarball_basename),
+                    ('fn', self.tarball_basename.replace(self.version, '{{ version }}')),
                     ('url', url),
                     ('sha256', self.sha256),
                 )),
@@ -659,14 +666,20 @@ class BioCProjectPage(object):
         rendered = pyaml.dumps(d).decode('utf-8')
         rendered = rendered.replace('GCC_PLACEHOLDER', 'gcc  # [linux]')
         rendered = rendered.replace('LLVM_PLACEHOLDER', 'llvm  # [osx]')
-        return rendered
+        rendered = '{% set version="' + self.version + '" %}\n\n' + rendered
+        tmp = tempfile.NamedTemporaryFile(delete=False).name
+        with open(tmp, 'w') as fout:
+            fout.write(rendered)
+        return fout.name
 
 
-def write_recipe(package, recipe_dir, force=False, bioc_version=None,
+def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
                  pkg_version=None, versioned=False):
     """
     Write the meta.yaml and build.sh files.
     """
+    config = utils.load_config(config)
+    env = list(utils.EnvMatrix(config['env_matrix']))[0]
     proj = BioCProjectPage(package, bioc_version, pkg_version)
     logger.debug('%s==%s, BioC==%s', proj.package, proj.version, proj.bioc_version)
     logger.info('Using tarball from %s', proj.tarball_url)
@@ -685,15 +698,15 @@ def write_recipe(package, recipe_dir, force=False, bioc_version=None,
     # *has* changed, then bump the version number.
     meta_file = os.path.join(recipe_dir, 'meta.yaml')
     if os.path.exists(meta_file):
-        updated_meta = pyaml.yaml.load(proj.meta_yaml)
-        current_meta = pyaml.yaml.load(open(meta_file))
+        updated_meta = utils.load_meta(proj.meta_yaml, env)
+        current_meta = utils.load_meta(meta_file, env)
 
         # pop off the version and build numbers so we can compare the rest of
         # the dicts
-        updated_version = updated_meta['package'].pop('version')
-        current_version = current_meta['package'].pop('version')
+        updated_version = updated_meta['package']['version']
+        current_version = current_meta['package']['version']
         # updated_build_number = updated_meta['build'].pop('number')
-        current_build_number = current_meta['build'].pop('number')
+        current_build_number = current_meta['build'].pop('number', 0)
 
         if (
             (updated_version == current_version) and
@@ -702,7 +715,7 @@ def write_recipe(package, recipe_dir, force=False, bioc_version=None,
             proj.build_number = int(current_build_number) + 1
 
     with open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fout:
-        fout.write(proj.meta_yaml)
+        fout.write(open(proj.meta_yaml).read())
 
     if not proj.is_data_package:
         with open(os.path.join(recipe_dir, 'build.sh'), 'w') as fout:

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -228,7 +228,6 @@ class BioCProjectPage(object):
                 os.path.join(base_url, self.bioc_version, 'data', 'experiment', 'html', package + '.html')
             )
 
-
         if not self.request:
             raise PageNotFoundError('Error {0.status_code} ({0.reason}) for page {0.url}'.format(self.request))
 
@@ -605,11 +604,13 @@ class BioCProjectPage(object):
             )
 
         url = [
-           sub_placeholders(u) for u in
-            [self.bioconductor_tarball_url,
-             self.bioconductor_annotation_data_url,
-             self.bioconductor_experiment_data_url,
-             self.bioaRchive_url, self.cargoport_url]
+            sub_placeholders(u) for u in
+            [
+                self.bioconductor_tarball_url,
+                self.bioconductor_annotation_data_url,
+                self.bioconductor_experiment_data_url,
+                self.bioaRchive_url, self.cargoport_url
+            ]
             if u is not None
         ]
 

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -531,7 +531,7 @@ def bioconductor_skeleton(
     """
     setup_logger(loglevel)
     _bioconductor_skeleton.write_recipe(
-        package, recipe_folder, force, bioc_version=bioc_version,
+        package, recipe_folder, config, force=force, bioc_version=bioc_version,
         pkg_version=pkg_version, versioned=versioned
     )
 


### PR DESCRIPTION
This PR reintroduces the minimum R version spec (since some packages are now requiring R versions >3.4) and now uses jinja templating for the version and name.  This is in preparation for moving all Bioc packages to 3.5 (and then hopefully to 3.6 at the end of October).
