### PR TITLE
minor tweaks

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -535,7 +535,9 @@ class BioCProjectPage(object):
 
                 # # "r >=2.5" rather than "r-r >=2.5"
                 specific_r_version = True
-                results.append(name.lower() + '-base' + version)
+
+                # results.append(name.lower() + '-base' + version)
+                results.append('r-base')
 
             else:
                 results.append(prefix + name.lower() + version)
@@ -723,6 +725,8 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
         # the dicts
         updated_version = updated_meta['package']['version']
         current_version = current_meta['package']['version']
+
+
         # updated_build_number = updated_meta['build'].pop('number')
         current_build_number = current_meta['build'].pop('number', 0)
 

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -70,6 +70,9 @@ def select_recipes(packages, git_range, recipe_folder, config_filename, config, 
     selected_recipes = list(utils.get_recipes(recipe_folder, packages))
     _recipes = []
     for recipe in selected_recipes:
+        if recipes in blacklisted_recipes and recipes in changed_recipes:
+            logger.warning('%s is blackliested but also has changed. Consider '
+                           'removing from blacklist if you want to build it', recipe)
         if force:
             _recipes.append(recipe)
             logger.debug('forced: %s', recipe)


### PR DESCRIPTION
1) bioconductor skeleton no longer pins `r-base`
2) warning is logged if a recipe has changed but is still in a blacklist