### PR TITLE
Remove deprecated log message in case of empty linting job.

### DIFF
--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -273,7 +273,6 @@ def lint(recipe_folder, config, packages="*", cache=None, list_funcs=False,
             msg = linting.markdown_report()
             github_integration.push_comment(
                 user, repo, pull_request, msg)
-        logger.info("\n\nThe following recipes passed linting:\n\n%s\n", summarized.to_string())
 
 
 @arg('recipe_folder', help='Path to top-level dir of recipes.')

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,7 +27,7 @@ add additional channels from which to install software packages not available
 in the defaults channel. Bioconda is one such channel specializing in
 bioinformatics software.
 
-When using Bioconda please **cite our article** `Grüning, Björn, Ryan Dale, Andreas Sjödin, Brad A. Chapman, Jillian Rowe, Christopher H. Tomkins-Tinch, Renan Valieris, the Bioconda Team, and Johannes Köster. 2018. "Bioconda: Sustainable and Comprehensive Software Distribution for the Life Sciences". Nature Methods, July. <https://doi.org/10.1038/s41592-018-0046-7>.`_.
+When using Bioconda please **cite our article** `Grüning, Björn, Ryan Dale, Andreas Sjödin, Brad A. Chapman, Jillian Rowe, Christopher H. Tomkins-Tinch, Renan Valieris, the Bioconda Team, and Johannes Köster. 2018. "Bioconda: Sustainable and Comprehensive Software Distribution for the Life Sciences". Nature Methods, 2018 <https://doi.org/10.1038/s41592-018-0046-7>`_.
 
 Bioconda has been acknowledged by NATURE in their
 `technology blog <http://blogs.nature.com/naturejobs/2017/11/03/techblog-bioconda-promises-to-ease-bioinformatics-software-installation-woes/>`_.


### PR DESCRIPTION
This would previously have thrown an unitialized variable error. In addition this PR fixes a syntax error in index.rst, leading to a broken paper link.