### PR TITLE
adding in environmental variable to pkg_test

### DIFF
--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -126,11 +126,15 @@ def test_package(
     tests = get_tests(path)
     logger.debug('Tests to run: %s', tests)
 
+    target = 'biocontainers'
+    if os.environ.get('QUAY_TARGET') is not None:
+        target = os.environ.get('QUAY_TARGET')
+
     cmd = [
         'mulled-build',
         'build-and-test',
         spec,
-        '-n', 'biocontainers',
+        '-n', target,
         '--test', tests
     ]
     if name_override:


### PR DESCRIPTION
@bgruening 

Here is a really simple and possibly stupid way to fix the hardcoded biocontainers problem.

Let me know if you think there is a better way to do this.