### PR TITLE
Allow conversion to e.g. win-64 for pure python packages via 'conda convert'.

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -85,7 +85,7 @@ def build(
         If not None, then apply linting just before building.
 
     convert_to_platforms : bool
-        If True, convert to platforms given in extra->convert->platforms
+        If True, convert to platforms given in extra->convert-to
     """
 
     if lint_args is not None:
@@ -204,7 +204,7 @@ def build(
 
     # convert to given platforms
     converted_pkgs = []
-    for platform in meta.get_value('extra/convert/platforms', []):
+    for platform in meta.get_value('extra/convert-to', []):
         for pkg in pkg_paths:
             try:
                 converted_pkgs.append(utils.convert(pkg, platform))
@@ -284,7 +284,7 @@ def build_recipes(
 
     convert_to_platforms : bool
         If True, try to convert packages to the additional platforms specified in
-        extra->convert->platforms. This will only work for pure Python packages.
+        extra->convert-to. This will only work for pure Python packages.
     """
     orig_config = config
     config = utils.load_config(config)

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -323,6 +323,10 @@ def lint(recipe_folder, config, packages="*", cache=None, list_funcs=False,
      already present in one of these channels will be skipped. The default is
      the first two channels specified in the config file. Note that this is
      ignored if you specify --git-range.''')
+@arg('--convert-to-platforms', action='store_true',
+     help='''Additionally convert python-only packages to platforms specified
+     in extra->convert->platforms in the meta.yaml. A typical target platform
+     would be win-64.''')
 def build(
     recipe_folder,
     config,
@@ -342,6 +346,7 @@ def build(
     lint_only=None,
     lint_exclude=None,
     check_channels=None,
+    convert_to_platforms=False
 ):
     utils.setup_logger('bioconda_utils', loglevel)
 
@@ -419,6 +424,7 @@ def build(
         mulled_upload_target=mulled_upload_target,
         lint_args=lint_args,
         check_channels=check_channels,
+        convert_to_platforms=convert_to_platforms,
     )
     exit(0 if success else 1)
 

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -325,7 +325,7 @@ def lint(recipe_folder, config, packages="*", cache=None, list_funcs=False,
      ignored if you specify --git-range.''')
 @arg('--convert-to-platforms', action='store_true',
      help='''Additionally convert python-only packages to platforms specified
-     in extra->convert->platforms in the meta.yaml. A typical target platform
+     in extra->convert-to in the meta.yaml. A typical target platform
      would be win-64.''')
 def build(
     recipe_folder,

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -12,6 +12,7 @@ from collections import Counter, Iterable, defaultdict, namedtuple
 from itertools import product, chain, groupby
 import logging
 import datetime
+import tempfile
 from threading import Event, Thread
 from pathlib import PurePath
 
@@ -1100,3 +1101,12 @@ class Progress:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop.set()
         self.thread.join()
+
+
+def convert(pkg_path, platform):
+    """Convert pure-python package to another platform and return the path."""
+    tmp = tempfile.gettempdir()
+    # try running conda convert
+    run(['conda', 'convert', '-p', platform,
+         '-o', tmp, pkg_path])
+    return os.path.join(tmp, os.path.basename(packagepath))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -748,6 +748,41 @@ def test_build_empty_extra_container():
 
 
 @pytest.mark.skipif(SKIP_DOCKER_TESTS, reason='skipping on osx')
+def test_convert_windows():
+    r = Recipes(
+        """
+        one:
+          meta.yaml: |
+           package:
+             name: one
+             version: 0.1
+           requirements:
+             host:
+               - python
+             run:
+               - python
+           extra:
+             convert:
+               platforms:
+                 - win-64
+        """
+    )
+    r.write_recipes()
+    pkgs = utils.built_package_paths(r.recipe_dirs['one'])
+
+    build_result = build.build(
+        recipe=r.recipe_dirs['one'],
+        recipe_folder='.',
+        pkg_paths=pkgs,
+        mulled_test=False,
+    )
+    assert build_result.success
+    for pkg in chain(pkgs, build_result.converted_pkgs):
+        assert os.path.exists(pkg)
+        ensure_missing(pkg)
+
+
+@pytest.mark.skipif(SKIP_DOCKER_TESTS, reason='skipping on osx')
 @pytest.mark.long_running
 def test_build_container_default_gcc(tmpdir):
     r = Recipes(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -762,9 +762,8 @@ def test_convert_windows():
              run:
                - python
            extra:
-             convert:
-               platforms:
-                 - win-64
+             convert-to:
+               - win-64
         """
     )
     r.write_recipes()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -764,8 +764,7 @@ def test_convert_windows():
            extra:
              convert-to:
                - win-64
-        """
-    )
+        """, from_string=True)
     r.write_recipes()
     pkgs = utils.built_package_paths(r.recipe_dirs['one'])
 


### PR DESCRIPTION
This PR adds automatic conversion to e.g. windows to bioconda-utils. This will only work for pure python packages. Target platforms have to be specified like this:

```
extra:
  convert-to:
      - win-64
```

If that section is empty or not present, conversion will be skipped. This allows us to enable windows builds in a very controlled way without runtime overhead (conversion is a matter of seconds).