### PR TITLE
Expose check_channels on the CLI and check the first 2 by default.

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -268,7 +268,7 @@ def build_recipes(
 
     if check_channels is None:
         if config['channels']:
-            check_channels = [config['channels'][0]]
+            check_channels = config['channels'][:2]
         else:
             check_channels = []
 

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -318,6 +318,11 @@ def lint(recipe_folder, config, packages="*", cache=None, list_funcs=False,
      help='''Only run this linting function. Can be used multiple times.''')
 @arg('--lint-exclude', nargs='+',
      help='''Exclude this linting function. Can be used multiple times.''')
+@arg('--check-channels', nargs='+',
+     help='''Channels to check recipes against before building. Any recipe
+     already present in one of these channels will be skipped. The default is
+     the first two channels specified in the config file. Note that this is
+     ignored if you specify --git-range.''')
 def build(
     recipe_folder,
     config,
@@ -336,6 +341,7 @@ def build(
     lint=False,
     lint_only=None,
     lint_exclude=None,
+    check_channels=None,
 ):
     utils.setup_logger('bioconda_utils', loglevel)
 
@@ -412,6 +418,7 @@ def build(
         anaconda_upload=anaconda_upload,
         mulled_upload_target=mulled_upload_target,
         lint_args=lint_args,
+        check_channels=check_channels,
     )
     exit(0 if success else 1)
 


### PR DESCRIPTION
This should fix builds in `bulk` and any other environment where `--git-range` is not specified. Previously, the first channel in the channels list in the config file was checked to ensure that packages that already existed weren't built. Since the channel order was changed, this now means that `conda-forge` is checked against rather than `bioconda`. It's probably good to check against `conda-forge`, but especially for the `bulk` branch we need to check the `bioconda` channel as well. This PR causes up to the first 2 channels in the config file to be checked against before building/uploading. This will fix builds in the `bulk` branch. Additionally, this adds a `--check-channels` option to `bioconda-utils build`, so this can be directly changed by users (or the script given to circleci). The `bioconda-utils build` option isn't really needed, it's just for convenience in the future (so I'm happy to remove it if desired).