### PR TITLE
Bump conda-forge-pinning to 2018.09.20, which adds build support for R 3.5.1

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -21,5 +21,5 @@ colorlog=3.1.*
 six=1.11.*
 alabaster=0.7.*
 git=2.14.*
-conda-forge-pinning=2018.08.05
+conda-forge-pinning=2018.09.20
 python>=3.6


### PR DESCRIPTION
Xref: https://github.com/bioconda/bioconda-recipes/issues/8947

This updates conda-forge-pinning to what is currently the most recent version. Most important to me is that this should result in builds for R 3.5.1. There are of course [other changes](https://github.com/conda-forge/conda-forge-pinning-feedstock/compare/5781b888537cf9c30a039a6a793d37ff56f88c56...e6ee6b2d76d590553937da9d5ae36ad1a13787aa) that may be important, in particular what appears to be gcc7 support depending on environment variables.