### PR TITLE
exclude less important lints on build

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -22,3 +22,4 @@ six=1.11.*
 alabaster=0.7.*
 git=2.14.*
 conda-forge-pinning=2018.05.22
+python>=3.6

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -312,9 +312,7 @@ def lint(recipe_folder, config, packages="*", cache=None, list_funcs=False,
 @arg('--lint-only', nargs='+',
      help='''Only run this linting function. Can be used multiple times.''')
 @arg('--lint-exclude', nargs='+',
-     help='''Exclude this linting function. Can be used multiple times.
-     If neither --lint-exclude nor --lint-only is given, this defaults to
-     exclude many less importand lints. (cf. `lint_functions.registry_build`)''')
+     help='''Exclude this linting function. Can be used multiple times.''')
 def build(
     recipe_folder,
     config,
@@ -389,11 +387,6 @@ def build(
             if len(registry) == 0:
                 sys.stderr.write('No valid linting functions selected, exiting.\n')
                 sys.exit(1)
-        elif lint_exclude is None:
-            lint_exclude = tuple(
-                func.__name__
-                for func in set(lint_functions.registry) - set(lint_functions.registry_build)
-            )
         df = linting.channel_dataframe()
         lint_args = linting.LintArgs(df=df, exclude=lint_exclude, registry=registry)
     else:

--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -396,5 +396,18 @@ registry = (
     should_not_use_fn,
     should_use_compilers,
     compilers_must_be_in_build,
-    bioconductor_37
+    bioconductor_37,
+)
+
+registry_build = (
+    in_other_channels,
+    uses_javajdk,
+    uses_perl_threaded,
+    should_be_noarch,
+    should_not_be_noarch,
+    invalid_identifiers,
+    deprecated_numpy_spec,
+    should_use_compilers,
+    compilers_must_be_in_build,
+    bioconductor_37,
 )

--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -398,16 +398,3 @@ registry = (
     compilers_must_be_in_build,
     bioconductor_37,
 )
-
-registry_build = (
-    in_other_channels,
-    uses_javajdk,
-    uses_perl_threaded,
-    should_be_noarch,
-    should_not_be_noarch,
-    invalid_identifiers,
-    deprecated_numpy_spec,
-    should_use_compilers,
-    compilers_must_be_in_build,
-    bioconductor_37,
-)

--- a/test/test_linting.py
+++ b/test/test_linting.py
@@ -1,5 +1,3 @@
-import pandas
-import yaml
 from helpers import Recipes
 from bioconda_utils import lint_functions
 from bioconda_utils import linting, utils
@@ -76,7 +74,9 @@ def test_empty_build_section():
     # access to contents of possibly empty build section can happen in
     # `should_be_noarch` and `should_not_be_noarch`
     registry = [lint_functions.should_be_noarch, lint_functions.should_not_be_noarch]
-    res = linting.lint(r.recipe_dirs.values(), df=None, registry=registry)
+    res = linting.lint(
+        r.recipe_dirs.values(),
+        linting.LintArgs(df=None, registry=registry))
     assert res is None
 
 
@@ -92,7 +92,9 @@ def test_lint_skip_in_recipe():
               version: "0.1"
         ''', from_string=True)
     r.write_recipes()
-    res = linting.lint(r.recipe_dirs.values(), df=None, registry=[lint_functions.missing_home])
+    res = linting.lint(
+        r.recipe_dirs.values(),
+        linting.LintArgs(df=None, registry=[lint_functions.missing_home]))
     assert res is not None
 
 
@@ -109,7 +111,9 @@ def test_lint_skip_in_recipe():
                 - missing_home
         ''', from_string=True)
     r.write_recipes()
-    res = linting.lint(r.recipe_dirs.values(), df=None, registry=[lint_functions.missing_home])
+    res = linting.lint(
+        r.recipe_dirs.values(),
+        linting.LintArgs(df=None, registry=[lint_functions.missing_home]))
     assert res is None
 
     # should pass; minimal recipe needs to skip these lints
@@ -127,7 +131,7 @@ def test_lint_skip_in_recipe():
                 - no_tests
         ''', from_string=True)
     r.write_recipes()
-    res = linting.lint(r.recipe_dirs.values(), df=None)
+    res = linting.lint(r.recipe_dirs.values(), linting.LintArgs(df=None))
     assert res is not None
 
 


### PR DESCRIPTION
- renamed `--prelint` to `--lint` since this happens always happens pre-build.
- added `--lint-only`/`--lint-exclude` to `build` command (equivalent to `--only`/`--exclude` from `lint` command).
- ~if none of `--lint-only`, `--lint-exclude` is given, all lints not in `lint_functions.registry_build` are excluded.~ (EDIT: didn't make sense since the build lint is also run on PRs)