### PR TITLE
Handle dependency cycles

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -298,7 +298,6 @@ def build_recipes(
         lint_exclude = (lint_args.exclude or ())
         if 'already_in_bioconda' not in lint_exclude:
             lint_exclude = tuple(lint_exclude) + ('already_in_bioconda',)
-            lint_args = linting.LintArgs(lint_args.df, lint_exclude, lint_args.registry)
         lint_args = linting.LintArgs(df, lint_exclude, lint_args.registry)
 
     dag, name2recipes = utils.get_dag(recipes, config=orig_config, blacklist=blacklist)

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -829,13 +829,6 @@ def check_recipe_skippable(recipe, channel_packages, force=False):
         return False
     platform, metas = _load_platform_metas(recipe, finalize=False)
     key_build_meta = _get_pkg_key_build_meta_map(metas)
-    num_new_pkg_builds = sum(
-        (
-            Counter((pkg_key, pkg_build.subdir) for pkg_build in build_meta.keys())
-            for pkg_key, build_meta in key_build_meta.items()
-        ),
-        Counter()
-    )
     num_existing_pkg_builds = sum(
         (
             Counter(
@@ -843,6 +836,16 @@ def check_recipe_skippable(recipe, channel_packages, force=False):
                 for pkg_build in channel_packages.get(pkg_key, set())
             )
             for pkg_key in key_build_meta.keys()
+        ),
+        Counter()
+    )
+    if num_existing_pkg_builds == Counter():
+        # No packages with same version + build num in channels: no need to skip
+        return False
+    num_new_pkg_builds = sum(
+        (
+            Counter((pkg_key, pkg_build.subdir) for pkg_build in build_meta.keys())
+            for pkg_key, build_meta in key_build_meta.items()
         ),
         Counter()
     )

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -492,7 +492,7 @@ def get_dag(recipes, config, blacklist=None, restrict=True):
         deps = reqs.get(sec)
         if not deps:
             return []
-        return [dep.split()[0] for dep in deps if dep is not None]
+        return [dep.split()[0] for dep in deps if dep]
 
     def get_inner_deps(dependencies):
         dependencies = list(dependencies)

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -505,8 +505,14 @@ def get_dag(recipes, config, blacklist=None, restrict=True):
                        for meta, recipe in metadata)
     for meta, recipe in metadata:
         name = meta["package"]["name"]
-        dag.add_edges_from((dep, name)
-                           for dep in set(get_inner_deps(get_deps(meta, "host"))))
+        dag.add_edges_from(
+            (dep, name)
+            for dep in set(chain(
+                get_inner_deps(get_deps(meta, "build")),
+                get_inner_deps(get_deps(meta, "host")),
+                get_inner_deps(get_deps(meta, "run")),
+            ))
+        )
 
     return dag, name2recipe
 


### PR DESCRIPTION
The first three commits are some minor fixes.
The last two fix handling of dependencies by considering all requirements from `build`, `host`, as well as `run` environments. To avoid the previous workaround of only considering `host` due to cyclic dependencies of some existing recipes, this detects those dependency cycles and marks all packages of a cycle as `failed` (+ skipping any downstream packages, of course).