### PR TITLE
Use requests 2.20.x (was 2.18.x)

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -9,7 +9,7 @@ jsonschema=2.6.*
 networkx=1.11
 pyaml=17.12.*
 pydotplus=2.0.*
-requests=2.18.*
+requests=2.20.*
 sphinx
 docutils
 sphinx_rtd_theme


### PR DESCRIPTION
From [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074)

> The Requests package before 2.20.0 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

(PR mostly to silence GH security warning)