### PR TITLE
docs for circle-ci macos

### DIFF
--- a/docs/source/contribute-a-recipe.rst
+++ b/docs/source/contribute-a-recipe.rst
@@ -76,7 +76,11 @@ Push your changes to your fork or to the main repo (if using a clone) to GitHub:
 
     git push -u origin my-recipe
 
-If using a fork, make sure to enable Circle CI for it under https://circleci.com/dashboard.
+**Update March 2018:** If using a fork, please do not enable Circle CI for it.
+If you have enabled CircleCI to build your fork in the past, please disable it
+under https://circleci.com/dashboard (look for the big red "Stop Building"
+button). See :ref:`circlecimacos` for more details.
+
 
 You can view the test status next to your commits in Github.
 Make and push changes as needed to get the tests to pass.

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -131,3 +131,19 @@ the `broken` label, i.e.,
 .. code-block:: bash
 
     conda install -c bioconda -c conda-forge -c defaults -c bioconda/label/broken my-package=<broken-version>
+
+
+.. _circlecimacos:
+
+CircleCI macOS plans
+--------------------
+In the past we had recommended enabling CircleCI for your fork to help conserve
+the bioconda team's build time quota. However this did not work very well:
+macOS builds on CircleCI require an extra macOS plan, which is not free to
+users. The result was that contributors' pull requests would fail tests simply
+due to not having a paid macOS plan. Luckily, CircleCI has generously provided
+macOS builds to the bioconda team.
+
+To ensure that CircleCI uses the bioconda team account, please **disable**
+CircleCI on your fork (look for the big red "Stop Building" button at
+https://circleci.com/dashboard under the settings for your fork.


### PR DESCRIPTION
Previously we had recommended enabling CircleCI for contributors' forks, but after some testing I confirmed that's what was causing all the "no macOS plan" issues. So this PR changes that recommendation.