### PR TITLE
Fail on Linux if Bioconductor data package has mismatched md5.

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -792,7 +792,7 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
 
               # Platform-specific md5sum checks.
               if [[ $(uname -s) == "Linux" ]]; then
-                if [[ $(md5sum -c <<<"$MD5  $TARBALL") ]]; then
+                if md5sum -c <<<"$MD5  $TARBALL"; then
                   SUCCESS=1
                   break
                 fi


### PR DESCRIPTION
I tried the following on macOS, but surprisingly it failed:

```
conda create -y -n test1 bioconductor-genomeinfodbdata
```

It turns out that the [expected](https://github.com/bioconda/bioconda-recipes/blob/master/recipes/bioconductor-genomeinfodbdata/post-link.sh#L7) and observed MD5 are different.

```
$ wget -q http://bioconductor.org/packages/3.6/data/annotation/src/contrib/GenomeInfoDbData_0.99.1.tar.gz
$ md5sum GenomeInfoDbData_0.99.1.tar.gz 
47c68c7ba79de1c309a5b6009bbc0c71  GenomeInfoDbData_0.99.1.tar.gz
```

Thus this should also fail on Linux, but it doesn't because the conditional statement always evaluates to TRUE. I updated the conditional statement for Linux based on this [SO answer](https://unix.stackexchange.com/a/254875/232582) so that it fails if the downloaded tarball does not match the expected MD5.

