### PR TITLE
lint: dont' require pin for run-only deps

### DIFF
--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -296,21 +296,22 @@ def _pin(env_var, dep_name):
         pinned = set()
         for line in open(os.path.join(recipe, 'meta.yaml')):
             line = line.rstrip("\n")
-            dedented_line = line.lstrip(' ')
             if line.startswith("requirements:"):
                 in_requirements = True
-            elif in_requirements and dedented_line.startswith("run:"):
-                section = "run"
-            elif in_requirements and dedented_line.startswith("build:"):
-                section = "build"
             elif line and not line.startswith(" ") and not line.startswith("#"):
                 in_requirements = False
                 section = None
-            if in_requirements and dedented_line.startswith('- {}'.format(dep_name)):
-                if pin_pattern.search(dedented_line) is None:
-                    not_pinned.add(section)
-                else:
-                    pinned.add(section)
+            if in_requirements:
+                dedented_line = line.lstrip(' ')
+                if dedented_line.startswith("run:"):
+                    section = "run"
+                elif dedented_line.startswith("build:"):
+                    section = "build"
+                elif dedented_line.startswith('- {}'.format(dep_name)):
+                    if pin_pattern.search(dedented_line) is None:
+                        not_pinned.add(section)
+                    else:
+                        pinned.add(section)
 
         # two error cases: 1) run is not pinned but in build
         #                  2) build is not pinned and run is pinned

--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -312,11 +312,12 @@ def _pin(env_var, dep_name):
                 else:
                     pinned.add(section)
 
-        # two error cases: 1) run is not pinned
+        # two error cases: 1) run is not pinned but in build
         #                  2) build is not pinned and run is pinned
         # Everything else is ok. E.g., if dependency is not in run, we don't
         # need to pin build, because it is statically linked.
-        if "run" in not_pinned or ("run" in pinned and "build" in not_pinned):
+        if (("run" in not_pinned and "build" in pinned.union(not_pinned)) or
+           ("run" in pinned and "build" in not_pinned)):
             err = {
                 '{}_not_pinned'.format(dep_name): True,
                 'fix': (

--- a/test/test_linting.py
+++ b/test/test_linting.py
@@ -662,6 +662,16 @@ def test_lint_pin():
                 - zlib  # build-only requirements are obviously statically linked, hence no pinning needed
               run:
                 - libgcc
+        ''',
+        '''
+        a:
+          meta.yaml: |
+            package:
+              name: a
+              version: '0.1'
+            requirements:
+              run:
+                - zlib  # run-only requirement doesn't need pinning; build is not influenced by it
         '''],
         should_fail=[
         '''


### PR DESCRIPTION
The linter currently request to pin run-only dependencies. But if those dependencies are not required/directly pulled in during the build phase, the built package shouldn't have those run constraints.
(The second commit doesn't change behavior and is just to make the code a bit clearer (I hope).)