### PR TITLE
requirements: update conda to 4.3.33

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -1,7 +1,7 @@
 anaconda-client=1.6.*
 argh=0.26.*
 beautifulsoup4=4.6.*
-conda=4.3.29
+conda=4.3.33
 conda-build=2.1.18
 galaxy-lib=17.9.*
 jinja2=2.10.*


### PR DESCRIPTION
The macOS queue for `conda-forge` on Travis CI was cleared 🍻. So we are now able to use the latest `conda 4.3.x` release!
IMO, updating to `conda 4.3.33` as soon as possible is important due to https://github.com/conda/conda/pull/6766.