### PR TITLE
Refactor bioconductor test

### DIFF
--- a/test/test_bioconductor_skeleton.py
+++ b/test/test_bioconductor_skeleton.py
@@ -141,7 +141,7 @@ def test_bioarchive_exists():
 
 
 def test_annotation_data(tmpdir, bioc_fetch):
-    bioconductor_skeleton.write_recipe('AHCytoBands', str(tmpdir), config, recursive=True, packages=bioc_fetch)
+    bioconductor_skeleton.write_recipe('AHCytoBands', str(tmpdir), config, recursive=False, packages=bioc_fetch)
     meta = utils.load_first_metadata(str(tmpdir.join('bioconductor-ahcytobands'))).meta
     assert 'wget' in meta['requirements']['run']
     assert len(meta['source']['url']) == 3
@@ -151,7 +151,7 @@ def test_annotation_data(tmpdir, bioc_fetch):
 
 
 def test_experiment_data(tmpdir, bioc_fetch):
-    bioconductor_skeleton.write_recipe('affydata', str(tmpdir), config, recursive=True, packages=bioc_fetch)
+    bioconductor_skeleton.write_recipe('affydata', str(tmpdir), config, recursive=False, packages=bioc_fetch)
     meta = utils.load_first_metadata(str(tmpdir.join('bioconductor-affydata'))).meta
     assert 'wget' in meta['requirements']['run']
     assert len(meta['source']['url']) == 3


### PR DESCRIPTION
This should speed up the bioconductor tests by ~33% (at least it does in testing). These still rely heavily upon internet sites, which are the slowest components (most of the time is spent waiting for sites to respond).