### PR TITLE
add `git push origin master` to fork repo update docs

### DIFF
--- a/docs/source/contribute-a-recipe.rst
+++ b/docs/source/contribute-a-recipe.rst
@@ -13,6 +13,7 @@ If you're using a fork (set up as :ref:`above <github-setup>`):
 
     git checkout master
     git pull upstream master
+    git push origin master
 
 If you're using a clone:
 


### PR DESCRIPTION
When just running the two steps described in the current docs for the fork workflow, the Travis build fails when pushing out changes on a new or updated branch, based on the newest upstream master -- it gets confused by the lack of commits in the fork's master branch. So whenever updating the local master branch from upstream, these changes should also be pushed out to the fork (origin):

`git push origin master`

I don't think this is necessary for the clone, that should only be on the local machine. But I haven't used that workflow yet, so I'm not absolutely sure.