### PR TITLE
Remove BLAST example from docs (outdated by #6073)

### DIFF
--- a/docs/source/guidelines.rst
+++ b/docs/source/guidelines.rst
@@ -407,11 +407,6 @@ Other examples of interest
 Packaging is hard. Here are some examples, in no particular order, of how
 contributors have solved various problems:
 
-- `blast
-  <https://github.com/bioconda/bioconda-recipes/tree/master/recipes/blast>`_
-  has an OS-specific installation -- OSX copies binaries while on Linux it is
-  compiled.
-
 - `graphviz
   <https://github.com/bioconda/bioconda-recipes/tree/master/recipes/graphviz>`_
   has an OS-specific option to ``configure``


### PR DESCRIPTION
BLAST is now built on OSX and Linux from scratch with nearly no OS dependent stuff, so no longer good example.

Merge when bioconda/bioconda-recipes#6073 has been merged.