### PR TITLE
Following a discussion on gitter, apparently the quay.io URLs for pac…

### DIFF
--- a/docs/source/templates/readme.rst_t
+++ b/docs/source/templates/readme.rst_t
@@ -51,7 +51,7 @@
 
    or use the docker container::
 
-      docker pull quay.io/repository/biocontainers/{{ package.name }}:<tag>
+      docker pull quay.io/biocontainers/{{ package.name }}:<tag>
 
    (see `{{package.name}}/tags`_ for valid values for ``<tag>``)
 


### PR DESCRIPTION
…kages are wrong.