### PR TITLE
RFC - adding openssh-clients

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -158,7 +158,7 @@ def build(
     use_base_image = utils.get_meta_value(
         meta,
         'extra', 'container', 'extended-base')
-    base_image = 'bioconda/extended-base-image' if use_base_image else None
+    base_image = 'bioconda/extended-base-image:openssh' if use_base_image else None
 
     try:
         res = pkg_test.test_package(pkg_path, base_image=base_image)

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -158,7 +158,7 @@ def build(
     use_base_image = utils.get_meta_value(
         meta,
         'extra', 'container', 'extended-base')
-    base_image = 'bioconda/extended-base-image:openssh' if use_base_image else None
+    base_image = 'bioconda/extended-base-image' if use_base_image else None
 
     try:
         res = pkg_test.test_package(pkg_path, base_image=base_image)

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -149,7 +149,7 @@ RUN /opt/conda/bin/conda config --add channels conda-forge
 RUN /opt/conda/bin/conda config --add channels bioconda
 RUN /opt/conda/bin/conda install --file /tmp/requirements.txt
 
-/usr/bin/sudo -n yum install -y openssh-clients
+RUN /usr/bin/sudo -n yum install -y openssh-clients
 
 """
 

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -149,7 +149,7 @@ RUN /opt/conda/bin/conda config --add channels conda-forge
 RUN /opt/conda/bin/conda config --add channels bioconda
 RUN /opt/conda/bin/conda install --file /tmp/requirements.txt
 
-/usr/bin/sudo -n yum install -y {self.yum_pkgs}
+/usr/bin/sudo -n yum install -y openssh-clients
 
 """
 

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -148,6 +148,9 @@ RUN /opt/conda/bin/conda config --add channels defaults
 RUN /opt/conda/bin/conda config --add channels conda-forge
 RUN /opt/conda/bin/conda config --add channels bioconda
 RUN /opt/conda/bin/conda install --file /tmp/requirements.txt
+
+/usr/bin/sudo -n yum install -y {self.yum_pkgs}
+
 """
 
 


### PR DESCRIPTION
This is needed for openmpi builds xref: https://github.com/bioconda/bioconda-recipes/pull/6649

and is also be done by conda-forge in similar cases: https://github.com/conda-forge/pytrilinos-feedstock/blob/89340939dc0591e3a31a0ef92fe4367aeb56a9cf/ci_support/run_docker_build.sh#L66

It will prolong our build-time, so we could do this in the base image from which we derive here. A more elaborated stunt would be to make it more flexible and add this package as a yaml-metadata and we install this on request ... this would mean deeper code changes and I'm not sure how frequent this use-case is.