### PR TITLE
test: pytest>=3.4 compat: capture >=INFO messages

### DIFF
--- a/pip-test-requirements.txt
+++ b/pip-test-requirements.txt
@@ -1,2 +1,2 @@
-pytest
+pytest>=3.3
 pytest-cov

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -8,6 +8,7 @@ import requests
 import uuid
 import contextlib
 import tarfile
+import logging
 
 from bioconda_utils import utils
 from bioconda_utils import pkg_test
@@ -885,9 +886,10 @@ class TestSubdags(object):
                 self._build(recipes_fixture)
 
     def test_subdags_more_than_recipes(self, caplog, recipes_fixture):
-        with utils.temp_env({'SUBDAGS': '5', 'SUBDAG': '4'}):
-            self._build(recipes_fixture)
-        assert 'Nothing to be done' in caplog.records[-1].getMessage()
+        with caplog.at_level(logging.INFO):
+            with utils.temp_env({'SUBDAGS': '5', 'SUBDAG': '4'}):
+                    self._build(recipes_fixture)
+            assert 'Nothing to be done' in caplog.records[-1].getMessage()
 
 
 def test_zero_packages():


### PR DESCRIPTION
`pytest 3.4`(just released on `conda-forge`) introduced a [breaking change](https://docs.pytest.org/en/latest/logging.html#incompatible-changes-in-pytest-3-4) so that `caplog` doesn't capture `INFO` messages on default in `test/test_utils.py::TestSubdags::test_subdags_more_than_recipes`, which thus failed.