### PR TITLE
travis: update Miniconda to 4.3.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script: ./travis-run.sh
 env:
   global:
   - ENCRYPTION_LABEL=195cdfd31577
-  - MINICONDA_VER="4.2.12"
+  - MINICONDA_VER="4.3.21"
   matrix:
   - BIOCONDA_UTILS_TEST_TYPE=pytest_docker
   - BIOCONDA_UTILS_TEST_TYPE=pytest_not_docker


### PR DESCRIPTION
Error reported by @nsoranzo:
> I think something broke bioconda-utils lint (and probably more): https://travis-ci.org/bioconda/bioconda-recipes/jobs/295247753

The reason is that `pytz` was changed to be a `noarch: python` package but for Bioconda `Miniconda 4.2.12` has been used as the starting point on Travis. `noarch: python` support is a `conda 4.3` things hence `pytz=2017.3=1` somehow wasn't correctly installed by `conda 4.2.12` when trying to update itself.

`conda ==4.3.21` is specified in `bioconda_utils-requirements.txt`. So, I guess it might be ok to use `Miniconda 4.3.21` for Travis?