### PR TITLE
Add lints that prevent jinja variable misuse. Add subcommand for bumping build number.

### DIFF
--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -632,6 +632,16 @@ def pypi_check(recipe_folder, config, loglevel='info', packages='*', only_out_of
         print('\t'.join(map(str, result)))
 
 
+@arg('recipe', nargs="+", help='Path to recipes')
+@arg('--loglevel', default='debug', help='Log level')
+def bump_build_number(recipes, loglevel="info"):
+    """
+    Bumps the build number in given recipes.
+    """
+    utils.setup_logger('bioconda_utils', loglevel)
+    utils.bump_build_number(recipes)
+
+
 def main():
     argh.dispatch_commands([
         build, dag, dependent, lint, duplicates,

--- a/test/test_linting.py
+++ b/test/test_linting.py
@@ -1019,6 +1019,135 @@ def test_should_not_use_fn():
     )
 
 
+def test_jinja_var_name():
+    run_lint(
+        func=lint_functions.jinja_var_name,
+        should_pass=[
+            '''
+            a:
+                meta.yaml: |
+                  package:
+                    name: a
+                    version: 0.1
+                  build:
+                    number: 0
+            ''',
+        ],
+        should_fail=[
+            r'''
+            a:
+                meta.yaml: |
+                  {% set name = "a" %}
+                  package:
+                    name: "{{ name|lower }}"
+                    version: 0.1
+                  build:
+                    number: 0
+            ''',
+            r'''
+            a:
+                meta.yaml: |
+                  {% set name = "a" %}
+                  package:
+                    name: {{ name }}
+                    version: 0.1
+                  build:
+                    number: 0
+            ''',
+        ]
+    )
+
+
+def test_jinja_var_version():
+    run_lint(
+        func=lint_functions.jinja_var_version,
+        should_pass=[
+            '''
+            a:
+                meta.yaml: |
+                  package:
+                    name: a
+                    version: 0.1
+                  build:
+                    number: 0
+            ''',
+        ],
+        should_fail=[
+            r'''
+            a:
+                meta.yaml: |
+                  {% set version = "1.0" %}
+                  package:
+                    name: a
+                    version: {{ version }}
+                  build:
+                    number: 0
+            ''',
+        ]
+    )
+
+
+def test_jinja_var_buildnum():
+    run_lint(
+        func=lint_functions.jinja_var_buildnum,
+        should_pass=[
+            '''
+            a:
+                meta.yaml: |
+                  package:
+                    name: a
+                    version: 0.1
+                  build:
+                    number: 0
+            ''',
+        ],
+        should_fail=[
+            r'''
+            a:
+                meta.yaml: |
+                  {% set buildnum = 1 %}
+                  package:
+                    name: a
+                    version: 0.1
+                  build:
+                    number: {{ buildnum }}
+            ''',
+        ]
+    )
+
+
+def test_jinja_var_checksum():
+    run_lint(
+        func=lint_functions.jinja_var_checksum,
+        should_pass=[
+            '''
+            a:
+                meta.yaml: |
+                  package:
+                    name: a
+                    version: 0.1
+                  build:
+                    number: 0
+                  source:
+                    sha256: abc
+            ''',
+        ],
+        should_fail=[
+            r'''
+            a:
+                meta.yaml: |
+                  {% set sha256 = "abc" %}
+                  package:
+                    name: a
+                    version: 0.1
+                  build:
+                    number: 0
+                  source:
+                    sha256: {{ sha256 }}
+            ''',
+        ]
+    )
+
 #def test_bioconductor_37():
 #    run_lint(
 #        func=lint_functions.bioconductor_37,


### PR DESCRIPTION
# Part one
Current conda-build supports accessing package version in meta.yaml via {{ PKG_VERSION }}.
Therefore, it is no longer reasonable to define your own jinja variables. For other parts
like name, build number and checksum, it was never reasonable because these either don't change
during updates (name) nor do they occur more than once.
By enforcing non-jinja style here, the recipe becomes much more readable.
Moreover, it becomes easier to update programatically.

# Part two
This PR adds a subcommand `bioconda-utils bump-build-number`, that takes a list of recipes and increases their build number by one. This helps us to rebuild stuff when the version pinnings change. Ideally, I would like to automate this, e.g. by finding out which pinning changed, and scanning through all packages with a corresponding dependency. However, this is not done yet.