### PR TITLE
Start supporting the BIOCONDA_LABEL env variable

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -467,7 +467,7 @@ def build_recipes(
             for pkg in pkg_paths:
                 # upload build
                 if anaconda_upload:
-                    if not upload.anaconda_upload(pkg, label):
+                    if not upload.anaconda_upload(pkg, label=label):
                         failed_uploads.append(pkg)
             if mulled_upload_target and keep_mulled_test:
                 for img in res.mulled_images:

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -407,6 +407,10 @@ def build(
         if lint_exclude is not None:
             logger.warning('--lint-exclude has no effect unless --lint is specified.')
 
+    label = os.getenv('BIOCONDA_LABEL', None)
+    if label == "":
+        label = None
+
     success = build_recipes(
         recipe_folder,
         config=config,
@@ -419,6 +423,7 @@ def build(
         mulled_upload_target=mulled_upload_target,
         lint_args=lint_args,
         check_channels=check_channels,
+        label=label,
     )
     exit(0 if success else 1)
 

--- a/docs/source/build-system.rst
+++ b/docs/source/build-system.rst
@@ -106,7 +106,7 @@ Configure the environment
         - report the successful test back to the GitHub PR, at which time it
           can be merged into the master branch
     - if we are on the master branch:
-        - upload the built conda package to anaconda.org
+        - upload the built conda package to anaconda.org, with an optional label
         - upload the BusyBox container to quay.io
 
 As soon as the package is uploaded to anaconda.org, it is available for
@@ -146,3 +146,12 @@ successfully built, our work is saved and we can start the next build where we
 left off. Failing tests are fixed in another round of commits, and these
 changes are then pushed to ``bulk`` and the process repeats. Once ``bulk`` is
 fully successful, a PR is opened to merge the changes into master.
+
+Labels
+------
+
+If the ``BIOCONDA_LABEL`` environment variable is set, then all uploads will
+have that label assigned to them, rather than ``main``. Consequently, they can
+only be installed by adding ``-c bioconda/BIOCONDA_LABEL`` to the channels,
+where ``BIOCONDA_LABEL`` is whatever that environment variable is set to. Note
+that uploads of biocontainers to quay.io will still occur!


### PR DESCRIPTION
This will end up being used in `bulk` to add a gcc7 label to bioconductor packages.