### PR TITLE
Lint pinning

### DIFF
--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -273,6 +273,31 @@ def setup_py_install_args(recipe, meta, df):
     ):
         return err
 
+
+def _pin(env_var, dep_name):
+    """
+    Generates a linting function that checks to make sure `dep_name` is pinned
+    to `env_var` using jinja templating.
+    """
+    def pin(recipe, meta, df):
+        # Note that we can't parse the meta.yaml using a normal YAML parser if it
+        # has jinja templating
+        lines = open(os.path.join(recipe, 'meta.yaml')).readlines()
+        lines = [i.strip() for i in lines]
+        for line in lines:
+            if line.startswith('- {}'.format(dep_name)):
+                if env_var not in line: # and '{{' not in line and '}}' not in line:
+                    err = {
+                        '{}_not_pinned'.format(dep_name): True,
+                        'fix': (
+                            'pin {0} using jinja templating: {{{{ {1} }}}}'.format(dep_name, env_var))
+                    }
+                    return err
+
+    pin.__name__ = "{}_not_pinned".format(dep_name)
+    return pin
+
+
 registry = (
     in_other_channels,
 
@@ -288,7 +313,19 @@ registry = (
     uses_perl_threaded,
     uses_setuptools,
     has_windows_bat_file,
+
     # should_be_noarch,
+    #
     should_not_be_noarch,
     setup_py_install_args,
+    _pin('CONDA_ZLIB', 'zlib'),
+    _pin('CONDA_GMP', 'gmp'),
+    _pin('CONDA_BOOST', 'boost'),
+    _pin('CONDA_GSL', 'gsl'),
+    _pin('CONDA_HDF5', 'hdf5'),
+    _pin('CONDA_NCURSES', 'ncurses'),
+    _pin('CONDA_HTSLIB', 'htslib'),
+
+    # Pinning in env_matrix.yml is not consistent for bzip2.
+    # _pin('CONDA_BZIP2', 'bzip2'),
 )

--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -282,9 +282,8 @@ def _pin(env_var, dep_name):
     def pin(recipe, meta, df):
         # Note that we can't parse the meta.yaml using a normal YAML parser if it
         # has jinja templating
-        lines = open(os.path.join(recipe, 'meta.yaml')).readlines()
-        lines = [i.strip() for i in lines]
-        for line in lines:
+        for line in open(os.path.join(recipe, 'meta.yaml')):
+            line = line.strip()
             if line.startswith('- {}'.format(dep_name)):
                 if env_var not in line: # and '{{' not in line and '}}' not in line:
                     err = {

--- a/docs/source/linting.rst
+++ b/docs/source/linting.rst
@@ -236,6 +236,52 @@ to::
 
     $PYTHON setup.py install --single-version-externally-managed --record=record.txt
 
+`*_not_pinned`
+~~~~~~~~~~~~~~
+
+Reason for failing: The recipe has dependencies that need to be pinned to
+a specific version all across bioconda.
+
+Rationale: Sometimes when a core dependency (like ``zlib``, which is used across
+many recipes) is updated it breaks backwards compatibility. In order to avoid
+this, for known-to-be-problematic dependencies we pin to a specific version
+across all recipes.
+
+How to resolve: Change the dependency line as follows. For each dependency
+failing the linting, specify a jinja-templated version by converting it to
+uppercase, prefixing it with ``CONDA_``, adding double braces, and adding a ``*``.
+
+Examples are much easier to understand:
+
+- ``zlib`` should become ``zlib {{ CONDA_ZLIB }}*``
+- ``ncurses`` should become ``ncurses {{ CONDA_NCURSES }}*``
+- ``htslib`` should become ``htslib {{ CONDA_HTSLIB }}*``
+- ``boost`` should become ``boost {{ CONDA_BOOST }}*``
+- ... and so on.
+
+Here is an example in the context of a ``meta.yaml`` file where ``zlib`` needs to be
+pinned:
+
+.. code-block:: yaml
+
+    # this will give a linting error because zlib is not pinned
+    build:
+      - zlib
+    run:
+      - zlib
+      - bedtools
+
+And here is the fixed version:
+
+.. code-block:: yaml
+
+    # fixed:
+    build:
+      - zlib {{ CONDA_ZLIB }}*
+    run:
+      - zlib {{ CONDA_ZLIB }}*
+      - bedtools
+
 
 Developer docs
 --------------


### PR DESCRIPTION
This PR ensures that new recipes pin [a subset of] dependencies listed in `env_matrix.yml`.

Once this is working well in practice, we can move towards changing our pinning to match https://github.com/conda-forge/conda-forge.github.io/blob/0661e2ecf4b213ddf36350ca100a5a820eb17eb7/scripts/pin_the_slow_way.py#L40-L85, both in terms of content and format (in that they include the dependency name in the templated variable).

@bgruening this should hopefully cut down on the number of comments you have to make on PRs ;)