### PR TITLE
Recursive cran functionality added to bioconductor-skeleton.py 

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -15,7 +15,7 @@ import logging
 import requests
 from colorlog import ColoredFormatter
 from . import utils
-import bioconda_utils.cran_skeleton
+from . import cran_skeleton
 
 logging.getLogger("requests").setLevel(logging.WARNING)
 
@@ -212,7 +212,7 @@ class BioCProjectPage(object):
         self._bioconductor_tarball_url = None
         self.is_data_package = False
         self.package_lower = package.lower()
-        self.raw_package_name = []
+        self.raw_dependency_names = []
 
         # If no version specified, assume the latest
         if not self.bioc_version:
@@ -540,12 +540,12 @@ class BioCProjectPage(object):
 
                 # # "r >=2.5" rather than "r-r >=2.5"
                 specific_r_version = True
-                self.raw_package_name.append("r-base")
+                self.raw_dependency_names.append("r-base")
                 results.append(name.lower() + '-base' + version)
 
             else:
                 results.append(prefix + name.lower() + version)
-                self.raw_package_name.append(name)
+                self.raw_dependency_names.append(name)
 
             if prefix + name.lower() in GCC_PACKAGES:
                 self.depends_on_gcc = True
@@ -553,12 +553,12 @@ class BioCProjectPage(object):
         # Add R itself
         if not specific_r_version:
             results.append('r-base')
-            self.raw_package_name.append('r-base')
+            self.raw_dependency_names.append('r-base')
 
         # Sometimes empty dependencies make it into the list from a trailing
         # comma in DESCRIPTION; remove them here.
         results = list(filter(lambda x: x != 'r-', results))
-        self.raw_package_name = list(filter(lambda x: x != "", self.raw_package_name))
+        self.raw_dependency_names = list(filter(lambda x: x != '', self.raw_dependency_names))
 
         self._dependencies = results
         return self._dependencies
@@ -710,26 +710,26 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
     config = utils.load_config(config)
     env = list(utils.EnvMatrix(config['env_matrix']))[0]
     proj = BioCProjectPage(package, bioc_version, pkg_version)
-    logger.info("Making recipe for: {}".format(package))
-    dependencies = proj.dependencies
+    logger.info('Making recipe for: {}'.format(package))
     if recursive:
-        logger.debug("list of dependencies: {}".format(proj.raw_package_name))
-        for dependency, name in zip(dependencies, proj.raw_package_name):
+        logger.debug('list of dependencies: {}'.format(proj.raw_dependency_names))
+        for dependency, name in zip(proj.dependencies, proj.raw_dependency_names):
             dependency_without_version = re.sub(r' >=.*$', '', dependency)
-            if dependency_without_version not in seen_dependencies:
-                seen_dependencies.append(dependency_without_version)
-                if dependency_without_version[:2] == 'r-':
-                    bioconda_utils.cran_skeleton.write_recipe(name, recipe_dir=recipe_dir, config=config,
-                                                              force=force, bioc_version=bioc_version,
-                                                              pkg_version=pkg_version, versioned=versioned,
-                                                              recursive=recursive,
-                                                              seen_dependencies=seen_dependencies)
-                else:
-                    write_recipe(name, recipe_dir=recipe_dir, config=config, force=force, bioc_version=bioc_version,
-                                 pkg_version=pkg_version, versioned=versioned, recursive=recursive,
-                                 seen_dependencies=seen_dependencies)
-            else:
+            if dependency_without_version in seen_dependencies:
                 logger.debug("seen {} before".format(dependency_without_version))
+                continue
+            seen_dependencies.append(dependency_without_version)
+            if dependency_without_version[:2] == 'r-':
+                cran_skeleton.write_recipe(name, recipe_dir=recipe_dir, config=config,
+                                                          force=force, bioc_version=bioc_version,
+                                                          pkg_version=pkg_version, versioned=versioned,
+                                                          recursive=recursive,
+                                                          seen_dependencies=seen_dependencies)
+            else:
+                write_recipe(name, recipe_dir=recipe_dir, config=config, force=force, bioc_version=bioc_version,
+                             pkg_version=pkg_version, versioned=versioned, recursive=recursive,
+                             seen_dependencies=seen_dependencies)
+
 
     logger.debug('%s==%s, BioC==%s', proj.package, proj.version, proj.bioc_version)
     logger.info('Using tarball from %s', proj.tarball_url)

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -520,7 +520,8 @@ def dependent(recipe_folder, config, restrict=False, dependencies=None, reverse_
 @arg('--loglevel', default='debug',
                 help='Log level')
 @arg('--recursive', action='store_true',
-                    help='TODO')
+                    help="""Creates the recipes for all bioconductor and cran recipes of the specified packages
+                    and puts the in the recipes directory""")
 def bioconductor_skeleton(
     recipe_folder, config, package, versioned=False, force=False,
     pkg_version=None, bioc_version=None, loglevel='info', recursive=False, seen_dependencies=[]

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -538,7 +538,7 @@ def bioconductor_skeleton(
         #print("osListDir: {}".format(os.listdir(recipe_folder)))
         for package in os.listdir(recipe_folder):
             if package[:2] == "r-":
-                bioconda_utils.skeleton_helper_cran.clean_skeleton_files(os.path.join(recipe_folder, package))
+                bioconda_utils.skeleton_helper_cran.clean_skeleton_files(os.path.join(recipe_folder, package))  
 
 
 @arg('recipe_folder', help='Path to recipes directory')

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -12,7 +12,7 @@ from argh import arg
 import networkx as nx
 from networkx.drawing.nx_pydot import write_dot
 import pandas
-import bioconda_utils.cran_skeleton
+from . import cran_skeleton
 
 from . import utils
 from .build import build_recipes
@@ -538,7 +538,7 @@ def bioconductor_skeleton(
         #print("osListDir: {}".format(os.listdir(recipe_folder)))
         for package in os.listdir(recipe_folder):
             if package[:2] == "r-":
-                bioconda_utils.cran_skeleton.clean_skeleton_files(os.path.join(recipe_folder, package))
+                cran_skeleton.clean_skeleton_files(os.path.join(recipe_folder, package))
 
 
 @arg('recipe_folder', help='Path to recipes directory')

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -535,8 +535,10 @@ def bioconductor_skeleton(
         pkg_version=pkg_version, versioned=versioned, recursive=recursive, seen_dependencies=seen_dependencies
     )
     if recursive:
+        #print("osListDir: {}".format(os.listdir(recipe_folder)))
         for package in os.listdir(recipe_folder):
-            bioconda_utils.skeleton_helper_cran.clean_skeleton_files(os.path.join(recipe_folder, package))
+            if package[:2] == "r-":
+                bioconda_utils.skeleton_helper_cran.clean_skeleton_files(os.path.join(recipe_folder, package))
 
 
 @arg('recipe_folder', help='Path to recipes directory')

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -12,7 +12,7 @@ from argh import arg
 import networkx as nx
 from networkx.drawing.nx_pydot import write_dot
 import pandas
-import bioconda_utils.skeleton_helper_cran
+import bioconda_utils.cran_skeleton
 
 from . import utils
 from .build import build_recipes
@@ -538,7 +538,7 @@ def bioconductor_skeleton(
         #print("osListDir: {}".format(os.listdir(recipe_folder)))
         for package in os.listdir(recipe_folder):
             if package[:2] == "r-":
-                bioconda_utils.skeleton_helper_cran.clean_skeleton_files(os.path.join(recipe_folder, package))  
+                bioconda_utils.cran_skeleton.clean_skeleton_files(os.path.join(recipe_folder, package))
 
 
 @arg('recipe_folder', help='Path to recipes directory')

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -12,7 +12,7 @@ from argh import arg
 import networkx as nx
 from networkx.drawing.nx_pydot import write_dot
 import pandas
-
+import bioconda_utils.skeleton_helper_cran
 
 from . import utils
 from .build import build_recipes
@@ -519,9 +519,11 @@ def dependent(recipe_folder, config, restrict=False, dependencies=None, reverse_
                 version""")
 @arg('--loglevel', default='debug',
                 help='Log level')
+@arg('--recursive', action='store_true',
+                    help='TODO')
 def bioconductor_skeleton(
     recipe_folder, config, package, versioned=False, force=False,
-    pkg_version=None, bioc_version=None, loglevel='info'
+    pkg_version=None, bioc_version=None, loglevel='info', recursive=False, seen_dependencies=[]
 ):
     """
     Build a Bioconductor recipe. The recipe will be created in the `recipes`
@@ -530,8 +532,11 @@ def bioconductor_skeleton(
     setup_logger(loglevel)
     _bioconductor_skeleton.write_recipe(
         package, recipe_folder, config, force=force, bioc_version=bioc_version,
-        pkg_version=pkg_version, versioned=versioned
+        pkg_version=pkg_version, versioned=versioned, recursive=recursive, seen_dependencies=seen_dependencies
     )
+    if recursive:
+        for package in os.listdir(recipe_folder):
+            bioconda_utils.skeleton_helper_cran.clean_skeleton_files(os.path.join(recipe_folder, package))
 
 
 @arg('recipe_folder', help='Path to recipes directory')

--- a/bioconda_utils/cran_skeleton.py
+++ b/bioconda_utils/cran_skeleton.py
@@ -68,9 +68,12 @@ def clean_build_file(package, no_windows=False):
     path = package + '/build.sh'
     with open(path, 'r') as build:
         lines = list(build.readlines())
-        lines = filter_lines_regex(lines, r'^mv\s.*$', '')  # Remove lines with mv commands
-        lines = filter_lines_regex(lines, r'^grep\s.*$', '')  # Remove lines with grep commands
-        lines = filter_lines_regex(lines, r'^\s*#.*$', '')  # Removes the lines consisting of only comments
+        # Remove lines with mv commands
+        lines = filter_lines_regex(lines, r'^mv\s.*$', '')
+        # Remove lines with grep commands
+        lines = filter_lines_regex(lines, r'^grep\s.*$', '')
+        # Removes the lines consisting of only comments
+        lines = filter_lines_regex(lines, r'^\s*#.*$', '')
         lines = remove_empty_lines(lines)
 
     with open(path, 'w') as build:
@@ -83,7 +86,8 @@ def clean_bld_file(package, no_windows):
     path = package + '/bld.bat'
     with open(path, 'r') as bld:
         lines = list(bld.readlines())
-        lines = filter_lines_regex(lines, r'^@.*$', '')  # Removes the lines that start with @
+        # Removes the lines that start with @
+        lines = filter_lines_regex(lines, r'^@.*$', '')
         lines = remove_empty_lines(lines)
 
     with open(path, 'w') as bld:

--- a/bioconda_utils/cran_skeleton.py
+++ b/bioconda_utils/cran_skeleton.py
@@ -17,7 +17,7 @@ gpl2_long = ("  license_family: GPL2\n  license_file: '{{ environ[\"PREFIX\"] }}
              "\\\R\\\share\\\licenses\\\GPL-2'  # [win]")
 
 gpl3_short = r"  license_family: GPL3"
-gpl3_long   = ("  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}" +
+gpl3_long = ("  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}" +
              "\/lib\/R\/share\/licenses\/GPL-3'  # [unix]\n  " +
              "license_file: '{{ environ[\"PREFIX\"] }}" +
              "\\\R\\\share\\\licenses\\\GPL-3'  # [win]")
@@ -27,16 +27,10 @@ win32_string = 'number: 0\n  skip: true  # [win32]'
 
 def write_recipe(package, recipe_dir='.', no_windows=True, config=None, force=False, bioc_version=None,
                  pkg_version=None, versioned=False, recursive=False, seen_dependencies=[]):
-        print("WRITING CRAN!!")
         if recursive:
-            print("ENTER RECURSIVE")
             sp.call(['conda skeleton cran ' + package + ' --output-dir ' + recipe_dir + " --recursive"], shell=True)
-            '''if package != "r-base": #TODO: This if statement should be deleted. Don't know what to do with r-base
-                print("ENTER CLEANING")
-                clean_skeleton_files(recipe_dir + '/r-' + package.lower(), no_windows)'''
         else:
             sp.call(['conda skeleton cran ' + package + ' --output-dir ' + recipe_dir], shell=True)
-            #clean_skeleton_files(recipe_dir + '/r-' + package, no_windows)
 
 
 def clean_skeleton_files(package, no_windows=True):
@@ -57,7 +51,7 @@ def clean_yaml_file(package, no_windows):
         lines = filter_lines_regex(lines, gpl2_short, gpl2_long)  # add gpl 2
         lines = filter_lines_regex(lines, gpl3_short, gpl3_long)  # add gpl 3
         if no_windows:
-            lines = filter_lines_regex(lines,r'number: 0',win32_string)  # Inserts the skip: true # [win32] after number: 0, to skip windows builds
+            lines = filter_lines_regex(lines, r'number: 0', win32_string)  # Inserts the skip: true # [win32] after number: 0, to skip windows builds
         add_maintainers(lines)
 
     with open(path, 'w') as yaml:

--- a/bioconda_utils/skeleton_helper_cran.py
+++ b/bioconda_utils/skeleton_helper_cran.py
@@ -17,7 +17,7 @@ gpl2_long = ("  license_family: GPL2\n  license_file: '{{ environ[\"PREFIX\"] }}
              "\\\R\\\share\\\licenses\\\GPL-2'  # [win]")
 
 gpl3_short = r"  license_family: GPL3"
-gpl3_long = ("  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}" +
+gpl3_long   = ("  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}" +
              "\/lib\/R\/share\/licenses\/GPL-3'  # [unix]\n  " +
              "license_file: '{{ environ[\"PREFIX\"] }}" +
              "\\\R\\\share\\\licenses\\\GPL-3'  # [win]")
@@ -27,14 +27,16 @@ win32_string = 'number: 0\n  skip: true  # [win32]'
 
 def write_recipe(package, recipe_dir='.', no_windows=True, config=None, force=False, bioc_version=None,
                  pkg_version=None, versioned=False, recursive=False, seen_dependencies=[]):
-
+        print("WRITING CRAN!!")
         if recursive:
+            print("ENTER RECURSIVE")
             sp.call(['conda skeleton cran ' + package + ' --output-dir ' + recipe_dir + " --recursive"], shell=True)
-            if package != "r-base": #TODO: This if statement should be deleted. Don't know what to do with r-base
-                clean_skeleton_files(recipe_dir + '/r-' + package.lower(), no_windows)
+            '''if package != "r-base": #TODO: This if statement should be deleted. Don't know what to do with r-base
+                print("ENTER CLEANING")
+                clean_skeleton_files(recipe_dir + '/r-' + package.lower(), no_windows)'''
         else:
             sp.call(['conda skeleton cran ' + package + ' --output-dir ' + recipe_dir], shell=True)
-            clean_skeleton_files(recipe_dir + '/r-' + package, no_windows)
+            #clean_skeleton_files(recipe_dir + '/r-' + package, no_windows)
 
 
 def clean_skeleton_files(package, no_windows=True):

--- a/bioconda_utils/skeleton_helper_cran.py
+++ b/bioconda_utils/skeleton_helper_cran.py
@@ -1,0 +1,134 @@
+from optparse import OptionParser
+import subprocess as sp
+import re
+from itertools import zip_longest
+import argparse
+import yaml
+
+
+INVALID_NAME_MAP = {
+    'r-edger': 'bioconductor-edger',
+}
+
+gpl2_short = r"  license_family: GPL2"
+gpl2_long = ("  license_family: GPL2\n  license_file: '{{ environ[\"PREFIX\"] }}" +
+             "\/lib\/R\/share\/licenses\/GPL-2'  # [unix]\n  " +
+             "license_file: '{{ environ[\"PREFIX\"] }}" +
+             "\\\R\\\share\\\licenses\\\GPL-2'  # [win]")
+
+gpl3_short = r"  license_family: GPL3"
+gpl3_long = ("  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}" +
+             "\/lib\/R\/share\/licenses\/GPL-3'  # [unix]\n  " +
+             "license_file: '{{ environ[\"PREFIX\"] }}" +
+             "\\\R\\\share\\\licenses\\\GPL-3'  # [win]")
+
+win32_string = 'number: 0\n  skip: true  # [win32]'
+
+
+def write_recipe(package, recipe_dir='.', no_windows=True, config=None, force=False, bioc_version=None,
+                 pkg_version=None, versioned=False, recursive=False, seen_dependencies=[]):
+
+        if recursive:
+            sp.call(['conda skeleton cran ' + package + ' --output-dir ' + recipe_dir + " --recursive"], shell=True)
+        else:
+            sp.call(['conda skeleton cran ' + package + ' --output-dir ' + recipe_dir], shell=True)
+            clean_skeleton_files(recipe_dir + '/r-' + package, no_windows)
+
+
+def clean_skeleton_files(package, no_windows=True):
+    # Cleans the yaml and build files to make them conda-forge compatible.
+
+    clean_yaml_file(package, no_windows)
+    clean_build_file(package, no_windows)
+    clean_bld_file(package, no_windows)
+
+
+def clean_yaml_file(package, no_windows):
+    path = package + '/meta.yaml'
+    with open(path, 'r') as yaml:
+        lines = list(yaml.readlines())
+        lines = filter_lines_regex(lines, r'^\s*#.*$', '')  # Removes the lines consisting of only comments
+        lines = remove_empty_lines(lines)
+        lines = filter_lines_regex(lines, r' [+|] file LICEN[SC]E', '')  # remove file license
+        lines = filter_lines_regex(lines, gpl2_short, gpl2_long)  # add gpl 2
+        lines = filter_lines_regex(lines, gpl3_short, gpl3_long)  # add gpl 3
+        if no_windows:
+            lines = filter_lines_regex(lines,r'number: 0',win32_string)  # Inserts the skip: true # [win32] after number: 0, to skip windows builds
+        add_maintainers(lines)
+
+    with open(path + '.c', 'w') as yaml:
+        out = "".join(lines)
+        out = out.replace('{indent}', '\n    - ')
+        for wrong, correct in INVALID_NAME_MAP.items():
+            out = out.replace(wrong, correct)
+        yaml.write(out)
+
+
+def clean_build_file(package, no_windows=False):
+    # Clean build.sh file
+
+    path = package + '/build.sh'
+    with open(path, 'r') as build:
+        lines = list(build.readlines())
+        lines = filter_lines_regex(lines, r'^mv\s.*$', '')  # Remove lines with mv commands
+        lines = filter_lines_regex(lines, r'^grep\s.*$', '')  # Remove lines with grep commands
+        lines = filter_lines_regex(lines, r'^\s*#.*$', '')  # Removes the lines consisting of only comments
+        lines = remove_empty_lines(lines)
+
+    with open(path, 'w') as build:
+        build.write("".join(lines))
+
+
+def clean_bld_file(package, no_windows):
+    # Clean bld.bat file
+
+    path = package + '/bld.bat'
+    with open(path, 'r') as bld:
+        lines = list(bld.readlines())
+        lines = filter_lines_regex(lines, r'^@.*$', '')  # Removes the lines that start with @
+        lines = remove_empty_lines(lines)
+
+    with open(path, 'w') as bld:
+        bld.write("".join(lines))
+
+
+def filter_lines_regex(lines, regex, substitute):
+    return [re.sub(regex, substitute, line) for line in lines]
+
+
+def remove_empty_lines(lines):
+    # Removes consecutive empty lines from a file
+
+    cleaned_lines = []
+
+    for line, next_line in zip_longest(lines, lines[1:]):
+        if (line.isspace() and next_line is None) or (line.isspace() and next_line.isspace()):
+            pass
+        else:
+            cleaned_lines.append(line)
+
+    if cleaned_lines[0].isspace():
+        cleaned_lines = cleaned_lines[1:]
+    return cleaned_lines
+
+
+def add_maintainers(lines):
+    with open("maintainers.yaml", 'r') as yaml:
+        extra_lines = list(yaml.readlines())
+        lines.extend(extra_lines)
+
+
+def main():
+    """ Adding support for arguments here """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('package', help='name of the cran package')
+    parser.add_argument('output_dir', help='output directory for the recipe')
+    parser.add_argument('--no-win', default=False, action="store_true",
+                        help='runs the skeleton and removes windows specific information')
+
+    args = parser.parse_args()
+    write_recipe(args.package, args.output_dir, no_windows=args.no_win)
+
+
+if __name__ == '__main__':
+    main()

--- a/bioconda_utils/skeleton_helper_cran.py
+++ b/bioconda_utils/skeleton_helper_cran.py
@@ -30,6 +30,8 @@ def write_recipe(package, recipe_dir='.', no_windows=True, config=None, force=Fa
 
         if recursive:
             sp.call(['conda skeleton cran ' + package + ' --output-dir ' + recipe_dir + " --recursive"], shell=True)
+            if package != "r-base": #TODO: This if statement should be deleted. Don't know what to do with r-base
+                clean_skeleton_files(recipe_dir + '/r-' + package.lower(), no_windows)
         else:
             sp.call(['conda skeleton cran ' + package + ' --output-dir ' + recipe_dir], shell=True)
             clean_skeleton_files(recipe_dir + '/r-' + package, no_windows)
@@ -56,7 +58,7 @@ def clean_yaml_file(package, no_windows):
             lines = filter_lines_regex(lines,r'number: 0',win32_string)  # Inserts the skip: true # [win32] after number: 0, to skip windows builds
         add_maintainers(lines)
 
-    with open(path + '.c', 'w') as yaml:
+    with open(path, 'w') as yaml:
         out = "".join(lines)
         out = out.replace('{indent}', '\n    - ')
         for wrong, correct in INVALID_NAME_MAP.items():

--- a/maintainers.yaml
+++ b/maintainers.yaml
@@ -3,7 +3,7 @@ extra:
     - MathiasHaudgaard
     - FrodePedersen
     - ArneKr
-    - Johanneskoester
-    - Bgruening
-    - Daler
-    - Jdblischak
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak

--- a/maintainers.yaml
+++ b/maintainers.yaml
@@ -1,0 +1,9 @@
+extra:
+   recipe-maintainers:
+    - MathiasHaudgaard
+    - FrodePedersen
+    - ArneKr
+    - Johanneskoester
+    - Bgruening
+    - Daler
+    - Jdblischak


### PR DESCRIPTION
Elixir in Aarhus has added a feature to bioconductor-skeleton so if there are any cran dependencies, there will be made recipes for these dependencies. However, we still have the following problems:
- What if you want to make the same recipe just with a different version. Right now that situation results in an error because the script sees that the recipe is already made.
- Not sure if we're handling r-base correct.

Feel free to comment and give suggestions :-)