### PR TITLE
Fix for building rust recipes and a corresponding test case

### DIFF
--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -79,6 +79,9 @@ BUILD_SCRIPT_TEMPLATE = \
 #!/bin/bash
 set -e
 
+# Set SSL certificates
+export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+
 # Add the host's mounted conda-bld dir so that we can use its contents as
 # dependencies for building this recipe.
 #

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -311,6 +311,32 @@ def test_conda_as_dep():
     assert build_result
 
 
+def test_rust():
+    r = Recipes(
+        """
+        one:
+          meta.yaml: |
+            package:
+              name: one
+              version: 0.1
+            build:
+              script: cargo install --root $PREFIX xsv
+            requirements:
+              build:
+                - rust
+        """, from_string=True)
+    r.write_recipes()
+    build_result = build.build_recipes(
+        r.basedir,
+        config={},
+        packages="*",
+        testonly=False,
+        force=False,
+        mulled_test=True,
+    )
+    assert build_result
+
+
 def test_env_matrix():
     contents = {
         'CONDA_PY': [27, 35],


### PR DESCRIPTION
For some reason, the SSL certificate bundle is not properly set to be recognized by cargo (the rust build tool). This PR tries to fix this in the docker template and adds a corresponding test case.

I still don't really understand what is going on here, because it works fine when testing our build env container manually...