### PR TITLE
Fix linting message on success.

### DIFF
--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -273,7 +273,8 @@ def lint(recipe_folder, config, packages="*", cache=None, list_funcs=False,
             msg = linting.markdown_report()
             github_integration.push_comment(
                 user, repo, pull_request, msg)
-        logger.info("\n\nThe following recipes passed linting:\n\n%s\n", summarized.to_string())
+        if _recipes:
+            logger.info("\n\nThe following recipes passed linting:\n%s", '\n'.join(_recipes))
 
 
 @arg('recipe_folder', help='Path to top-level dir of recipes.')


### PR DESCRIPTION
The change in #327 introduced a bug.  If all recipes pass linting or there are no recipes to lint, the process will crash with the following

```
+ bioconda-utils lint recipes config.yml --git-range master HEAD --loglevel=info
21:04:06 BIOCONDA INFO Recipes newly unblacklisted:

21:04:06 BIOCONDA INFO No recipe modified according to git, exiting.
Traceback (most recent call last):
  File "/anaconda/bin/bioconda-utils", line 11, in <module>
    load_entry_point('bioconda-utils==0.9.2+1040.gcb2c4585', 'console_scripts', 'bioconda-utils')()
  File "/anaconda/lib/python3.6/site-packages/bioconda_utils/cli.py", line 639, in main
    bioconductor_skeleton, pypi_check, clean_cran_skeleton,
  File "/anaconda/lib/python3.6/site-packages/argh/dispatching.py", line 328, in dispatch_commands
    dispatch(parser, *args, **kwargs)
  File "/anaconda/lib/python3.6/site-packages/argh/dispatching.py", line 174, in dispatch
    for line in lines:
  File "/anaconda/lib/python3.6/site-packages/argh/dispatching.py", line 277, in _execute_command
    for line in result:
  File "/anaconda/lib/python3.6/site-packages/argh/dispatching.py", line 260, in _call
    result = function(*positional, **keywords)
  File "/anaconda/lib/python3.6/site-packages/bioconda_utils/cli.py", line 276, in lint
    logger.info("\n\nThe following recipes passed linting:\n\n%s\n", summarized.to_string())
UnboundLocalError: local variable 'summarized' referenced before assignment
```

The issue is that the `summarized` object only exists within the if block in the case that a recipe fails linting.  This fix uses the `_recipes` list variable which is defined prior to the if else block, and only prints a message if the list is non-empty.