### PR TITLE
lint: fix: crash at empty build section

### DIFF
--- a/bioconda_utils/linting.py
+++ b/bioconda_utils/linting.py
@@ -245,6 +245,7 @@ def lint(recipes, config, df, exclude=None, registry=None):
                  'severity': 'ERROR',
                  'info': result})
             continue
+        logger.debug('lint {}'.format(recipe))
 
         # skips defined in commit message
         skip_for_this_recipe = skip_dict[recipe]

--- a/test/test_linting.py
+++ b/test/test_linting.py
@@ -60,6 +60,24 @@ def run_lint(
         _run(contents, expect_pass=False)
 
 
+def test_empty_build_section():
+    r = Recipes(
+        '''
+        empty_build_section:
+          meta.yaml: |
+            package:
+              name: empty_build_section
+              version: "0.1"
+            build:
+        ''', from_string=True)
+    r.write_recipes()
+    # access to contents of possibly empty build section can happen in
+    # `should_be_noarch` and `should_not_be_noarch`
+    registry = [lint_functions.should_be_noarch, lint_functions.should_not_be_noarch]
+    res = linting.lint(r.recipe_dirs.values(), config={}, df=None, registry=registry)
+    assert res is None
+
+
 def test_lint_skip_in_recipe():
 
     # should fail (note we're only linting `missing_home`)


### PR DESCRIPTION
Linting for recipes with empty `build:` sections failed since `meta.get('build', {})` is `None` in that case and thus does not support any `dict`-operations. Testcase and fix added.
Also added a debug log for every recipe before executing the lint functions to help debugging batch linting. @johanneskoester 