### PR TITLE
update deps: conda=4.5.11 and conda-build=3.14.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM condaforge/linux-anvil
 RUN sudo -n yum install -y openssh-clients
-COPY . /tmp/repo
+RUN mkdir -p /tmp/repo/bioconda_utils/
+COPY ./bioconda_utils/bioconda_utils-requirements.txt /tmp/repo/bioconda_utils/
 RUN export PATH="/opt/conda/bin:${PATH}" && \
     conda config --add channels defaults && \
     conda config --add channels conda-forge && \
@@ -8,6 +9,7 @@ RUN export PATH="/opt/conda/bin:${PATH}" && \
 RUN export PATH="/opt/conda/bin:${PATH}" && \
     conda install --file /tmp/repo/bioconda_utils/bioconda_utils-requirements.txt && \
     conda clean -y --all
+COPY . /tmp/repo
 RUN export PATH="/opt/conda/bin:${PATH}" && \
     pip install /tmp/repo
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/tmp/repo/docker-entrypoint" ]

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -1,8 +1,8 @@
 anaconda-client=1.6.*
 argh=0.26.*
 beautifulsoup4=4.6.*
-conda=4.5.9
-conda-build=3.12.1
+conda=4.5.11
+conda-build=3.14.4
 galaxy-lib>=18.5.5
 jinja2=2.10.*
 jsonschema=2.6.*

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -82,7 +82,7 @@ logger = logging.getLogger(__name__)
 BUILD_SCRIPT_TEMPLATE = \
 """
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Add the host's mounted conda-bld dir so that we can use its contents as
 # dependencies for building this recipe.
@@ -93,7 +93,9 @@ set -e
 # exists before adding the channel.
 mkdir -p {self.container_staging}/linux-64
 mkdir -p {self.container_staging}/noarch
-conda config --add channels file://{self.container_staging}
+conda config --add channels file://{self.container_staging} 2> >(
+    grep -vF "Warning: 'file://{self.container_staging}' already in 'channels' list, moving to the top" >&2
+)
 
 # The actual building...
 # we explicitly point to the meta.yaml, in order to keep

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -489,7 +489,7 @@ class RecipeBuilder(object):
         env_list.append('{0}={1}'.format('HOST_USER_ID', self.user_info['uid']))
 
         cmd = [
-            'docker', 'run',
+            'docker', 'run', '-t',
             '--net', 'host',
             '--rm',
             '-v', '{0}:/opt/build_script.bash'.format(build_script),

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -93,7 +93,7 @@ set -e
 # exists before adding the channel.
 mkdir -p {self.container_staging}/linux-64
 mkdir -p {self.container_staging}/noarch
-conda config --add channels file://{self.container_staging}  > /dev/null 2>&1
+conda config --add channels file://{self.container_staging}
 
 # The actual building...
 # we explicitly point to the meta.yaml, in order to keep


### PR DESCRIPTION
Fixes the failing `test_build_container_default_gcc` by updating `conda` to `4.5.11`. That version fixes an incompatibility of `conda config` with a newer `ruamel.yaml` release. The error didn't show up because the error stream for `conda config` was piped to `/dev/null`.

This also updates `conda-build` to `3.14.4` which gives us
https://github.com/conda/conda-build/blob/3.14.4/CHANGELOG.txt#L81:
> * add ``tags``, ``identifiers``, and ``keywords`` to about section. Tie them into channeldata.json. #3091

which will be helpful in future.