### PR TITLE
Add template pre-unlink.sh for Bioconductor data packages

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -776,10 +776,9 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
         post_link_template += urls
         post_link_template += dedent(
             '''
-        )
+            )
             MD5="{proj.md5}"
-            '''.format(proj=proj, urls=urls)
-        )
+            '''.format(proj=proj, urls=urls))
         post_link_template += dedent(
             """
             # Use a staging area in the conda dir rather than temp dirs, both to avoid
@@ -817,7 +816,7 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
 
             # Install and clean up
             R CMD INSTALL --library=$PREFIX/lib/R/library --build $TARBALL
-            rm $TARBALL""")
+            rm -r $STAGING""")
         with open(os.path.join(recipe_dir, 'post-link.sh'), 'w') as fout:
             fout.write(dedent(post_link_template))
         pre_unlink_template = "rm -r $PREFIX/lib/R/library/{0}\n".format(package)

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -815,11 +815,12 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
             fi
 
             # Install and clean up
-            R CMD INSTALL --library=$PREFIX/lib/R/library --build $TARBALL
-            rm -r $STAGING""")
+            R CMD INSTALL --library=$PREFIX/lib/R/library $TARBALL
+            rm $TARBALL
+            rmdir $STAGING""")
         with open(os.path.join(recipe_dir, 'post-link.sh'), 'w') as fout:
             fout.write(dedent(post_link_template))
-        pre_unlink_template = "rm -r $PREFIX/lib/R/library/{0}\n".format(package)
+        pre_unlink_template = "R CMD REMOVE --library=$PREFIX/lib/R/library/ {0}\n".format(package)
         with open(os.path.join(recipe_dir, 'pre-unlink.sh'), 'w') as fout:
             fout.write(pre_unlink_template)
 

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -820,5 +820,8 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
             rm $TARBALL""")
         with open(os.path.join(recipe_dir, 'post-link.sh'), 'w') as fout:
             fout.write(dedent(post_link_template))
+        pre_unlink_template = "rm -r $PREFIX/lib/R/library/{0}\n".format(package)
+        with open(os.path.join(recipe_dir, 'pre-unlink.sh'), 'w') as fout:
+            fout.write(pre_unlink_template)
 
     logger.info('Wrote recipe in %s', recipe_dir)


### PR DESCRIPTION
xref: #234 #235 

This PR adds a template `pre-unlink.sh` file for Bioconductor data packages that runs prior to removing the package from the conda environment. Without this file, the R package remains installed and accessible in `$PREFIX/lib/R/library` even after it has been removed.

It also makes two minor edits to the `post-link.sh` file:

1. Removes indentation from the line that defines `MD5`
1.  The subdirectory within `$PREFIX/share` that was created to download the tarball is deleted instead of only deleting the tarball