### PR TITLE
Update pinning

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -1,7 +1,7 @@
 anaconda-client=1.6.*
 argh=0.26.*
 beautifulsoup4=4.6.*
-conda=4.5.11
+conda=4.6.0
 conda-build=3.15.1
 galaxy-lib>=18.9.1
 jinja2=2.10.*
@@ -21,7 +21,7 @@ colorlog=3.1.*
 six=1.11.*
 alabaster=0.7.*
 git=2.14.*
-conda-forge-pinning=2018.09.20
+conda-forge-pinning=2019.01.29
 python>=3.6
 aiohttp=3.4.*
 aiofiles=0.4.*

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -1,7 +1,7 @@
 anaconda-client=1.6.*
 argh=0.26.*
 beautifulsoup4=4.6.*
-conda=4.6.0
+conda=4.5.11
 conda-build=3.15.1
 galaxy-lib>=18.9.1
 jinja2=2.10.*

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -268,7 +268,7 @@ def build_recipes(
 
     if check_channels is None:
         if config['channels']:
-            check_channels = config['channels'][:2]
+            check_channels = [c for c in config['channels'] if c != "defaults"]
         else:
             check_channels = []
 

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -255,9 +255,7 @@ def build_recipes(
 
     check_channels : list
         Channels to check to see if packages already exist in them. If None,
-        then defaults to the highest-priority channel (that is,
-        `config['channels'][0]`). If this list is empty, then do not check any
-        channels.
+        then defaults to every channel in the config file except "defaults".
 
     lint_args : linting.LintArgs | None
         If not None, then apply linting just before building.

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -20,6 +20,7 @@ from . import linting
 from . import github_integration
 from . import bioconductor_skeleton as _bioconductor_skeleton
 from . import cran_skeleton
+from .update_pinnings import should_be_bumped, bump_recipe
 
 logger = logging.getLogger(__name__)
 
@@ -447,7 +448,13 @@ def dag(recipe_folder, config, packages="*", format='gml', hide_singletons=False
     """
     Export the DAG of packages to a graph format file for visualization
     """
-    dag, name2recipes = utils.get_dag(utils.get_recipes(recipe_folder, packages), config)
+    dag, name2recipes = utils.get_dag(utils.get_recipes(recipe_folder, "*"), config)
+    if packages != "*":
+        filterNodes= set(packages)
+        for package in packages:
+            for child in nx.ancestors(dag, package):
+                filterNodes.add(child)
+        dag = nx.subgraph(dag, filterNodes)
     if hide_singletons:
         for node in nx.nodes(dag):
             if dag.degree(node) == 0:
@@ -475,6 +482,65 @@ def dag(recipe_folder, config, packages="*", format='gml', hide_singletons=False
             recipes = [recipe for package in singletons for recipe in
                        name2recipes[package]]
             print('\n'.join(recipes) + '\n')
+
+
+@arg('recipe_folder', help='Path to recipes directory')
+@arg('config', help='Path to yaml file specifying the configuration')
+@arg('--packages',
+     nargs="+",
+     help='Glob for package[s] to update, as needed due to a change in pinnings')
+@arg('--skip-if-in-channels',
+     nargs='*',
+     help="""Skip updating/bumping packges that are already built with
+     compatible pinnings in one of the given channels.""")
+@arg('--bump-only-python',
+     help="""Bump package build numbers even if the only applicable pinning
+     change is the python version. This is generally required unless you plan
+     on building everything.""")
+def update_pinning(recipe_folder, config, packages="*", skip_if_in_channels=['bioconda', 'bioconda/label/gcc7'], bump_only_python=False):
+    """
+    Bump a package build number and all dependencies as required due to a change in pinnings
+    """
+    bioconda_cfg = utils.load_config(config)
+    bioconda_cfg['channels'] = skip_if_in_channels
+    repodata = utils.RepoData().df # Can this be quiet?
+    blacklist = utils.get_blacklist(bioconda_cfg.get('blacklists'), recipe_folder)
+    build_config = utils.load_conda_build_config()
+    build_config.trim_skip = True
+
+    dag, name2recipes = utils.get_dag(utils.get_recipes(recipe_folder, '*') , config, blacklist=blacklist)
+    if packages != "*":
+        filterNodes= set(packages)
+        for package in packages:
+            for child in nx.ancestors(dag, package):
+                filterNodes.add(child)
+        dag = nx.subgraph(dag, filterNodes)
+
+    updated = [0, 0, 0, 0]
+    hadErrors = set()
+    bumpErrors = set()
+    for node in nx.nodes(dag):
+        for recipe in name2recipes[node]:
+            # This should all go in a different module
+            status = should_be_bumped(recipe, build_config, repodata)
+            updated[status] += 1
+            if bump_only_python and status == 1:
+                status = 2
+            if status == 2:
+                if not bump_recipe(recipe):
+                    bumpErrors.add(recipe)
+            if status == 3:
+                hadErrors.add(recipe)
+
+    # Print some information
+    logger.info("Packages requiring the following:")
+    logger.info("  No build number change needed: {}".format(updated[0]))
+    logger.info("  A rebuild for a new python version: {}".format(updated[1]))
+    logger.info("  A build number increment: {}".format(updated[2]))
+    if updated[3]:
+        logger.info("{} packages produced an error in conda-build: {}".format(updated[3], list(hadErrors)))
+    if len(bumpErrors):
+        logger.info("The build numbers in the following recipes could not be incremented: {}".format(list(bumpErrors)))
 
 
 @arg('recipe_folder', help='Path to recipes directory')
@@ -709,6 +775,6 @@ def autobump(recipe_folder, config, loglevel='info', packages='*', cache=None,
 
 def main():
     argh.dispatch_commands([
-        build, dag, dependent, lint, duplicates,
+        build, dag, dependent, lint, duplicates, update_pinning,
         bioconductor_skeleton, clean_cran_skeleton, autobump
     ])

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -533,14 +533,14 @@ def update_pinning(recipe_folder, config, packages="*", skip_if_in_channels=['bi
                 hadErrors.add(recipe)
 
     # Print some information
-    logger.info("Packages requiring the following:")
-    logger.info("  No build number change needed: {}".format(updated[0]))
-    logger.info("  A rebuild for a new python version: {}".format(updated[1]))
-    logger.info("  A build number increment: {}".format(updated[2]))
+    print("Packages requiring the following:")
+    print("  No build number change needed: {}".format(updated[0]))
+    print("  A rebuild for a new python version: {}".format(updated[1]))
+    print("  A build number increment: {}".format(updated[2]))
     if updated[3]:
-        logger.info("{} packages produced an error in conda-build: {}".format(updated[3], list(hadErrors)))
+        print("{} packages produced an error in conda-build: {}".format(updated[3], list(hadErrors)))
     if len(bumpErrors):
-        logger.info("The build numbers in the following recipes could not be incremented: {}".format(list(bumpErrors)))
+        print("The build numbers in the following recipes could not be incremented: {}".format(list(bumpErrors)))
 
 
 @arg('recipe_folder', help='Path to recipes directory')

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -268,8 +268,7 @@ class RecipeBuilder(object):
 
         docker_base_image : str or None
             Name of base image that can be used in `dockerfile_template`.
-            Defaults to 'bioconda/bioconda-utils-build-env:TAG' where TAG is
-            `os.environ.get('BIOCONDA_UTILS_TAG', 'latest')`.
+            Defaults to 'bioconda/bioconda-utils-build-env:2019-02-01'
         """
         self.tag = tag
         self.requirements = requirements
@@ -278,8 +277,7 @@ class RecipeBuilder(object):
         self.dockerfile_template = dockerfile_template
         self.keep_image = keep_image
         if docker_base_image is None:
-            docker_base_image = 'bioconda/bioconda-utils-build-env:{}'.format(
-                os.environ.get('BIOCONDA_UTILS_TAG', 'latest'))
+            docker_base_image = 'bioconda/bioconda-utils-build-env:2019-02-01'
         self.docker_base_image = docker_base_image
 
         # To address issue #5027:

--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -349,6 +349,10 @@ def should_use_compilers(recipe, meta):
 def compilers_must_be_in_build(recipe, meta):
     if (
 
+        any(['gcc_impl_linux-64' in i for i in _get_deps(meta, 'run')]) or
+        any(['gcc_impl_linux-64' in i for i in _get_deps(meta, 'host')]) or
+        any(['clang_osx-64' in i for i in _get_deps(meta, 'run')]) or
+        any(['clang_osx-64' in i for i in _get_deps(meta, 'host')]) or
         any(['toolchain' in i for i in _get_deps(meta, 'run')]) or
         any(['toolchain' in i for i in _get_deps(meta, 'host')])
     ):

--- a/bioconda_utils/update_pinnings.py
+++ b/bioconda_utils/update_pinnings.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+from conda_build.metadata import MetaData
+from conda_build import render
+from conda_build import variants
+from conda_build import api
+import re
+import sys
+import os.path
+buildNumberRegex = re.compile("^( +number: +)(\d+)(.*?)$")
+buildNumberJinja = re.compile("^({% +set build +=.+?)(\d+)(.*?%})")
+
+def already_bumped(r, name, version, buildNumber):
+    rsub = r.loc[(r.name == name) &
+             (r.platform != "osx") &
+             (r.version == version)]
+    if rsub.shape[0] == 0:
+        # The version was never built, it doesn't explicitly require bumping
+        return True
+    if buildNumber > max(rsub.build_number):
+        # Already bumped
+        return True
+    return False
+
+
+def already_built(r, name, version, buildstring):
+    if r.loc[(r.name == name) &
+             (r.platform != "osx") &
+             (r.version == version) &
+             (r.build == buildstring)].shape[0] > 0:
+        return True
+    print("checked for {} version {} with buildstring {}".format(name, version, buildstring))
+    return False
+
+
+def only_python(r, name, version, buildstring):
+    s = r.loc[(r.name == name) &
+              (r.platform != "osx") &
+              (r.version == version)]
+    if s.shape[0] == 0:
+        # Version doesn't exist in linux/noarch
+        return False
+    build_set = set()
+    for b in s.build:
+        bs = b.split("_")
+        if bs[0].startswith("py"):
+            build_set.add(bs[0][4:])
+        else:
+            build_set.add(bs[0])
+    if buildstring in build_set:
+        return True
+    # Version exists, but build doesn't
+    return False
+
+
+def should_be_bumped(recipe, build_config, repodata):
+    """
+    Determine if a given recipe should have its build number increments
+    (bumped) due to a recent change in pinnings.
+
+    The output is an integer between 0 and 4:
+
+    0: A change in pinnings has no affect on the given recipe.
+    1: A bump is not explicitly needed, but a new python build is required.
+    2: A recipe's build number should be bumped.
+    3: conda-build returned an error while rendering the recipe.
+    """
+    status = 0
+    m = MetaData(recipe, build_config)
+    try:
+        # for renderedMeta, _, _ in render.distribute_variants(m, variants.get_package_variants(recipe, config=build_config)):
+        for renderedMeta, _, _ in api.render(recipe, config=build_config, permit_unsatisfiable_variants=False):
+            if renderedMeta.skip():
+                continue
+            # FIXME This gives funky results for things like ascat albatradis and afterqc
+            # Also, builds that should be skipped aren't (asqcan)!
+            buildID = renderedMeta.build_id()  # e.g., py36h47cebea_1 or 0
+            # This doesn't work for noarch: python, which is just py_0 or pyhXXXX_1
+            # However those won't ever need to be rebuilt due to only a python version change
+            buildID_nopy = buildID[4:] if buildID.startswith("py") else buildID
+
+            if already_bumped(repodata, renderedMeta.name(), renderedMeta.version(), renderedMeta.build_number()):
+                # Don't double bump
+                continue
+            if already_built(repodata, renderedMeta.name(), renderedMeta.version(), buildID):
+                continue
+            if only_python(repodata, renderedMeta.name(), renderedMeta.version(), buildID_nopy):
+                status = max(1, status)
+                continue
+            status = max(2, status)
+    except:
+        print(sys.exc_info()[1])
+        status = 3
+    if status == 2:
+        print("{} hash due to {}, original buildID is {}".format(recipe, renderedMeta.get_hash_contents(), renderedMeta.build_id()))
+    return status
+
+
+def bump_recipe(recipe):
+    """
+    Increment the build number of a recipe
+
+    returns True on success and False on error (the build number couldn't be updated)
+    """
+    m = open(os.path.join(recipe, "meta.yaml")).read().split("\n")
+    found = False
+    for idx, line in enumerate(m):
+        matches = buildNumberRegex.match(line)
+        if matches:
+            found = True
+            buildNumber = int(matches.group(2))
+            m[idx] = "{}{}{}".format(matches.group(1), buildNumber + 1, matches.group(3))
+            break
+    if not found:
+        for idx, line in enumerate(m):
+            matches = buildNumberJinja.match(line)
+            if matches:
+                found = True
+                buildNumber = int(matches.group(2))
+                m[idx] = "{}{}{}".format(matches.group(1), buildNumber + 1, matches.group(3))
+                break
+
+    if found:
+        f = open(os.path.join(recipe, "meta.yaml"), "w")
+        f.write("\n".join(m))
+        return True
+    return False

--- a/bioconda_utils/update_pinnings.py
+++ b/bioconda_utils/update_pinnings.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-from conda_build.metadata import MetaData
-from conda_build import render
-from conda_build import variants
 from conda_build import api
 import re
 import sys
@@ -28,7 +25,6 @@ def already_built(r, name, version, buildstring):
              (r.version == version) &
              (r.build == buildstring)].shape[0] > 0:
         return True
-    print("checked for {} version {} with buildstring {}".format(name, version, buildstring))
     return False
 
 
@@ -65,14 +61,10 @@ def should_be_bumped(recipe, build_config, repodata):
     3: conda-build returned an error while rendering the recipe.
     """
     status = 0
-    m = MetaData(recipe, build_config)
     try:
-        # for renderedMeta, _, _ in render.distribute_variants(m, variants.get_package_variants(recipe, config=build_config)):
         for renderedMeta, _, _ in api.render(recipe, config=build_config, permit_unsatisfiable_variants=False):
             if renderedMeta.skip():
                 continue
-            # FIXME This gives funky results for things like ascat albatradis and afterqc
-            # Also, builds that should be skipped aren't (asqcan)!
             buildID = renderedMeta.build_id()  # e.g., py36h47cebea_1 or 0
             # This doesn't work for noarch: python, which is just py_0 or pyhXXXX_1
             # However those won't ever need to be rebuilt due to only a python version change
@@ -90,8 +82,6 @@ def should_be_bumped(recipe, build_config, repodata):
     except:
         print(sys.exc_info()[1])
         status = 3
-    if status == 2:
-        print("{} hash due to {}, original buildID is {}".format(recipe, renderedMeta.get_hash_contents(), renderedMeta.build_id()))
     return status
 
 

--- a/test/test_bioconductor_skeleton.py
+++ b/test/test_bioconductor_skeleton.py
@@ -69,7 +69,7 @@ def test_meta_contents(tmpdir):
     # The rendered meta has {{ compiler('c') }} filled in, so we need to check
     # for one of those filled-in values.
     names = [i.split()[0] for i in edger_meta['requirements']['build']]
-    assert 'toolchain' in names
+    assert 'libstdcxx-ng' in names or 'clang_osx-64' in names
 
     # bioconductor, bioarchive, and cargoport
     assert len(edger_meta['source']['url']) == 3


### PR DESCRIPTION
This (A) updates the conda-forge-pinnings to the (currently) most recent version and adds a `bioconda-utils update-pinnings` function that can be used to bump a given package and all dependencies as appropriate if and only if they are affected by the change in pinnings.

I also changed `bioconda-utils dag` so that it will show the DAG of all dependencies of the package(s) specified. The previous behavior was to filter the DAG for only the packages specified, which tended to leave a bunch of singletons and was probably now what people really wanted.