### PR TITLE
Refactor generate_docs 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'sphinx.ext.extlinks',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -315,3 +316,9 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
+
+# We are using the `extlinks` extension to render links for identifiers:
+extlinks = {
+   'biotools': ('https://bio.tools/%s', ''),
+   'doi': ('https://dx.doi.org/%s', ''),
+}

--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -161,11 +161,11 @@ def generate_recipes(app):
 
         for version, version_info in sorted(versions_in_channel.items()):
             t = template_options.copy()
-            if 'linux' in version_info:
-                t['Linux'] = '<i class="fa fa-linux"></i>'
-            if 'osx' in version_info:
-                t['OSX'] = '<i class="fa fa-apple"></i>'
-            t['Version'] = version
+            t.update({
+                'Linux': '<i class="fa fa-linux"></i>' if 'linux' in version_info else '',
+                'OSX': '<i class="fa fa-apple"></i>' if 'osx' in version_info else '',
+                'Version': version
+            })
             recipes.append(t)
 
         renderer.render_to_file(

--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -64,7 +64,7 @@ class Renderer(object):
         template_loader = BuiltinTemplateLoader()
         template_loader.init(app.builder)
         template_env = SandboxedEnvironment(loader=template_loader)
-        template_env.filters['escape'] = rst_escape
+        template_env.filters['escape'] = lambda x: rst_escape(x) if x else x
         template_env.filters['underline'] = lambda x: x + '\n' + '=' * len(x)
         self.env = template_env
         self.templates = {}

--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -2,15 +2,26 @@ import os
 import os.path as op
 from collections import defaultdict
 from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 from bioconda_utils import utils
+from sphinx.util import logging as sphinx_logging
+from sphinx.util import status_iterator
+from sphinx.util.template import SphinxRenderer
+from sphinx.util.rst import escape as rst_escape
+from sphinx.jinja2glue import BuiltinTemplateLoader
+from distutils.version import LooseVersion
+
+try:
+    logger = sphinx_logging.getLogger(__name__)
+except AttributeError:  # not running within sphinx
+    import logging
+    logger = logging.getLogger(__name__)
 
 try:
     from conda_build.metadata import MetaData
-except Exception as e:
-    import traceback
-    traceback.print_exc()
-    raise e
-from distutils.version import LooseVersion
+except Exception:
+    logging.exception("Failed to import MetaData")
+    raise
 
 
 BASE_DIR = op.dirname(op.abspath(__file__))
@@ -18,95 +29,9 @@ RECIPE_DIR = op.join(op.dirname(BASE_DIR), 'bioconda-recipes', 'recipes')
 OUTPUT_DIR = op.join(BASE_DIR, 'recipes')
 
 # jinja2 template for the DataTable of recipes
-RECIPES_TEMPLATE = u"""\
-.. _recipes:
+RECIPES_TEMPLATE = "recipes.rst_t"
+README_TEMPLATE = "readme.rst_t"
 
-Available packages
-==================
-
-.. toctree::
-   :hidden:
-   :maxdepth: 1
-   :glob:
-
-   recipes/*/*
-
-.. raw:: html
-
-    <table id="recipestable" class="display" cellspacing="0" width="100%">
-    <thead>
-        <tr>
-        {% for key in keys %}
-        <th>{{ key }}</th>
-        {% endfor %}
-        </tr>
-    </thead>
-    <tbody>
-    {% for r in recipes %}
-    <tr>
-        {% for k in keys %}
-        <td>{{ r[k] }}</td>
-        {% endfor %}
-    </tr>
-    {% endfor %}
-    </tbody>
-    <tfoot></tfoot>
-    </table>
-"""
-
-
-README_TEMPLATE = u"""\
-.. _`{title}`:
-
-{title}
-{title_underline}
-
-|downloads|
-
-{summary}
-
-======== ===========
-Home     {home}
-Versions {versions}
-License  {license}
-Recipe   {recipe}
-======== ===========
-
-Installation
-------------
-
-.. highlight: bash
-
-With an activated Bioconda channel (see :ref:`set-up-channels`), install with::
-
-   conda install {title}
-
-and update with::
-
-   conda update {title}
-
-{notes}
-
-|docker|
-
-A Docker container is available at https://quay.io/repository/biocontainers/{title}.
-
-Link to this page
------------------
-
-Render an |badge| badge with the following Markdown::
-
-   [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](http://bioconda.github.io/recipes/{title}/README.html)
-
-.. |badge| image:: https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square
-           :target: http://bioconda.github.io/recipes/{title}/README.html
-.. |downloads| image:: https://anaconda.org/bioconda/{title}/badges/downloads.svg
-               :target: https://anaconda.org/bioconda/{title}
-.. |docker| image:: https://quay.io/repository/biocontainers/{title}/status
-                :target: https://quay.io/repository/biocontainers/{title}
-
-
-"""
 
 def parse_pkgname(p):
     p = p.replace('.tar.bz2', '')
@@ -117,14 +42,35 @@ def parse_pkgname(p):
     return dict(name=name, version=version, build_string=build_string)
 
 
-def setup(*args):
+class Renderer(object):
+    def __init__(self, app):
+        template_loader = BuiltinTemplateLoader()
+        template_loader.init(app.builder)
+        template_env = SandboxedEnvironment(loader=template_loader)
+        template_env.filters['escape'] = rst_escape
+        self.env = template_env
+        self.templates = {}
+
+    def render(self, template_name, context):
+        try:
+            template = self.templates[template_name]
+        except KeyError:
+            template = self.env.get_template(template_name)
+            self.templates[template_name] = template
+
+        return template.render(**context)
+
+
+def generate_recipes(app):
     """
     Go through every folder in the `bioconda-recipes/recipes` dir
     and generate a README.rst file.
     """
-    print('Generating package READMEs...')
 
+    renderer = Renderer(app)
+    render = renderer.render
 
+    logger.info('Loading packages...')
     repodata = defaultdict(lambda: defaultdict(list))
     for platform in ['linux', 'osx']:
         for pkg in utils.get_channel_packages(channel='bioconda', platform=platform):
@@ -141,7 +87,9 @@ def setup(*args):
     summaries = []
     recipes = []
 
-    for folder in os.listdir(RECIPE_DIR):
+    recipe_dirs = os.listdir(RECIPE_DIR)
+    for folder in status_iterator(recipe_dirs, 'Generating package READMEs...',
+                                  "purple", len(recipe_dirs), app.verbosity):
         # Subfolders correspond to different versions
         versions = []
         for sf in os.listdir(op.join(RECIPE_DIR, folder)):
@@ -151,11 +99,12 @@ def setup(*args):
             try:
                 LooseVersion(sf)
             except ValueError:
-                print("'{}' does not look like a proper version!".format(sf))
+                logger.error("'{}' does not look like a proper version!"
+                             "".format(sf))
                 continue
             versions.append(sf)
-        #versions.sort(key=LooseVersion, reverse=True)
-        # Read the meta.yaml file
+
+        # Read the meta.yaml file(s)
         recipe = op.join(RECIPE_DIR, folder, "meta.yaml")
         if op.exists(recipe):
             metadata = MetaData(recipe)
@@ -208,7 +157,8 @@ def setup(*args):
             t['Version'] = version
             recipes.append(t)
 
-        readme = README_TEMPLATE.format(**template_options)
+        readme = render(README_TEMPLATE, template_options)
+
         # Write to file
         try:
             os.makedirs(op.join(OUTPUT_DIR, folder))  # exist_ok=True on Python 3
@@ -226,13 +176,12 @@ def setup(*args):
             ofh.write(readme.encode('utf-8'))
 
     # render the recipes datatable page
-    t = Template(RECIPES_TEMPLATE)
-    recipes_contents = t.render(
-        recipes=recipes,
+    recipes_contents = render(RECIPES_TEMPLATE, {
+        'recipes': recipes,
 
         # order of columns in the table; must be keys in template_options
-        keys=['Package', 'Version', 'License', 'Linux', 'OSX']
-    )
+        'keys': ['Package', 'Version', 'License', 'Linux', 'OSX']
+    })
     recipes_rst = 'source/recipes.rst'
     if not (
         os.path.exists(recipes_rst)
@@ -241,5 +190,6 @@ def setup(*args):
         with open(recipes_rst, 'w') as fout:
             fout.write(recipes_contents)
 
-if __name__ == '__main__':
-    setup()
+
+def setup(app):
+    app.connect('builder-inited', generate_recipes)

--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -93,7 +93,6 @@ def generate_recipes(app):
     #   },
     #}
 
-    summaries = []
     recipes = []
 
     recipe_dirs = os.listdir(RECIPE_DIR)
@@ -134,29 +133,21 @@ def generate_recipes(app):
         # Format the README
         notes = metadata.get_section('extra').get('notes', '')
         if notes:
-            if isinstance(notes,list): notes = "\n".join(notes)
+            if isinstance(notes, list): notes = "\n".join(notes)
             notes = 'Notes\n-----\n\n' + notes
         summary = metadata.get_section('about').get('summary', '')
-        summaries.append(summary)
         template_options = {
-            'title': metadata.name(),
-            'title_underline': '=' * len(metadata.name()),
+            'title': name,
+            'title_underline': '=' * len(name),
             'summary': summary,
             'home': metadata.get_section('about').get('home', ''),
             'versions': ', '.join(versions_in_channel),
             'license': metadata.get_section('about').get('license', ''),
             'recipe': ('https://github.com/bioconda/bioconda-recipes/tree/master/recipes/' +
                 op.dirname(op.relpath(metadata.meta_path, RECIPE_DIR))),
-            'notes': notes
+            'notes': notes,
+            'Package': '<a href="recipes/{0}/README.html">{0}</a>'.format(name)
         }
-
-        # Add additional keys to template_options for use in the recipes
-        # datatable.
-
-
-        template_options['Package'] = (
-            '<a href="recipes/{0}/README.html">{0}</a>'.format(name)
-        )
 
         for version in versions_in_channel:
             t = template_options.copy()
@@ -174,7 +165,6 @@ def generate_recipes(app):
 
     updated = renderer.render_to_file("source/recipes.rst", "recipes.rst_t", {
         'recipes': recipes,
-
         # order of columns in the table; must be keys in template_options
         'keys': ['Package', 'Version', 'License', 'Linux', 'OSX']
     })

--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -129,8 +129,7 @@ def generate_readme(folder, repodata, renderer):
         'name': name,
         'about': metadata.get_section('about'),
         'extra': metadata.get_section('extra'),
-        'versions': ', '.join(sorted(versions_in_channel.keys())),
-        'license': metadata.get_section('about').get('license', ''),
+        'versions': versions_in_channel,
         'gh_recipes': 'https://github.com/bioconda/bioconda-recipes/tree/master/recipes/',
         'recipe_path': op.dirname(op.relpath(metadata.meta_path, RECIPE_DIR)),
         'Package': '<a href="recipes/{0}/README.html">{0}</a>'.format(name)

--- a/docs/source/templates/readme.rst_t
+++ b/docs/source/templates/readme.rst_t
@@ -4,7 +4,7 @@
 
 |downloads|
 
-{{ about.summary }}
+{{ about.summary | escape }}
 
 ======== ===========
 Home     {{ about.home }}
@@ -12,6 +12,8 @@ Versions {{ versions.keys() | sort | join(", ") }}
 License  {{ about.license }}
 Recipe   {{ gh_recipes }}{{ recipe_path }}
 ======== ===========
+
+{{ about.description | escape }}
 
 Installation
 ------------

--- a/docs/source/templates/readme.rst_t
+++ b/docs/source/templates/readme.rst_t
@@ -1,17 +1,16 @@
-.. _`{{title}}`:
+.. _`{{ name }}`:
 
-{{title}}
-{{title_underline}}
+{{ name | underline }}
 
 |downloads|
 
-{{summary}}
+{{ about.summary }}
 
 ======== ===========
-Home     {{home}}
-Versions {{versions}}
-License  {{license}}
-Recipe   {{recipe}}
+Home     {{ about.home }}
+Versions {{ versions }}
+License  {{ about.license }}
+Recipe   {{ gh_recipes }}{{ recipe_path }}
 ======== ===========
 
 Installation
@@ -21,30 +20,34 @@ Installation
 
 With an activated Bioconda channel (see :ref:`set-up-channels`), install with::
 
-   conda install {{title}}
+   conda install {{ name }}
 
 and update with::
 
-   conda update {{title}}
+   conda update {{ name }}
 
-{{notes | escape}}
+{% if extra.notes %}
+Notes
+-----
+{{ extra.notes | escape }}
+{% endif %}
 
 |docker|
 
-A Docker container is available at https://quay.io/repository/biocontainers/{{title}}.
+A Docker container is available at https://quay.io/repository/biocontainers/{{ name }}.
 
 Link to this page
 -----------------
 
 Render an |badge| badge with the following Markdown::
 
-   [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](http://bioconda.github.io/recipes/{{title}}/README.html)
+   [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](http://bioconda.github.io/recipes/{{ name }}/README.html)
 
 .. |badge| image:: https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square
-           :target: http://bioconda.github.io/recipes/{{title}}/README.html
-.. |downloads| image:: https://anaconda.org/bioconda/{{title}}/badges/downloads.svg
-               :target: https://anaconda.org/bioconda/{{title}}
-.. |docker| image:: https://quay.io/repository/biocontainers/{{title}}/status
-                :target: https://quay.io/repository/biocontainers/{{title}}
+           :target: http://bioconda.github.io/recipes/{{ name }}/README.html
+.. |downloads| image:: https://anaconda.org/bioconda/{{ name }}/badges/downloads.svg
+               :target: https://anaconda.org/bioconda/{{ name }}
+.. |docker| image:: https://quay.io/repository/biocontainers/{{ name }}/status
+                :target: https://quay.io/repository/biocontainers/{{ name }}
 
 

--- a/docs/source/templates/readme.rst_t
+++ b/docs/source/templates/readme.rst_t
@@ -11,6 +11,9 @@ Home     {{ about.home }}
 Versions {{ versions.keys() | sort | join(", ") }}
 License  {{ about.license }}
 Recipe   {{ gh_recipes }}{{ recipe_path }}
+{% if extra.identifiers %}
+Links    {{ extra.identifiers | as_extlink | join(", ") }}
+{% endif %}
 ======== ===========
 
 {{ about.description | escape }}

--- a/docs/source/templates/readme.rst_t
+++ b/docs/source/templates/readme.rst_t
@@ -1,0 +1,50 @@
+.. _`{{title}}`:
+
+{{title}}
+{{title_underline}}
+
+|downloads|
+
+{{summary}}
+
+======== ===========
+Home     {{home}}
+Versions {{versions}}
+License  {{license}}
+Recipe   {{recipe}}
+======== ===========
+
+Installation
+------------
+
+.. highlight: bash
+
+With an activated Bioconda channel (see :ref:`set-up-channels`), install with::
+
+   conda install {{title}}
+
+and update with::
+
+   conda update {{title}}
+
+{{notes | escape}}
+
+|docker|
+
+A Docker container is available at https://quay.io/repository/biocontainers/{{title}}.
+
+Link to this page
+-----------------
+
+Render an |badge| badge with the following Markdown::
+
+   [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](http://bioconda.github.io/recipes/{{title}}/README.html)
+
+.. |badge| image:: https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square
+           :target: http://bioconda.github.io/recipes/{{title}}/README.html
+.. |downloads| image:: https://anaconda.org/bioconda/{{title}}/badges/downloads.svg
+               :target: https://anaconda.org/bioconda/{{title}}
+.. |docker| image:: https://quay.io/repository/biocontainers/{{title}}/status
+                :target: https://quay.io/repository/biocontainers/{{title}}
+
+

--- a/docs/source/templates/readme.rst_t
+++ b/docs/source/templates/readme.rst_t
@@ -8,7 +8,7 @@
 
 ======== ===========
 Home     {{ about.home }}
-Versions {{ versions }}
+Versions {{ versions.keys() | sort | join(", ") }}
 License  {{ about.license }}
 Recipe   {{ gh_recipes }}{{ recipe_path }}
 ======== ===========

--- a/docs/source/templates/recipes.rst_t
+++ b/docs/source/templates/recipes.rst_t
@@ -1,0 +1,33 @@
+.. _recipes:
+
+Available packages
+==================
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :glob:
+
+   recipes/*/*
+
+.. raw:: html
+
+    <table id="recipestable" class="display" cellspacing="0" width="100%">
+    <thead>
+        <tr>
+        {% for key in keys %}
+        <th>{{ key }}</th>
+        {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+    {% for r in recipes %}
+    <tr>
+        {% for k in keys %}
+        <td>{{ r[k] }}</td>
+        {% endfor %}
+    </tr>
+    {% endfor %}
+    </tbody>
+    <tfoot></tfoot>
+    </table>


### PR DESCRIPTION
 - Templates for recipes and readme pages are now in separate files
 - Shows progress as it's working (no more `print()` calls)
 - Using Jinja for formatting logic
 - Adds text from `about:description` field
 - Escapes text from `notes`, `description` and `summary`
 - Shows new `extra:identifiers` links (xref bioconda/bioconda-recipes#7940)
 - Adds parallel generation of README.rst (call `make html SPHINXOPTS="-j16"` for 16 threads)
