### PR TITLE
Use more conda-forge pins and slim down the Docker image

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -16,6 +16,7 @@ docutils
 sphinx_rtd_theme
 involucro=1.1.2
 pandas=0.19.2
+numpy
 pygithub=1.29
 colorlog=2.10.*
 six=1.10.0

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -1,6 +1,6 @@
 anaconda-client=1.6.3
 argh=0.26.2
-beautifulsoup4=4.4.1
+beautifulsoup4=4.6.0
 conda=4.3.21
 conda-build=2.1.16
 galaxy-lib=17.9.7

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -16,7 +16,7 @@ docutils
 sphinx_rtd_theme
 involucro=1.1.2
 pandas=0.19.2
-numpy
+numpy=1.12.1
 pygithub=1.29
 colorlog=2.10.*
 six=1.10.0

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -23,6 +23,7 @@ conda config --add channels bioconda
 
 conda config --get
 conda install -y --file bioconda_utils/bioconda_utils-requirements.txt
+conda clean -y -tp
 
 python setup.py install
 


### PR DESCRIPTION
This does three things:

1. Add `numpy` explicitly to the requirements (previously implicitly by `pandas`). That way we should get `numpy` from `conda-forge` instead of from https://repo.continuum.io/pkgs which would
   * reduce the dependency on https://repo.continuum.io/pkgs,
   * use the `openblas` build instead of the `mkl` one.

   That way we can avoid downloading/installing that big `mkl` package and thus skim maybe 20-30 seconds setup time as well as a couple of hundreds MB from the Docker image.
   The reason we didn't get `numpy` from `conda-forge` in the first place is described here: https://github.com/conda/conda/issues/6199#issuecomment-344097039.
2. Update to `beautifulsoup4 4.6.0`. The previous version is not available on `conda-forge` since its `beautifulsoup4` package only got added this year. I don't think this update should cause any troubles since the package is only used in `bioconda_utils.bioconductor_skeleton` to parse some HTML files. Nonetheless, for reference, the commit which introduced the `4.4.1` pin as well as Beautiful Soup's changelog:
   https://github.com/bioconda/bioconda-utils/pull/18/files#diff-c07a161f6233d35a615a6849711b2d1dR3
   http://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/NEWS.txt
3. Remove tarballs and unused packages from Conda's package cache.
   * This will further decrease the size of the Docker image.
   * It is a fast operation that shouldn't really increase the setup time.
   * It is ok to remove the tarballs since we don't use/need them for anything after their installation.
   * It is ok to remove the unused packages since that are those which came with Miniconda from the `defaults` channels and won't be re-downloaded afterwards as `conda-forge` packages will always be used instead.