### PR TITLE
requirements: update to conda-forge-pinning 2018.07.18

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -21,5 +21,5 @@ colorlog=3.1.*
 six=1.11.*
 alabaster=0.7.*
 git=2.14.*
-conda-forge-pinning=2018.05.22
+conda-forge-pinning=2018.07.18
 python>=3.6


### PR DESCRIPTION
The current `conda-forge-pinning` has some important changes in comparison to the ones we are currently using, namely updated `boost` and more strictly pinned `perl`. See the full changeset at https://github.com/conda-forge/conda-forge-pinning-feedstock/compare/86ded4c96afa1d2fd63d6295d91be1a9fc96839a...5781b888537cf9c30a039a6a793d37ff56f88c56.

We should discuss whether we should always use the latest `conda-forge-pinning` version or update manually. There are pros and cons for both strategies.