### PR TITLE
Install Bioconductor data packages in conda R library.

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -812,7 +812,7 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
             fi
 
             # Install and clean up
-            R CMD INSTALL --build $TARBALL
+            R CMD INSTALL --library=$PREFIX/lib/R/library --build $TARBALL
             rm $TARBALL""")
         with open(os.path.join(recipe_dir, 'post-link.sh'), 'w') as fout:
             fout.write(dedent(post_link_template))


### PR DESCRIPTION
On Ubuntu, a user library is automatically set, e.g. `~/R/x86_64-pc-linux-gnu-library/3.4`. When I install a Bioconductor data package, e.g. GenomeInfoDb, it gets install in my Ubuntu user library instead of in the conda R library.

This PR updates the `post-link.sh` file created by `bioconductor-skeleton.py` to install the Bioconductor data package in the conda R library path. I tested that this works on Ubuntu.