### PR TITLE
Changed the use of 'yaml.load(input)' to 'yaml.safe_load(input)':

### DIFF
--- a/bioconda_utils/update.py
+++ b/bioconda_utils/update.py
@@ -218,7 +218,7 @@ class ExcludeBlacklisted(Filter):
     def __init__(self, scanner, config_fn: str) -> None:
         super().__init__(scanner)
         with open(config_fn, "r") as config_fdes:
-            config = yaml.load(config_fdes)
+            config = yaml.safe_load(config_fdes)
         blacklists = [os.path.join(os.path.dirname(config_fn), bl)
                       for bl in config['blacklists']]
         self.blacklisted = utils.get_blacklist(blacklists, scanner.recipe_folder)

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -309,7 +309,7 @@ def load_meta_fast(recipe: str, env=None):
     try:
         pth = os.path.join(recipe, 'meta.yaml')
         template = jinja_silent_undef.from_string(open(pth, 'r', encoding='utf-8').read())
-        meta = yaml.load(template.render(env))
+        meta = yaml.safe_load(template.render(env))
         return (meta, recipe)
     except Exception:
         raise ValueError('Problem inspecting {0}'.format(recipe))
@@ -473,7 +473,7 @@ class EnvMatrix:
         """
         if isinstance(env, str):
             with open(env) as f:
-                self.env = yaml.load(f)
+                self.env = yaml.safe_load(f)
         else:
             self.env = env
         for key, val in self.env.items():
@@ -738,14 +738,14 @@ def newly_unblacklisted(config_file, recipe_folder, git_range):
     # config file and then all the original blacklists it had listed
     previous = set()
     orig_config = file_from_commit(git_range[0], config_file)
-    for bl in yaml.load(orig_config)['blacklists']:
+    for bl in yaml.safe_load(orig_config)['blacklists']:
         with open('.tmp.blacklist', 'w', encoding='utf8') as fout:
             fout.write(file_from_commit(git_range[0], bl))
         previous.update(get_blacklist(['.tmp.blacklist'], recipe_folder))
         os.unlink('.tmp.blacklist')
 
     current = get_blacklist(
-        yaml.load(
+        yaml.safe_load(
             file_from_commit(git_range[1], config_file))['blacklists'],
         recipe_folder)
     results = previous.difference(current)
@@ -915,11 +915,11 @@ def validate_config(config):
         directly.
     """
     if not isinstance(config, dict):
-        config = yaml.load(open(config))
+        config = yaml.safe_load(open(config))
     fn = pkg_resources.resource_filename(
         'bioconda_utils', 'config.schema.yaml'
     )
-    schema = yaml.load(open(fn))
+    schema = yaml.safe_load(open(fn))
     validate(config, schema)
 
 
@@ -941,7 +941,7 @@ def load_config(path):
     else:
         def relpath(p):
             return os.path.join(os.path.dirname(path), p)
-        config = yaml.load(open(path))
+        config = yaml.safe_load(open(path))
 
     def get_list(key):
         # always return empty list, also if NoneType is defined in yaml

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -92,10 +92,10 @@ class Recipes(object):
 
         if from_string:
             self.data = dedent(data)
-            self.recipes = yaml.load(data)
+            self.recipes = yaml.safe_load(data)
         else:
             self.data = os.path.join(os.path.dirname(__file__), data)
-            self.recipes = yaml.load(open(self.data))
+            self.recipes = yaml.safe_load(open(self.data))
 
     def write_recipes(self):
         basedir = tempfile.mkdtemp()

--- a/test/test_hosters.py
+++ b/test/test_hosters.py
@@ -9,7 +9,7 @@ from bioconda_utils.hosters import Hoster, HosterMeta
 
 
 with open(op.join(op.dirname(__file__), "hoster_cases.yaml")) as data:
-    TEST_CASES = yaml.load(data)
+    TEST_CASES = yaml.safe_load(data)
 
 
 TEST_CASE_LIST = [

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -592,7 +592,7 @@ def test_rendering_sandboxing():
             tmp = tempfile.mkdtemp()
             target = 'info/recipe/meta.yaml'
             t.extract(target, path=tmp)
-            contents = yaml.load(open(os.path.join(tmp, target)).read())
+            contents = yaml.safe_load(open(os.path.join(tmp, target)).read())
             assert contents['extra']['var2'] == 'conda-val-here', contents
 
 


### PR DESCRIPTION
The use of yaml.load(input) is deprecated, because of an security exploit see:
https://msg.pyyaml.org/load

All use of 'yaml.load(input) has been changed to 'yaml.safe_load(input)', all tests seems to pass.

This resolve #462