### PR TITLE
Log when linting was successful.

### DIFF
--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -273,6 +273,7 @@ def lint(recipe_folder, config, packages="*", cache=None, list_funcs=False,
             msg = linting.markdown_report()
             github_integration.push_comment(
                 user, repo, pull_request, msg)
+        logger.info("\n\nThe following recipes passed linting:\n\n%s\n", summarized.to_string())
 
 
 @arg('recipe_folder', help='Path to top-level dir of recipes.')


### PR DESCRIPTION
The current output below leaves the user wondering if linting passed as there's no summary output when it is successful.
```
bioconda-utils lint recipes config.yml --git-range master
21:54:00 BIOCONDA INFO Recipes newly unblacklisted:

21:54:00 BIOCONDA INFO Recipes to consider according to git: 
recipes/<recipe>
 recipes/<recipe>
21:54:01 BIOCONDA INFO Recipes to lint:
recipes/<recipe>
Setting build platform. This is only useful when pretending to be on another platform, such as for rendering necessary dependencies on a non-native platform. I trust that you know what you're doing.
Adding in variants from internal_defaults
Adding in variants from /tmp/miniconda/miniconda/conda_build_config.yaml
Adding in variants from /tmp/miniconda/miniconda/lib/python3.6/site-packages/bioconda_utils/bioconda_utils-conda_build_config.yaml
``` 