### PR TITLE
build: fix: sections may be empty in get_meta_value 

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -88,6 +88,8 @@ def get_meta_value(meta, *keys, default=None):
     """
     try:
         for key in keys:
+            if not meta:
+                raise KeyError(key)
             meta = meta[key]
         return meta
     except KeyError:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -876,6 +876,7 @@ def test_zero_packages():
     assert list(utils.filter_recipes([], {'CONDA_PY': [27, 35]})) == []
 
 
+@pytest.mark.skipif(SKIP_DOCKER_TESTS, reason='skipping on osx')
 def test_build_empty_extra_container():
     r = Recipes(
         """

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -874,3 +874,29 @@ def test_zero_packages():
     provided.
     """
     assert list(utils.filter_recipes([], {'CONDA_PY': [27, 35]})) == []
+
+
+def test_build_empty_extra_container():
+    r = Recipes(
+        """
+        one:
+          meta.yaml: |
+            package:
+              name: one
+              version: 0.1
+            extra:
+              container:
+                # empty
+        """, from_string=True)
+    r.write_recipes()
+
+    build_result = build.build(
+        recipe=r.recipe_dirs['one'],
+        recipe_folder='.',
+        env={},
+        mulled_test=True,
+    )
+    assert build_result.success
+    pkg = utils.built_package_path(r.recipe_dirs['one'])
+    assert os.path.exists(pkg)
+    ensure_missing(pkg)


### PR DESCRIPTION
`meta.yaml` sections may be empty and thus will be an empty `str` when parsed by `conda-build`. Hence accessing `meta[key]` in `get_meta_value` will fail since `meta` can be `""` which cannot be subscripted by another `str`, i.e., section name.

Use case that will fail:
```yaml
extra:
  container:
    extended-base: true  # [py27]
```
Due to the selector, `container` will be empty for Python 3 builds.