### PR TITLE
Fix the linting errors due to conda-forge having a different json for…

### DIFF
--- a/bioconda_utils/linting.py
+++ b/bioconda_utils/linting.py
@@ -120,13 +120,14 @@ def channel_dataframe(cache=None, channels=['bioconda', 'conda-forge',
         for platform in ['linux', 'osx']:
             for channel in channels:
                 repo, noarch = utils.get_channel_repodata(channel, platform)
+                repo = {k: v for k, v in repo.items() if k in ["info", "packages"]}
                 x = pd.DataFrame(repo)
                 x = x.drop([
                     'arch',
                     'default_numpy_version',
                     'default_python_version',
                     'platform',
-                    'subdir'])
+                    'subdir'], errors="ignore")  # conda-forge actually lacks these now
                 for k in [
                     'build', 'build_number', 'name', 'version', 'license',
                     'platform'


### PR DESCRIPTION
…mat in its repodata

This should hopefully fix some of the errors people have been hitting during linting. It turns out that the conda-forge repodata.json file has a different format than that from bioconda, having extra keys some places and fewer others. This at least allows everything to get consumed into a pandas dataframe, though I don't know if there are other downstream repercussions. 