### PR TITLE
lint: disable uses_setuptools

### DIFF
--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -341,7 +341,9 @@ registry = (
     uses_git_url,
     uses_javajdk,
     uses_perl_threaded,
-    uses_setuptools,
+    # removing setuptools from run requirements should be done cautiously:
+    # it breaks packages that use pkg_resources or setuptools console scripts!
+    # uses_setuptools,
     has_windows_bat_file,
 
     # should_be_noarch,

--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -207,7 +207,7 @@ def uses_setuptools(recipe, meta, df):
     if 'setuptools' in _get_deps(meta, 'run'):
         return {
             'depends_on_setuptools': True,
-            'fix': 'setuptools may not be required',
+            'fix': 'setuptools might not be a run requirement,
         }
 
 

--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -207,7 +207,8 @@ def uses_setuptools(recipe, meta, df):
     if 'setuptools' in _get_deps(meta, 'run'):
         return {
             'depends_on_setuptools': True,
-            'fix': 'setuptools might not be a run requirement,
+            'fix': ('setuptools might not be a run requirement (unless it uses '
+                    'pkg_resources or setuptools console scripts)'),
         }
 
 

--- a/docs/source/linting.rst
+++ b/docs/source/linting.rst
@@ -68,8 +68,8 @@ a bioconda-specific patch is required. However it is almost always better to
 fix or update the recipe in the other channel. Note that the package in the
 bioconda channel will remain in order to maintain reproducibility.
 
-`already_in_bioconda`
-~~~~~~~~~~~~~~~~~~~~~
+`already_in_bioconda` (currently disabled)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The current package version, build, and platform
 (linux/osx) already exists in the bioconda channel.
 
@@ -133,8 +133,8 @@ How to resolve: Add a hash in the `source section
 <https://conda.io/docs/building/meta-yaml.html#source-section>`_. See
 :ref:`hashes` for more info.
 
-`should_be_noarch`
-~~~~~~~~~~~~~~~~~~
+`should_be_noarch` (currently disabled)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The package should be labelled as ``noarch``.
 
 Rationale: A ``noarch`` package should be created for pure Python packages, data packages, or
@@ -194,8 +194,8 @@ recipes is updated, it will fail this check.
 
 How to resolve: Change ``java-jdk`` to ``openjdk``.
 
-`uses_setuptools`
-~~~~~~~~~~~~~~~~~
+`uses_setuptools` (currently disabled)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The recipe has ``setuptools`` as a run dependency.
 
 Rationale: ``setuptools`` is typically used to install dependencies for Python

--- a/docs/source/linting.rst
+++ b/docs/source/linting.rst
@@ -203,7 +203,13 @@ packages but most of the time this is not needed within a conda package as
 a run dependency.
 
 How to resolve: Ensure that all dependencies are explicitly defined. Some
-packages do need setuptools, in which case this can be overridden.
+packages do need ``setuptools``, in which case this can be overridden.
+``setuptools`` may be required, e.g., if a package loads resources via
+``pkg_resources`` which is part of ``setuptools``. That dependency can also be
+introduced implicitly when ``setuptools``-created console scripts are used.
+To avoid this, make sure to carry ``console_scripts`` entry points from
+``setup.py`` over to ``meta.yaml`` to replace them with scripts created by
+``conda``/``conda-build`` which don't require ``pkg_resources``.
 
 `has_windows_bat_file`
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The `uses_setuptools` lint suggests to remove `setuptools` dependencies.
But `setuptools` can be a run requirement if a Python package
* uses `pkg_resources` (which is part of `setuptools`),
* uses `setup(entry_points={"console_scripts": [...]})` but doesn't have all those entry points replaced by Conda-created entry points in `meta.yaml` (which thus automatically use `pkg_resources` unlike the Conda-created ones),
* (very unlikely: imports `setuptools` (other than in `setup.py`)).

The previous wording `'setuptools may not be required'` let contributor to unconditionally remove `setuptools` from run/build requirements, I suppose because
* `may not` is more of a "prohibition" phrase,
* `be required` doesn't state we're only talking about run requirements.

This PR fixes and clarifies that wording. But it also disabled `uses_setuptools` all together since that might be the "safest bet" to avoid broken packages -- a surplus dependency isn't nice but also doesn't hurt as much as a missing one...
