### PR TITLE
[WIP] support lists of versions

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -249,9 +249,15 @@ class EnvMatrix:
         else:
             self.env = env
         for key, val in self.env.items():
-            if key != "CONDA_PY" and not isinstance(val, str):
-                raise ValueError(
-                    "All versions except CONDA_PY must be strings.")
+            if not isinstance(val, list):
+                val = [val]
+            for v in val:
+                if key != "CONDA_PY" and not isinstance(v, str):
+                    raise ValueError(
+                        "All specified versions except CONDA_PY must be "
+                        "strings; For {0} found a value of {1}"
+                        .format(key, v)
+                    )
 
     def __iter__(self):
         """


### PR DESCRIPTION
Fixes a bug when checking `env_matrix.yml`, which previously only let CONDA_PY because it's not a string (it's a list) and had a misleading error message for other keys with lists.

Now we can add lists of versions to `env_matrix.yml` to support all combinations. For example, 

```yaml
CONDA_PY:
  - 27
  - 35
  - 36
CONDA_NPY:
  - "111"
  - "112"
  - "113"
```
will build 
```
CONDA_PY=27; CONDA_NPY=111
CONDA_PY=27; CONDA_NPY=112
CONDA_PY=27; CONDA_NPY=113
CONDA_PY=35; CONDA_NPY=111
CONDA_PY=35; CONDA_NPY=112
CONDA_PY=35; CONDA_NPY=113
CONDA_PY=36; CONDA_NPY=111
CONDA_PY=36; CONDA_NPY=112
CONDA_PY=36; CONDA_NPY=113
```

However I think build strings need to include `{{ CONDA_NPY }}`, otherwise earlier-built packages will get clobbered by subsequent builds with a different numpy. I'm not familiar enough with how conda-build chooses to include things in the build string -- looks like python version is included in the build string by default but nothing else?

So we shouldn't actually change `env_matrix.yml` yet. 

ping @bgruening
