### PR TITLE
Update the bioconductor skeleton to pin to packages in the same bioco…

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -16,3 +16,5 @@ bamtools:
   - 2.4.1
 libdeflate:
   - 1.0
+r_base:
+  - 3.5.1

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -300,6 +300,35 @@ class BioCProjectPage(object):
         self.version = self.packages[package]['Version']
         self.depends_on_gcc = False
 
+        # Determine the URL
+        htmls = {
+            'regular_package': os.path.join(
+                base_url, self.bioc_version, 'bioc', 'html', package
+                + '.html'),
+            'annotation_package': os.path.join(
+                base_url, self.bioc_version, 'data', 'annotation', 'html',
+                package + '.html'),
+            'experiment_package': os.path.join(
+                base_url, self.bioc_version, 'data', 'experiment', 'html',
+                package + '.html'),
+        }
+        tried = []
+        for label, url in htmls.items():
+            request = requests.get(url)
+            tried.append(url)
+            if request:
+                break
+
+        if not request:
+            raise PageNotFoundError(
+                'Could not find HTML page for {0.package}. Tried: '
+                '{1}'.format(self, ', '.join(tried)))
+
+        # Since we provide the "short link" we will get redirected. Using
+        # requests allows us to keep track of the final destination URL,
+        # which we need for reconstructing the tarball URL.
+        self.url = request.url
+
     @property
     def bioarchive_url(self):
         """

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -298,6 +298,9 @@ class BioCProjectPage(object):
         else:
             self.packages = packages
 
+        if package not in self.packages:
+            raise PackageNotFoundError('{} does not exist in this bioconductor release!'.format(package))
+
         if not pkg_version:
             self.version = self.packages[package]['Version']
         self.depends_on_gcc = False
@@ -777,7 +780,7 @@ class BioCProjectPage(object):
                 'about', OrderedDict((
                     ('home', sub_placeholders(self.url)),
                     ('license', self.license),
-                    ('summary', self.description['Description']),
+                    ('summary', self.packages[self.package]['Description']),
                 )),
             ),
         ))

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -790,6 +790,16 @@ class BioCProjectPage(object):
             d['requirements']['build'].append(k + '_' + "PLACEHOLDER")
 
         rendered = pyaml.dumps(d, width=1e6).decode('utf-8')
+
+        # Add Suggests: and SystemRequirements:
+        renderedsplit = rendered.split('\n')
+        idx = renderedsplit.index('requirements:')
+        if self.packages[self.package].get('SystemRequirements', None):
+            renderedsplit.insert(idx, '# SystemRequirements: {}'.format(self.packages[self.package]['SystemRequirements']))
+        if self.packages[self.package].get('Suggests', None):
+            renderedsplit.insert(idx, '# Suggests: {}'.format(self.packages[self.package]['Suggests']))
+        rendered = '\n'.join(renderedsplit) + '\n'
+
         rendered = (
             '{% set version = "' + self.version + '" %}\n' +
             '{% set name = "' + self.package + '" %}\n' +

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -243,7 +243,7 @@ def fetchPackages(bioc_version):
         req = requests.get(url)
         if not req.ok:
             sys.exit("ERROR: Could not fetch {}!\n".format(url))
-        for pkg in req.text.split("\n\n"):
+        for pkg in req.text.strip().split("\n\n"):
             y = yaml.load(pkg)
             d[y['Package']] = y
     return d

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -282,6 +282,7 @@ class BioCProjectPage(object):
         self._bioconductor_tarball_url = None
         self.is_data_package = False
         self.package_lower = package.lower()
+        self.version = pkg_version
         self.extra = None
 
         # If no version specified, assume the latest
@@ -297,7 +298,8 @@ class BioCProjectPage(object):
         else:
             self.packages = packages
 
-        self.version = self.packages[package]['Version']
+        if not pkg_version:
+            self.version = self.packages[package]['Version']
         self.depends_on_gcc = False
 
         # Determine the URL

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -539,7 +539,7 @@ def dependent(
 def bioconductor_skeleton(
     recipe_folder, config, package, versioned=False, force=False,
     pkg_version=None, bioc_version=None, loglevel='debug', recursive=False,
-    skip_if_in_channels=['conda-forge', 'bioconda'], update_all=False,
+    skip_if_in_channels=['conda-forge', 'bioconda'],
 ):
     """
     Build a Bioconductor recipe. The recipe will be created in the `recipes`

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -585,13 +585,6 @@ def bioconductor_skeleton(
             seen_dependencies=seen_dependencies,
             skip_if_in_channels=skip_if_in_channels)
 
-    # E.g., r-probmetab has versioned 1.0 and 1.1 dirs in bioconda-recipes, and
-    # this fails to find the meta.yaml files.
-    # if recursive:
-    #     for package in os.listdir(recipe_folder):
-    #         if package[:2] == "r-":
-    #             cran_skeleton.clean_skeleton_files(os.path.join(recipe_folder, package))
-
 
 @arg('recipe', help='''Path to recipe to be cleaned''')
 @arg('--no-windows', action='store_true', help="""Use this when submitting an

--- a/test/test_bioconductor_skeleton.py
+++ b/test/test_bioconductor_skeleton.py
@@ -96,7 +96,7 @@ def test_pkg_version():
     assert b.version == '1.14.1'
     assert b.bioc_version == '3.4'
     assert b.bioconductor_tarball_url == (
-        'http://bioconductor.org/packages/3.4/bioc/src/contrib/DESeq2_1.14.1.tar.gz')
+        'https://bioconductor.org/packages/3.4/bioc/src/contrib/DESeq2_1.14.1.tar.gz')
     assert b.bioarchive_url is None
     assert b.cargoport_url == (
         'https://depot.galaxyproject.org/software/bioconductor-deseq2/bioconductor-deseq2_1.14.1_src_all.tar.gz')  # noqa: E501: line too long
@@ -106,7 +106,7 @@ def test_pkg_version():
     assert b.version == '3.18.1'
     assert b.bioc_version == '3.5'
     assert b.bioconductor_tarball_url == (
-        'http://bioconductor.org/packages/3.5/bioc/src/contrib/edgeR_3.18.1.tar.gz')
+        'https://bioconductor.org/packages/3.5/bioc/src/contrib/edgeR_3.18.1.tar.gz')
     assert b.bioarchive_url is None
     assert b.cargoport_url == (
         'https://depot.galaxyproject.org/software/bioconductor-edger/bioconductor-edger_3.18.1_src_all.tar.gz')  # noqa: E501: line too long

--- a/test/test_bioconductor_skeleton.py
+++ b/test/test_bioconductor_skeleton.py
@@ -155,7 +155,7 @@ def test_experiment_data(tmpdir):
 def test_nonexistent_pkg(tmpdir):
 
     # no such package exists in the current bioconductor
-    with pytest.raises(bioconductor_skeleton.PageNotFoundError):
+    with pytest.raises(bioconductor_skeleton.PackageNotFoundError):
         bioconductor_skeleton.write_recipe(
             'nonexistent', str(tmpdir), config, recursive=True)
 


### PR DESCRIPTION
…nductor release. This closes https://github.com/bioconda/bioconda-recipes/issues/11456 as best I can tell.

This also adds the ability to update/create all bioconductor packages in a single command, which is quite handy when new bioconductor releases come out. Further, this changes the `r_base` pinning project wide to 3.5.1. The update process for bioconductor 3.7 really drove home that we should just build for the most recent R release, since otherwise it's a massive annoyance to track down the various packages that need a custom `conda_build_config.yaml`.