### PR TITLE
Copy over bioconductor skeleton fixes from gcc7

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -986,7 +986,12 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
                 mv DESCRIPTION DESCRIPTION.old
                 grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
                 mkdir -p ~/.R
-                echo -e "CC=$CC\nFC=$FC\n$CXX=$CXX\nCXX98=$CXX\nCXX11=$CXX\nCXX14=$CXX" > ~/.R/Makevars
+                echo -e "CC=$CC
+                FC=$FC
+                CXX=$CXX
+                CXX98=$CXX
+                CXX11=$CXX
+                CXX14=$CXX" > ~/.R/Makevars
                 $R CMD INSTALL --build .'''
                 )
             )


### PR DESCRIPTION
This fixes an issue I inadvertently introduced back in October when I updated the bioconductor skeleton. Part of the compiler injection stuff that goes into `build.sh` was preventing `dedent()` from stripping white space and resulting in files with a bunch of extra white space in them. It's a low priority fix, but it's been bugging me for a while.