### PR TITLE
Skip mulled-build test for conda-dependent recipes

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -349,12 +349,28 @@ def build_recipes(
 
         for target in recipe_targets[recipe]:
 
+            # If a recipe depends on conda, it means it must be installed in
+            # the root env, which is not compatible with mulled-build tests. In
+            # that case, we temporarily disable the mulled-build tests for the
+            # recipe.
+            deps = []
+            deps += utils.get_deps(recipe, orig_config, build=True)
+            deps += utils.get_deps(recipe, orig_config, build=False)
+            keep_mulled_test = True
+            if 'conda' in deps or 'conda-build' in deps:
+                keep_mulled_test = False
+                if mulled_test:
+                    logger.info(
+                        'TEST SKIP: '
+                        'skipping test for %s because it depends '
+                        'on conda or conda-build')
+
             res = build(
                 recipe=recipe,
                 recipe_folder=recipe_folder,
                 env=target.env,
                 testonly=testonly,
-                mulled_test=mulled_test,
+                mulled_test=mulled_test & keep_mulled_test,
                 force=force,
                 channels=config['channels'],
                 docker_builder=docker_builder,

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -362,8 +362,8 @@ def build_recipes(
                 if mulled_test:
                     logger.info(
                         'TEST SKIP: '
-                        'skipping test for %s because it depends '
-                        'on conda or conda-build')
+                        'skipping mulled-build test for %s because it '
+                        'depends on conda or conda-build', recipe)
 
             res = build(
                 recipe=recipe,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -288,6 +288,30 @@ def test_get_deps():
     assert list(utils.get_deps(r.recipe_dirs['three'], config={}, build=False)) == ['two']
 
 
+def test_conda_as_dep():
+    r = Recipes(
+        """
+        one:
+          meta.yaml: |
+            package:
+              name: one
+              version: 0.1
+            requirements:
+              run:
+                - conda
+        """, from_string=True)
+    r.write_recipes()
+    build_result = build.build_recipes(
+        r.basedir,
+        config={},
+        packages="*",
+        testonly=False,
+        force=False,
+        mulled_test=True,
+    )
+    assert build_result
+
+
 def test_env_matrix():
     contents = {
         'CONDA_PY': [27, 35],


### PR DESCRIPTION
xref https://github.com/bioconda/bioconda-recipes/pull/7241, ping @johanneskoester and @bgruening. 

Rather than special-case `bioconda-utils`, this skips mulled-build for any recipe depending on conda. Should allow a `bioconda-utils` conda package to be built.