### PR TITLE
generic and compilers for bioconductor packages

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -786,6 +786,8 @@ class BioCProjectPage(object):
 
         if self._cb3_build_reqs:
             d['requirements']['build'] = []
+        else:
+            d['build']['noarch'] = 'generic'
         for k, v in self._cb3_build_reqs.items():
             d['requirements']['build'].append(k + '_' + "PLACEHOLDER")
 
@@ -987,6 +989,8 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
                 #!/bin/bash
                 mv DESCRIPTION DESCRIPTION.old
                 grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+                mkdir -p ~/.R
+                echo -e "CC=$CC\nFC=$FC\n$CXX=$CXX\nCXX98=$CXX\nCXX11=$CXX\nCXX14=$CXX" > ~/.R/Makevars
                 $R CMD INSTALL --build .'''
                 )
             )


### PR DESCRIPTION
This modifies the bioconductor skeleton in two important ways:

 1. For packages not requiring compilation, it makes them `noarch: generic`. The same strategy is already being taken on conda-forge.
 2. Compilers specified by environment variables are injected into the build scripts. This is something that I've noticed needing to do with some CRAN packages on conda-forge. Note that this mostly makes sense if you're running in a docker container, since otherwise it'll modify any `~/.R/Makevars` that already exists, which could obviously be problematic.

BTW, there aren't any C++14 bioconductor packages yet, though there are a number of them in CRAN. Injecting the environment variable for that is mostly for future-proofing.