### PR TITLE
docker: split entrypoint in source/exec parts

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -1,7 +1,7 @@
 #!/bin/bash -il
 
 # Source everything that needs to be.
-. /opt/docker/bin/entrypoint_source
+. /tmp/repo/docker-entrypoint-source
 
 # Run whatever the user wants.
 exec "$@"

--- a/docker-entrypoint-source
+++ b/docker-entrypoint-source
@@ -1,0 +1,2 @@
+# Enable devtoolset-2 compilers and activate /opt/conda/bin
+. /opt/docker/bin/entrypoint_source


### PR DESCRIPTION
This is just a very minor change to make the `source` part of the Docker entrypoint reusable from outside the entrypoint.
Could be used in https://github.com/bioconda/bioconda-recipes/pull/7684/files/d5af76c8c779dcde05dce44ab52c724574879c6c#diff-1d37e48f9ceff6d8030570cd36286a61R50.