### PR TITLE
lint: test for empty values in `missing_*` lints

### DIFF
--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -1,8 +1,12 @@
-import os
+from functools import partial
 import glob
+import os
 import re
+
 import pandas
 import numpy as np
+
+from .utils import get_meta_value
 
 
 def _get_not_none(meta, key, none_subst=dict):
@@ -111,9 +115,7 @@ def already_in_bioconda(recipe, meta, df):
 
 
 def missing_home(recipe, meta, df):
-    try:
-        meta['about']['home']
-    except KeyError:
+    if not get_meta_value(meta, 'about', 'home'):
         return {
             'missing_home': True,
             'fix': 'add about:home',
@@ -121,9 +123,7 @@ def missing_home(recipe, meta, df):
 
 
 def missing_summary(recipe, meta, df):
-    try:
-        meta['about']['summary']
-    except KeyError:
+    if not get_meta_value(meta, 'about', 'summary'):
         return {
             'missing_summary': True,
             'fix': 'add about:summary',
@@ -131,9 +131,7 @@ def missing_summary(recipe, meta, df):
 
 
 def missing_license(recipe, meta, df):
-    try:
-        meta['about']['license']
-    except KeyError:
+    if not get_meta_value(meta, 'about', 'license'):
         return {
             'missing_license': True,
             'fix': 'add about:license'
@@ -142,7 +140,7 @@ def missing_license(recipe, meta, df):
 
 def missing_tests(recipe, meta, df):
     test_files = ['run_test.py', 'run_test.sh', 'run_test.pl']
-    if 'test' not in meta:
+    if not get_meta_value(meta, 'test'):
         if not any([os.path.exists(os.path.join(recipe, f)) for f in
                     test_files]):
             return {
@@ -160,13 +158,13 @@ def missing_hash(recipe, meta, df):
     except KeyError:
         return
 
-    if not any(
+    if not any(map(partial(get_meta_value, src),
         (
-            'md5' in src,
-            'sha1' in src,
-            'sha256' in src
+            'md5',
+            'sha1',
+            'sha256',
         )
-    ):
+    )):
         return {
             'missing_hash': True,
             'fix': 'add md5, sha1, or sha256 hash to "source" section',

--- a/test/test_linting.py
+++ b/test/test_linting.py
@@ -139,13 +139,24 @@ def test_missing_home():
             about:
               home: "http://bioconda.github.io"
         ''',
-        should_fail='''
+        should_fail=[
+        '''
         missing_home:
           meta.yaml: |
             package:
               name: missing_home
               version: "0.1"
-        ''')
+        ''',
+        '''
+        missing_home:
+          meta.yaml: |
+            package:
+              name: missing_home
+              version: "0.1"
+            about:
+              home: ""
+        ''',
+        ])
 
 
 def test_missing_summary():
@@ -160,13 +171,24 @@ def test_missing_summary():
             about:
               summary: "tool description"
         ''',
-        should_fail='''
+        should_fail=[
+        '''
         missing_summary:
           meta.yaml: |
             package:
               name: missing_summary
               version: "0.1"
-        ''')
+        ''',
+        '''
+        missing_summary:
+          meta.yaml: |
+            package:
+              name: missing_summary
+              version: "0.1"
+            about:
+              summary: ""
+        ''',
+        ])
 
 
 def test_missing_license():
@@ -181,19 +203,31 @@ def test_missing_license():
             about:
               license: "MIT"
         ''',
-        should_fail='''
+        should_fail=[
+        '''
         missing_license:
           meta.yaml: |
             package:
               name: missing_license
               version: "0.1"
-        ''')
+        ''',
+        '''
+        missing_license:
+          meta.yaml: |
+            package:
+              name: missing_license
+              version: "0.1"
+            about:
+              license: ""
+        ''',
+        ])
 
 
 def test_missing_tests():
     run_lint(
         func=lint_functions.missing_tests,
-        should_pass=['''
+        should_pass=[
+        '''
         missing_tests:
           meta.yaml: |
             package:
@@ -218,21 +252,33 @@ def test_missing_tests():
               version: "0.1"
           run_test.py: ""
         ''',
-                    ],
-        should_fail='''
+        ],
+        should_fail=[
+        '''
         missing_tests:
           meta.yaml: |
             package:
               name: missing_tests
               version: "0.1"
           run_tst.sh: ""
-        ''')
+        ''',
+        '''
+        missing_tests:
+          meta.yaml: |
+            package:
+              name: missing_tests
+              version: "0.1"
+            test:
+              # empty test section
+        ''',
+        ])
 
 
 def test_missing_hash():
     run_lint(
         func=lint_functions.missing_hash,
-        should_pass=['''
+        should_pass=[
+        '''
         missing_hash:
           meta.yaml: |
             package:
@@ -246,8 +292,11 @@ def test_missing_hash():
         missing_hash:
           meta.yaml: |
             name: missing_hash
-            version: "0.1"'''],
-        should_fail='''
+            version: "0.1"
+        ''',
+        ],
+        should_fail=[
+        '''
         missing_hash:
           meta.yaml: |
             package:
@@ -255,7 +304,17 @@ def test_missing_hash():
               version: "0.1"
             source:
               fn: "a.txt"
-        ''')
+        ''',
+        '''
+        missing_hash:
+          meta.yaml: |
+            package:
+              name: missing_hash
+              version: "0.1"
+            source:
+              sha256: ""
+        ''',
+        ])
 
 
 def test_uses_git_url():


### PR DESCRIPTION
This extends the `missing_*` lint functions to also test whether the requested values actually have content. E.g., the following cases can now be caught too:
```yaml
source:
  sha256: ""
```
```yaml
test:
  # empty test section
```
```yaml
about:
  home: ""
```
