### PR TITLE
Add API Docs for Bioconda Utils Package

### DIFF
--- a/bioconda_utils/__init__.py
+++ b/bioconda_utils/__init__.py
@@ -1,3 +1,41 @@
+"""
+Bioconda Utilities Package
+
+.. rubric:: Subpackages
+
+.. autosummary::
+   :toctree:
+
+   bioconda_utils.bot
+
+.. rubric:: Submodules
+
+.. autosummary::
+   :toctree:
+
+   cli
+   async
+   bioconductor_skeleton
+   build
+   circleci
+   cli
+   cran_skeleton
+   docker_utils
+   githandler
+   github_integration
+   githubhandler
+   graph
+   hosters
+   lint_functions
+   linting
+   pkg_test
+   recipe
+   update
+   update_pinnings
+   upload
+   utils
+"""
+
 from ._version import get_versions
 __version__ = get_versions()["version"]
 del get_versions

--- a/bioconda_utils/async.py
+++ b/bioconda_utils/async.py
@@ -1,4 +1,4 @@
-"""Provides utilities for async processing"""
+"""Utilities for Asynchronous Processing"""
 
 import abc
 import asyncio
@@ -208,7 +208,7 @@ class AsyncRequests():
         """Fetch content at **url** and return as text
 
         - On non-permanent errors (429, 502, 503, 504), the GET is retried 10 times with
-        increasing wait times according to fibonacci series.
+          increasing wait times according to fibonacci series.
         - Permanent errors raise a ClientResponseError
         """
         if self.cache and url in self.cache["url_text"]:

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -226,17 +226,17 @@ def find_best_bioc_version(package, version):
 
 def fetchPackages(bioc_version):
     """
-    Return a dictionary of all bioconductor packages in a given release:
+    Return a dictionary of all bioconductor packages in a given release::
 
-    {package: {Version: "version",
-               Depends: [list],
-               Suggests: [list],
-               MD5sum: "hash",
-               License: "foo",
-               Description: "Something...",
-               NeedsCompilation: boolean},
-              ...
-    }
+        {package: {Version: "version",
+                   Depends: [list],
+                   Suggests: [list],
+                   MD5sum: "hash",
+                   License: "foo",
+                   Description: "Something...",
+                   NeedsCompilation: boolean},
+                  ...
+        }
     """
     d = dict()
     packages_urls = [(os.path.join(base_url, bioc_version, 'bioc', 'VIEWS'), 'bioc'),
@@ -893,7 +893,7 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
     config : str or dict
 
     force : bool
-        If True, then recipes will get overwritten. If `recursive` is also
+        If True, then recipes will get overwritten. If **recursive** is also
         True, *all* recipes created will get overwritten.
 
     bioc_version : str
@@ -911,7 +911,7 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
 
     seen_dependencies : set
         Dependencies to skip and will be updated with any packages built by
-        this function. Used internally when `recursive=True`.
+        this function. Used internally when ``recursive=True``.
 
     packages : dict
         A dictionary, as returned by fetchPackages(), of all packages in a
@@ -919,7 +919,7 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
 
     skip_if_in_channels : list or None
         List of channels whose existing packages will be automatically added to
-        `seen_dependencies`. Only has an effect if `recursive=True`.
+        **seen_dependencies**. Only has an effect if ``recursive=True``.
     """
     config = utils.load_config(config)
     proj = BioCProjectPage(package, bioc_version, pkg_version, packages=packages)

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -1,5 +1,6 @@
-#!/usr/bin/env python
-
+"""
+Conda Skeleton for Bioconductor Recipes
+"""
 import shutil
 import tempfile
 import configparser

--- a/bioconda_utils/bot/__init__.py
+++ b/bioconda_utils/bot/__init__.py
@@ -1,0 +1,14 @@
+"""
+Bioconda Bot & Github App
+
+.. autosummary::
+   :toctree:
+
+   commands
+   config
+   events
+   tasks
+   views
+   web
+   worker
+"""

--- a/bioconda_utils/bot/commands.py
+++ b/bioconda_utils/bot/commands.py
@@ -28,6 +28,7 @@ class CommandDispatch:
         """Decorator adding decorated function to dispatcher"""
         def decorator(func):
             self.mapping[cmd] = func
+            return func
         return decorator
 
     async def dispatch(self, cmd, *args, **kwargs):

--- a/bioconda_utils/bot/commands.py
+++ b/bioconda_utils/bot/commands.py
@@ -1,5 +1,5 @@
 """
-Bot commands issued via issue/pull-request comments
+Handlers for user commmands (``@biocondabot do this``)
 """
 
 import logging

--- a/bioconda_utils/bot/config.py
+++ b/bioconda_utils/bot/config.py
@@ -1,9 +1,10 @@
 """
-Access to configuration, hardcoded and from environ
+Bot configuration variables
 """
 
 import os
 import re
+import sys
 
 def get_secret(name):
     """Load a secret from file or env
@@ -18,6 +19,9 @@ def get_secret(name):
         try:
             return os.environ[name]
         except KeyError:
+            if os.path.basename(sys.argv[0]) == 'sphinx-build':
+                # We won't have nor need secrets when building docs
+                return None
             raise ValueError(
                 f"Missing secrets: configure {name} or {name}_FILE to contain or point at secret"
             ) from None

--- a/bioconda_utils/bot/events.py
+++ b/bioconda_utils/bot/events.py
@@ -1,5 +1,5 @@
 """
-Github Events
+Handlers for incoming Github Events
 """
 
 import logging

--- a/bioconda_utils/bot/tasks.py
+++ b/bioconda_utils/bot/tasks.py
@@ -1,5 +1,5 @@
 """
-Celery Tasks
+Celery Tasks doing the actual work
 """
 
 import logging

--- a/bioconda_utils/bot/views.py
+++ b/bioconda_utils/bot/views.py
@@ -1,5 +1,5 @@
 """
-HTTP Views (pages)
+HTTP Views (accepts and parses webhooks)
 """
 
 import logging

--- a/bioconda_utils/bot/web.py
+++ b/bioconda_utils/bot/web.py
@@ -50,7 +50,7 @@ async def start():
 async def start_with_celery():
     """Initialize app and launch internal celery worker
 
-    This isn't simply a flag for `init_app` because async app factories
+    This isn't simply a flag for `start` because async app factories
     cannot (easily) receive parameters from the gunicorn commandline.
     """
     app = await start()

--- a/bioconda_utils/bot/web.py
+++ b/bioconda_utils/bot/web.py
@@ -1,4 +1,4 @@
-"""Bioconda Bot"""
+"""AioHTTP Web Server Setup"""
 
 import logging
 import subprocess

--- a/bioconda_utils/bot/worker.py
+++ b/bioconda_utils/bot/worker.py
@@ -51,7 +51,7 @@ class AsyncTask(Task):
       avoid wasting API calls to create those tokens continuously, the
       Task class maintains a copy.
 
-    - Default to `acks_late = True`. The reason we use Celery at all
+    - Default to ``acks_late = True``. The reason we use Celery at all
       is so that spawned tasks can survive a shutdown of the app.
 
     """
@@ -100,8 +100,7 @@ class AsyncTask(Task):
     async def async_pre_run(self, args, _kwargs):
         """Per-call async initialization
 
-        Prepares the `ghapi` property for tasks using ghapi_data added
-        to arguments via `schedule()`.
+        Prepares the `ghapi` property for tasks.
 
         FIXME: doesn't replace kwargs
         """

--- a/bioconda_utils/bot/worker.py
+++ b/bioconda_utils/bot/worker.py
@@ -1,5 +1,5 @@
 """
-Celery Worker
+Celery Worker Setup
 """
 
 import abc

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -1,3 +1,7 @@
+"""
+Package Builder
+"""
+
 import subprocess as sp
 from itertools import chain
 from collections import defaultdict, namedtuple

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -74,7 +74,7 @@ def build(
         a build.
 
     channels : list
-        Channels to include via the `--channel` argument to conda-build. Higher
+        Channels to include via the ``--channel`` argument to conda-build. Higher
         priority channels should come first.
 
     docker_builder : docker_utils.RecipeBuilder object

--- a/bioconda_utils/circleci.py
+++ b/bioconda_utils/circleci.py
@@ -1,3 +1,7 @@
+"""
+CircleCI Web-API Bindings
+"""
+
 import abc
 import logging
 from typing import Any, Mapping, Optional, Tuple

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python
+"""
+Bioconda Utils Command Line Interface
+
+"""
 
 # Workaround for spurious numpy warning message
 # ".../importlib/_bootstrap.py:219: RuntimeWarning: numpy.dtype size \

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -642,8 +642,8 @@ def bioconductor_skeleton(
     pkg_version=None, bioc_version=None, recursive=False,
     skip_if_in_channels=['conda-forge', 'bioconda']):
     """
-    Build a Bioconductor recipe. The recipe will be created in the `recipes`
-    directory and will be prefixed by "bioconductor-". If `--recursive` is set,
+    Build a Bioconductor recipe. The recipe will be created in the 'recipes'
+    directory and will be prefixed by "bioconductor-". If --recursive is set,
     then any R dependency recipes will be prefixed by "r-".
 
     These R recipes must be evaluated on a case-by-case basis to determine if
@@ -651,11 +651,11 @@ def bioconductor_skeleton(
     bioconda) or not (submit to conda-forge).
 
     Biology-related:
-        `bioconda-utils clean-cran-skeleton <recipe> --no-windows`
+        'bioconda-utils clean-cran-skeleton <recipe> --no-windows'
         and submit to Bioconda.
 
     Not bio-related:
-        `bioconda-utils clean-cran-skeleton <recipe>`
+        'bioconda-utils clean-cran-skeleton <recipe>'
         and submit to conda-forge.
 
     """
@@ -692,10 +692,10 @@ def bioconductor_skeleton(
 @enable_logging()
 def clean_cran_skeleton(recipe, no_windows=False):
     """
-    Cleans skeletons created by `conda skeleton cran`.
+    Cleans skeletons created by ``conda skeleton cran``.
 
-    Before submitting to conda-forge or Bioconda, recipes generated with `conda
-    skeleton cran` need to be cleaned up: comments removed, licenses fixed, and
+    Before submitting to conda-forge or Bioconda, recipes generated with ``conda
+    skeleton cran`` need to be cleaned up: comments removed, licenses fixed, and
     other linting.
 
     Use --no-windows for a Bioconda submission.

--- a/bioconda_utils/cran_skeleton.py
+++ b/bioconda_utils/cran_skeleton.py
@@ -121,7 +121,7 @@ def clean_skeleton_files(package, no_windows=True):
 
 def clean_yaml_file(package, no_windows):
     """
-    Cleans the YAML file output by `conda skeleton cran` to make it conda-forge
+    Cleans the YAML file output by ``conda skeleton cran`` to make it conda-forge
     compatible.
 
     Parameters

--- a/bioconda_utils/cran_skeleton.py
+++ b/bioconda_utils/cran_skeleton.py
@@ -43,11 +43,11 @@ win32_string = 'number: 0\n  skip: true  # [win32]'
 def write_recipe(package, recipe_dir='.', recursive=False, force=False,
                  no_windows=False, **kwargs):
         """
-        Call out to to `conda skeleton cran`.
+        Call out to to ``conda skeleton cran``.
 
         Kwargs are accepted for uniformity with
         `bioconductor_skeleton.write_recipe`; the only one handled here is
-        `recursive`.
+        ``recursive``.
 
         Parameters
         ----------
@@ -57,16 +57,16 @@ def write_recipe(package, recipe_dir='.', recursive=False, force=False,
             "r-pkgname" conda package name.
 
         recipe_dir : str
-            Recipe will be created as a subdirectory in `recipe_dir`
+            Recipe will be created as a subdirectory in ``recipe_dir``
 
         recursive : bool
-            Add the `--recursive` argument to `conda skeleton cran` to
+            Add the ``--recursive`` argument to ``conda skeleton cran`` to
             recursively build CRAN recipes.
 
         force : bool
-            If True, then remove the directory `<recipe_dir>/<pkgname>`, where
-            `<pkgname>` the sanitized conda version of the package name,
-            regardless of which format was provided as `package`.
+            If True, then remove the directory ``<recipe_dir>/<pkgname>``, where
+            ``<pkgname>`` the sanitized conda version of the package name,
+            regardless of which format was provided as ``package``.
 
         no_windows : bool
             If True, then after creating the skeleton the files are then
@@ -101,7 +101,7 @@ def write_recipe(package, recipe_dir='.', recursive=False, force=False,
 
 def clean_skeleton_files(package, no_windows=True):
     """
-    Cleans output files created by `conda skeleton cran` to make them
+    Cleans output files created by ``conda skeleton cran`` to make them
     conda-forge compatible.
 
     Parameters
@@ -111,7 +111,7 @@ def clean_skeleton_files(package, no_windows=True):
         "r-pkgname" conda package name.
 
     no_windows : bool
-        If True, no bld.bat will be created and no `[win]` preprocess selectors
+        If True, no bld.bat will be created and no ``[win]`` preprocess selectors
         will be added to the yaml
     """
     clean_yaml_file(package, no_windows)
@@ -172,7 +172,7 @@ def clean_yaml_file(package, no_windows):
 
 def clean_build_file(package, no_windows=False):
     """
-    Cleans build.sh file created by `conda skeleton cran` to be compatible with
+    Cleans build.sh file created by ``conda skeleton cran`` to be compatible with
     conda-forge.
 
     Parameters
@@ -181,7 +181,7 @@ def clean_build_file(package, no_windows=False):
         Must be sanitized "r-pkgname" package name.
 
     no_windows : bool
-        Included for consistency with other `clean_*` functions; does not have
+        Included for consistency with other ``clean_*`` functions; does not have
         any effect for this function.
     """
 
@@ -206,7 +206,7 @@ def clean_build_file(package, no_windows=False):
 
 def clean_bld_file(package, no_windows):
     """
-    Cleans bld.bat file created by `conda skeleton cran` to be compatible with
+    Cleans bld.bat file created by ``conda skeleton cran`` to be compatible with
     conda-forge.
 
     Parameters
@@ -236,8 +236,8 @@ def clean_bld_file(package, no_windows):
 
 def filter_lines_regex(lines, regex, substitute):
     """
-    Substitutes `substitute` for every match to `regex` in each line of
-    `lines`.
+    Substitutes **substitute** for every match to **regex** in each line of
+    **lines**.
 
     Parameters
     ----------
@@ -251,7 +251,7 @@ def filter_lines_regex(lines, regex, substitute):
 
 def remove_empty_lines(lines):
     """
-    Removes consecutive empty lines in `lines`.
+    Removes consecutive empty lines in **lines**.
 
     Parameters
     ----------

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -19,7 +19,7 @@ In the end the workflow is:
 
     - build a custom docker container (assumed to already have conda installed)
       where the requirements in
-      `bioconda-utils/bioconda-utils_requirements.txt` have been conda
+      ``bioconda-utils/bioconda-utils_requirements.txt`` have been conda
       installed.
 
     - mount the host's conda-bld to a read/write temporary dir in the container
@@ -141,7 +141,7 @@ def dummy_recipe():
     Builds a throwaway recipe in a temp dir.
 
     The best way to figure out where a recipe will be built seems to be by
-    running `conda build --output $RECIPE`, but this means a recipe has to
+    running ``conda build --output $RECIPE``, but this means a recipe has to
     exist. This creates a minimal meta.yaml file in a temp dir that can be used
     as an example recipe.
 
@@ -234,32 +234,32 @@ class RecipeBuilder(object):
             and any recipes successfully built by the container will be added
             here.
 
-            Otherwise, use `pkg_dir` as a common host directory used across
+            Otherwise, use **pkg_dir** as a common host directory used across
             multiple runs of this RecipeBuilder object.
 
         pkg_dir : str or None
             Specify where packages should appear on the host.
 
-            If `pkg_dir` is None, then a temporary directory will be
+            If **pkg_dir** is None, then a temporary directory will be
             created once for each RecipeBuilder instance and that directory
             will be used for each call to `RecipeBuilder.build()`. This allows
             subsequent recipes built by the container to see previous built
             recipes without polluting the host's conda-bld directory.
 
-            If `pkg_dir` is a string, then it will be created if needed and
+            If **pkg_dir** is a string, then it will be created if needed and
             this directory will be used store all built packages on the host
             instead of the temp dir.
 
-            If the above argument `use_host_conda_bld` is True, then the value
-            of `pkg_dir` will be ignored and the host's conda-bld directory
+            If the above argument **use_host_conda_bld** is `True`, then the value
+            of **pkg_dir** will be ignored and the host's conda-bld directory
             will be used.
 
-            In all cases, `pkg_dir` will be mounted to `container_staging` in
+            In all cases, **pkg_dir** will be mounted to **container_staging** in
             the container.
 
         keep_image : bool
             By default, the built docker image will be removed when done,
-            freeing up storage space.  Set keep_image=True to disable this
+            freeing up storage space.  Set ``keep_image=True`` to disable this
             behavior.
 
         image_build_dir : str or None
@@ -267,7 +267,7 @@ class RecipeBuilder(object):
             instead of a temporary one. For testing purposes only.
 
         docker_base_image : str or None
-            Name of base image that can be used in `dockerfile_template`.
+            Name of base image that can be used in **dockerfile_template**.
             Defaults to 'bioconda/bioconda-utils-build-env:2019-02-01'
         """
         self.tag = tag

--- a/bioconda_utils/githandler.py
+++ b/bioconda_utils/githandler.py
@@ -1,4 +1,4 @@
-"""Abstraction layer handling git actions"""
+"""Wrappers for interacting with ``git``"""
 
 import asyncio
 import logging

--- a/bioconda_utils/githandler.py
+++ b/bioconda_utils/githandler.py
@@ -205,8 +205,8 @@ class GitHandlerBase():
         See also `get_merge_base()`.
 
         Args:
-          ref: Defaults to `HEAD` (active branch), one of the tips compared
-          other: Defaults to `origin/master`, other tip compared
+          ref: Defaults to ``HEAD`` (active branch), one of the tips compared
+          other: Defaults to ``origin/master``, other tip compared
 
         Returns:
           Generator over modified or created (**not deleted**) files.

--- a/bioconda_utils/githubhandler.py
+++ b/bioconda_utils/githubhandler.py
@@ -65,16 +65,24 @@ class GitHubHandler:
                  to_user: str = "bioconda",
                  to_repo: str = "bioconda-recipes",
                  installation: int = None) -> None:
+        #: API Bearer Token
         self.token = token
+        #: If set, no actual modifying actions are taken
         self.dry_run = dry_run
+        #: The installation ID if this instance is connected to an App
         self.installation = installation
+        #: Owner of the Repo
         self.user = to_user
+        #: Name of the Repo
         self.repo = to_repo
+        #: Default variables for API calls
         self.var_default = {'user': to_user,
                             'repo': to_repo}
 
         # filled in by login():
+        #: Gidgethub API object
         self.api: gidgethub.abc.GitHubAPI = None
+        #: Login username
         self.username: str = None
 
     def __str__(self):
@@ -115,7 +123,7 @@ class GitHubHandler:
             branch_name=branch_name, path=path, **self.var_default)
 
     async def login(self, *args, **kwargs):
-        """Log into API (fills `self.username`)"""
+        """Log into API (fills `username`)"""
 
         self.create_api_object(*args, **kwargs)
 

--- a/bioconda_utils/githubhandler.py
+++ b/bioconda_utils/githubhandler.py
@@ -1,4 +1,4 @@
-"""Highlevel API for managing PRs on Github"""
+"""Wrappers for Github Web-API Bindings"""
 
 import abc
 import datetime
@@ -410,9 +410,6 @@ class GitHubAppHandler:
         self._tokens: Dict[str, Tuple[int, str]] = {}
         #: GitHubHandlers for each installation
         self._handlers: Dict[Tuple[str, str], GitHubHandler] = {}
-
-        # Failing early is best - check that we can generate a JWT
-        self.get_app_jwt()
 
     def get_app_jwt(self) -> str:
         """Returns JWT authenticating as this app"""

--- a/bioconda_utils/graph.py
+++ b/bioconda_utils/graph.py
@@ -1,3 +1,7 @@
+"""
+Construction and Manipulation of Package/Recipe Graphs
+"""
+
 import logging
 import networkx as nx
 

--- a/bioconda_utils/hosters.py
+++ b/bioconda_utils/hosters.py
@@ -8,8 +8,8 @@ as simple as defining a regex to match the existing source URL, a
 formatting string creating the URL of the relases page and a regex
 to match links and extract their version.
 
-- We need to use `regex` rather than `re` to allow recursive matching
-  to manipulate capture groups in URL patterns as
+- We need to use :conda:package:`regex` rather than `re` to allow
+  recursive matching to manipulate capture groups in URL patterns as
   needed. (Technically, we could avoid this using a Snakemake wildcard
   type syntax to define the patterns - implementers welcome).
 

--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -1,3 +1,7 @@
+"""
+Lint Checks for Recipe Linter
+"""
+
 from functools import partial
 import glob
 import os

--- a/bioconda_utils/lint_functions.py
+++ b/bioconda_utils/lint_functions.py
@@ -387,7 +387,7 @@ def compilers_must_be_in_build(_recipe, meta):
 #                'fix': 'Need to wait until R 3.5 conda package is available',
 #            }
 
-
+#: Registry of lint functions
 registry = (
     in_other_channels,
     already_in_bioconda,

--- a/bioconda_utils/linting.py
+++ b/bioconda_utils/linting.py
@@ -133,7 +133,7 @@ class LintArgs(namedtuple('LintArgs', (
 ))):
     """
     exclude : list
-        List of function names in `registry` to skip globally. When running on
+        List of function names in ``registry`` to skip globally. When running on
         CI, this will be merged with anything else detected from the commit
         message or LINT_SKIP environment variable using the special string
         "[skip lint <function name> for <recipe name>]". While those other
@@ -142,7 +142,7 @@ class LintArgs(namedtuple('LintArgs', (
 
     registry : list or tuple
         List of functions to apply to each recipe. If None, defaults to
-        `lint_functions.registry`.
+        `bioconda_utils.lint_functions.registry`.
     """
     def __new__(cls, exclude=None, registry=None):
         return super().__new__(cls, exclude, registry)

--- a/bioconda_utils/linting.py
+++ b/bioconda_utils/linting.py
@@ -1,3 +1,7 @@
+"""
+Recipe Linter
+"""
+
 import os
 import re
 import itertools

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -1,3 +1,7 @@
+"""
+Mulled Tests
+"""
+
 import subprocess as sp
 import tempfile
 import tarfile

--- a/bioconda_utils/recipe.py
+++ b/bioconda_utils/recipe.py
@@ -52,7 +52,7 @@ class DuplicateKey(RecipeError):
     does not allow those, but the PyYAML parser silently overwrites
     previous keys.
 
-    For duplicate keys that are a result of `# [osx]` style line selectors,
+    For duplicate keys that are a result of ``# [osx]`` style line selectors,
     `Recipe` attempts to resolve them as a list of dictionaries instead.
     """
     template = "has duplicate key"
@@ -74,7 +74,7 @@ class MissingBuild(RecipeError):
 
 
 class HasSelector(RecipeError):
-    """Raised when recplacements fail due to `# [cond]` line selectors
+    """Raised when recplacements fail due to ``# [cond]`` line selectors
     FIXME: This should no longer be an error
     """
     template = "has selector in line %i (replace failed)"

--- a/bioconda_utils/recipe.py
+++ b/bioconda_utils/recipe.py
@@ -1,4 +1,7 @@
-"""The **meta.yaml** format used by conda to describe how a package
+"""
+Editable Recipe (``meta.yaml``)
+
+The **meta.yaml** format used by conda to describe how a package
 is built has diverged from standard YAML format significantly. This
 module implements a class `Recipe` that in contrast to the **Meta**
 object resulting from parsing by **conda_build** offers functions to
@@ -369,12 +372,11 @@ class Recipe():
         """Runs string replace on parts of recipe text.
 
         - Lines considered are those containing Jinja set statements
-        (``{% set var="val" %}``) and those defining the top level
-        Mapping entries given by **within** (default:``package`` and
-        ``source``).
-
+          (``{% set var="val" %}``) and those defining the top level
+          Mapping entries given by **within** (default:``package`` and
+          ``source``).
         - Cowardly refuses to modify lines with ``# [expression]``
-        selectors.
+          selectors.
         """
         logger.debug("Trying to replace %s with %s", before, after)
 

--- a/bioconda_utils/update.py
+++ b/bioconda_utils/update.py
@@ -242,8 +242,7 @@ class UpdateVersion(Filter):
      3. fetch url
      4. hoster extracts (link,version) pairs
      5. select newest
-     4. update sources
-
+     6. update sources
     """
 
     class Metapackage(EndProcessingItem):

--- a/bioconda_utils/update.py
+++ b/bioconda_utils/update.py
@@ -7,7 +7,7 @@ Overview:
   objects for each recipe.
 
 - The `Recipe` handles reading, modification and writing of
-   ``meta.yaml`` files.
+  ``meta.yaml`` files.
 
 - The filters `ExcludeSubrecipe` and `ExcludeOtherChannel` exclude
   recipes in sub folders and present in other channels as configured.
@@ -38,7 +38,7 @@ Rationale (for all those imports):
 
 - We use `ruamel.yaml` to know where in a ``.yaml`` file a value is
   defined. Ideally, we would extend its round-trip type to handle the
-  `# [exp]` line selectors and at least simple parts of Jinja2
+  ``# [exp]`` line selectors and at least simple parts of Jinja2
   template expansion.
 
 """

--- a/bioconda_utils/update_pinnings.py
+++ b/bioconda_utils/update_pinnings.py
@@ -1,3 +1,7 @@
+"""
+Determine which packages need updates after pinning change
+"""
+
 import re
 import sys
 import os.path

--- a/bioconda_utils/update_pinnings.py
+++ b/bioconda_utils/update_pinnings.py
@@ -50,7 +50,7 @@ def have_variant(meta):
 
 
 def have_variant_but_for_python(meta):
-    """Checks if we have an exact or `py[23]_` prefixed match to
+    """Checks if we have an exact or ``py[23]_`` prefixed match to
     name/version/buildstring
 
     Ignores osx.

--- a/bioconda_utils/upload.py
+++ b/bioconda_utils/upload.py
@@ -1,3 +1,7 @@
+"""
+Deploy Artifacts to Anaconda and Quay
+"""
+
 import os
 import subprocess as sp
 import logging

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1,5 +1,8 @@
-#!/usr/bin/env python
+"""
+Utility Functions and Classes
 
+This module collects small pieces of code used throughout `bioconda_utils`.
+"""
 import os
 import re
 import glob

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -47,8 +47,9 @@ logger = logging.getLogger(__name__)
 
 class TqdmHandler(logging.StreamHandler):
     """Tqdm aware logging StreamHandler
-    Passes all log writes through tqdm to allow progress bars
-    and log messages to coexist without clobbering terminal
+
+    Passes all log writes through tqdm to allow progress bars and log
+    messages to coexist without clobbering terminal
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -229,7 +230,7 @@ def temp_env(env):
     """
     Context manager to temporarily set os.environ.
 
-    Used to send values in `env` to processes that only read the os.environ,
+    Used to send values in **env** to processes that only read the os.environ,
     for example when filling in meta.yaml with jinja2 template variables.
 
     All values are converted to string before sending to os.environ
@@ -249,7 +250,7 @@ def temp_env(env):
 def sandboxed_env(env):
     """
     Context manager to temporarily set os.environ, only allowing env vars from
-    the existing `os.environ` or the provided `env` that match
+    the existing `os.environ` or the provided **env** that match
     ENV_VAR_WHITELIST globs.
     """
     env = dict(env)
@@ -401,7 +402,7 @@ def run(cmds, env=None, mask=None, **kwargs):
     Wrapper around subprocess.run()
 
     Explicitly decodes stdout to avoid UnicodeDecodeErrors that can occur when
-    using the `universal_newlines=True` argument in the standard
+    using the ``universal_newlines=True`` argument in the standard
     subprocess.run.
 
     Also uses check=True and merges stderr with stdout. If a CalledProcessError
@@ -575,7 +576,7 @@ def get_recipes(recipe_folder, package="*"):
     """
     Generator of recipes.
 
-    Finds (possibly nested) directories containing a `meta.yaml` file.
+    Finds (possibly nested) directories containing a ``meta.yaml`` file.
 
     Parameters
     ----------
@@ -601,7 +602,7 @@ def get_latest_recipes(recipe_folder, config, package="*"):
     """
     Generator of recipes.
 
-    Finds (possibly nested) directories containing a `meta.yaml` file and returns
+    Finds (possibly nested) directories containing a ``meta.yaml`` file and returns
     the latest version of each recipe.
 
     Parameters
@@ -664,7 +665,7 @@ def built_package_paths(recipe):
     """
     Returns the path to which a recipe would be built.
 
-    Does not necessarily exist; equivalent to `conda build --output recipename`
+    Does not necessarily exist; equivalent to ``conda build --output recipename``
     but without the subprocess.
     """
     config = load_conda_build_config()
@@ -723,9 +724,9 @@ def newly_unblacklisted(config_file, recipe_folder, git_range):
         Path to recipe dir, needed by get_blacklist
 
     git_range : str or list
-        If str or single-item list. If 'HEAD' or ['HEAD'] or ['master',
-        'HEAD'], compares the current changes to master. If other commits are
-        specified, then use those commits directly via `git show`.
+        If str or single-item list. If ``'HEAD'`` or ``['HEAD']`` or ``['master',
+        'HEAD']``, compares the current changes to master. If other commits are
+        specified, then use those commits directly via ``git show``.
     """
 
     # 'HEAD' becomes ['HEAD'] and then ['master', 'HEAD'].
@@ -760,9 +761,9 @@ def changed_since_master(recipe_folder):
     """
     Return filenames changed since master branch.
 
-    Note that this uses `origin`, so if you are working on a fork of the main
-    repo and have added the main repo as `upstream`, then you'll have to do
-    a `git checkout master && git pull upstream master` to update your fork.
+    Note that this uses ``origin``, so if you are working on a fork of the main
+    repo and have added the main repo as ``upstream``, then you'll have to do
+    a ``git checkout master && git pull upstream master`` to update your fork.
     """
     p = run(['git', 'fetch', 'origin', 'master'])
     p = run(['git', 'diff', 'FETCH_HEAD', '--name-only'])
@@ -980,12 +981,12 @@ def modified_recipes(git_range, recipe_folder, config_file):
     """
     Returns files under the recipes dir that have been modified within the git
     range. Includes meta.yaml files for recipes that have been unblacklisted in
-    the git range. Filenames are returned with the `recipe_folder` included.
+    the git range. Filenames are returned with the ``recipe_folder`` included.
 
     git_range : list or tuple of length 1 or 2
-        For example, ['00232ffe', '10fab113'], or commonly ['master', 'HEAD']
-        or ['master']. If length 2, then the commits are provided to `git diff`
-        using the triple-dot syntax, `commit1...commit2`. If length 1, the
+        For example, ``['00232ffe', '10fab113']``, or commonly ``['master', 'HEAD']``
+        or ``['master']``. If length 2, then the commits are provided to ``git diff``
+        using the triple-dot syntax, ``commit1...commit2``. If length 1, the
         comparison is any changes in the working tree relative to the commit.
 
     recipe_folder : str

--- a/docs/source/build-system.rst
+++ b/docs/source/build-system.rst
@@ -29,7 +29,7 @@ need to create the entire bioconda-build system environment from scratch for
 each build.
 
 When testing locally with ``circleci build``, we use the
-`bioconda/bioconda-utils-build-env` Docker container to avoid changing the
+``bioconda/bioconda-utils-build-env`` Docker container to avoid changing the
 local system. This container is defined by `this Dockerfile
 <https://github.com/bioconda/bioconda-utils/blob/master/Dockerfile>`_.
 

--- a/docs/source/cb3.rst
+++ b/docs/source/cb3.rst
@@ -178,10 +178,10 @@ Global pinning is the idea of making sure all recipes use the same versions of
 common libraries.  Problems arise when the build-time version does not match
 the install-time version. Furthermore, all packages installed into the same
 environment should have been built using the same version so that they can
-co-exist. For example, many bioinformatics tools have `zlib` as a dependency.
-The version of `zlib` used when building the package should be the same as the
+co-exist. For example, many bioinformatics tools have ``zlib`` as a dependency.
+The version of ``zlib`` used when building the package should be the same as the
 version used when installing the package into a new environment. This implies
-that we need to specify the `zlib` version in one place and have all recipes
+that we need to specify the ``zlib`` version in one place and have all recipes
 use that version.
 
 Previously we maintained a global, bioconda-specific pinning file (see

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -286,12 +286,17 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'conda.io': ('https://conda.io/en/latest', None),
+    'conda-build': ('https://conda.io/projects/conda-build/en/latest/', None),
+    'conda': ('https://conda.io/projects/conda/en/latest/', None),
+}
 
 # We are using the `extlinks` extension to render links for identifiers:
 extlinks = {
-   'biotools': ('https://bio.tools/%s', ''),
-   'doi': ('https://doi.org/%s', ''),
+    'biotools': ('https://bio.tools/%s', ''),
+    'doi': ('https://doi.org/%s', ''),
 }
 
 # autogenerate autodoc stubs via autosummary

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,6 +30,10 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
+
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinxcontrib.napoleon'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -61,7 +65,7 @@ exclude_patterns = ['build']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+default_role = "any"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #add_function_parentheses = True
@@ -288,3 +292,10 @@ extlinks = {
    'biotools': ('https://bio.tools/%s', ''),
    'doi': ('https://doi.org/%s', ''),
 }
+
+# autogenerate autodoc stubs via autosummary
+autosummary_generate = True
+
+# placate assertion in utils.RepoData()
+from bioconda_utils import utils
+utils.load_config('../bioconda-recipes/config.yml')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ extensions = [
 
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
     'celery.contrib.sphinx',
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,8 @@ extensions = [
 
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    'sphinxcontrib.napoleon'
+    'sphinxcontrib.napoleon',
+    'celery.contrib.sphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/contribute-a-recipe.rst
+++ b/docs/source/contribute-a-recipe.rst
@@ -163,7 +163,7 @@ If
 * the recipe is doing something non-standard or
 * it adds a new package
 
-please ask `@bioconda/core` for a review. If you are a member
+please ask ``@bioconda/core`` for a review. If you are a member
 of the bioconda team and none of above criteria apply, feel free to merge your
 recipe once the tests pass.
 

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -130,7 +130,7 @@ Testing ``bioconda-utils`` locally
 ----------------------------------
 
 Follow the instructions at :ref:`bootstrap` to create a separate Miniconda
-installation using the ``bootstrap.py`` script in the `bioconda-recipes` repo.
+installation using the ``bootstrap.py`` script in the ``bioconda-recipes`` repo.
 
 Then, in the activated environment, install the bioconda-utils test
 requirements, from the top-level directory of the ``bioconda-utils`` repo.

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -32,11 +32,11 @@ Recipe vs package
 
 A *recipe* is a directory containing small set of files that defines name,
 version, dependencies, and URL for source code. A recipe typically contains
-a `meta.yaml` file that defines these settings and a `build.sh` script that
+a ``meta.yaml`` file that defines these settings and a ``build.sh`` script that
 builds the software. A recipe is converted into a *package* by running
-`conda-build` on the recipe. A package is a bgzipped tar file (`.tar.bz2`) that
+`conda-build` on the recipe. A package is a bgzipped tar file (``.tar.bz2``) that
 contains the built software. Packages are uploaded to anaconda.org so that
-users can install them with `conda install`.
+users can install them with ``conda install``.
 
 .. seealso::
 
@@ -57,12 +57,12 @@ a "build" means identifying any recipes that need to built, running
 How is Circle CI set up and configured?
 ---------------------------------------
 
-- `.circleci/config.yml` is read by the Circle CI worker.
+- ``.circleci/config.yml`` is read by the Circle CI worker.
 
-- The worker runs `.circleci/setup.sh`. This installs conda, adds
-  channels, and installs `bioconda-utils`
+- The worker runs ``.circleci/setup.sh``. This installs conda, adds
+  channels, and installs :doc:`bioconda-utils`
 
-- The worker runs tests defined in `.circleci/config.yml`.
+- The worker runs tests defined in ``.circleci/config.yml``.
 
 A local version of the Circle CI tests can be executed via the
 :ref:`Circle CI client <circleci-client>`. Note that this version lacks some
@@ -95,7 +95,7 @@ What's the lifecycle of a bioconda package?
 - Circle CI tests again, but this time after testing the built packages are
   uploaded to the bioconda channel on anaconda.org.
 - Users can now install the package just like any other conda package with
-  `conda install`.
+  ``conda install``.
 
 Once uploaded to anaconda.org, it is our intention to never delete any old
 packages. Even if a recipe in the bioconda repo is updated to a new version,
@@ -104,7 +104,7 @@ to sponsor the storage required by the bioconda channel.
 Nevertheless, it can sometimes happen that we have to mark packages as broken
 in order to avoid that they are accidentally pulled by the conda solver.
 In such a case it is only possible to install them by specifically considering
-the `broken` label, i.e.,
+the ``broken`` label, i.e.,
 
 .. code-block:: bash
 

--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -298,11 +298,12 @@ class CondaObjectDescription(ObjectDescription):
             objects = self.env.domaindata[self.domain]['objects']
             key = (self.objtype, name)
             if key in objects:
-                self.env.warn(
-                    self.env.docname,
-                    "Duplicate entry {} {} at {} (other in {})".format(
-                        self.objtype, name, self.lineno,
-                        self.env.doc2path(objects[key][0])))
+                if hasattr(self.env, 'warn'):
+                    self.env.warn(
+                        self.env.docname,
+                        "Duplicate entry {} {} at {} (other in {})".format(
+                            self.objtype, name, self.lineno,
+                            self.env.doc2path(objects[key][0])))
             objects[key] = (self.env.docname, target_name)
 
         index_text = self.get_index_text(name)

--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -497,10 +497,11 @@ class CondaDomain(Domain):
         for (typ, name), (docname, ref) in otherdata['objects'].items():
             if docname in docnames:
                 self.data['objects'][typ, name] = (docname, ref)
-        for key, data in otherdata['backrefs'].items():
-            if docname in docnames:
-                xdata = self.data['backrefs'].setdefault(key, set())
-                xdata |= data
+        # broken?
+        #for key, data in otherdata['backrefs'].items():
+        #    if docname in docnames:
+        #        xdata = self.data['backrefs'].setdefault(key, set())
+        #        xdata |= data
 
 
 def generate_readme(folder, repodata, renderer):

--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -505,6 +505,26 @@ class CondaDomain(Domain):
         #        xdata |= data
 
 
+class AutoRecipesDirective(rst.Directive):
+    """FIXME: This does not yet do ANYTHING!
+
+    In theory, a directive like this should act as a hook for a repo
+    to generate stubs for, similar to other autoXYZ directives.
+    """
+    required_arguments = 0
+    optional_argument = 0
+    option_spec = {
+        'repo': rst.directives.unchanged,
+        'folder': rst.directives.unchanged,
+        'config': rst.directives.unchanged,
+    }
+    has_content = False
+
+    def run(self):
+        #self.env: BuildEnvironment = self.state.document.settings.env
+        return [nodes.paragraph('')]
+
+
 def generate_readme(folder, repodata, renderer):
     """Generates README.rst for the recipe in folder
 

--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -636,11 +636,33 @@ def generate_recipes(app):
         tasks.join()
 
 
+def add_ribbon(app, pagename, templatename, context, doctree):
+    if templatename != 'page.html':
+        return
+    if pagename.startswith('_autosummary') or pagename.startswith('_modules'):
+        _, _, path = pagename.partition('/')
+        path = path.replace('.', '/') + '.py'
+        repo = 'bioconda-utils'
+    elif pagename.startswith('recipes/') and pagename.endswith('/README'):
+        repo = 'bioconda-recipes'
+        path = pagename[:-len('README')] + 'meta.yaml'
+    else:
+        repo = 'bioconda-utils'
+        path = 'docs/source/' + os.path.relpath(doctree.get('source'), app.builder.srcdir)
+
+    context['git_ribbon_url'] = (f'https://github.com/bioconda/{repo}/'
+                                 f'edit/master/{path}')
+    context['git_ribbon_message'] = "Edit me on GitHub"
+
+
+
 def setup(app):
     """Set up sphinx extension"""
     app.add_domain(CondaDomain)
+    app.add_directive('autorecipes', AutoRecipesDirective)
     app.connect('builder-inited', generate_recipes)
     app.connect('missing-reference', resolve_required_by_xrefs)
+    app.connect('html-page-context', add_ribbon)
     return {
         'version': "0.0.0",
         'parallel_read_safe': True,

--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -193,6 +193,7 @@ class RequirementsField(GroupedField):
             backrefs.add((env.docname, source))
 
         fieldbody = nodes.field_body('', listnode)
+        fieldbody.set_class('field-list-wrapped')
         return nodes.field('', fieldname, fieldbody)
 
 

--- a/docs/source/guidelines.rst
+++ b/docs/source/guidelines.rst
@@ -8,12 +8,12 @@ bioconda recipe checklist
 - Source URL is stable (:ref:`details <stable-url>`)
 - sha256 or md5 hash included for source download (:ref:`details <hashes>`)
 - Appropriate build number (:ref:`details <buildnum>`)
-- `.bat` file for Windows removed (:ref:`details <bat-files>`)
+- ``.bat`` file for Windows removed (:ref:`details <bat-files>`)
 - Remove unnecessary comments (:ref:`details <comments-in-meta>`)
 - Adequate tests included (:ref:`details <tests>`)
 - Files created by the recipe follow the FSH (:ref:`details <fsh-section>`)
 - License allows redistribution and license is indicated in ``meta.yaml``
-- Package does not already exist in the `defaults` or `conda-forge`
+- Package does not already exist in the ``defaults`` or ``conda-forge``
   channels with some exceptions (:ref:`details <channel-exceptions>`)
 - Package is appropriate for bioconda (:ref:`details <appropriate-for-bioconda>`)
 - If the recipe installs custom wrapper scripts, usage notes should be added to
@@ -28,7 +28,7 @@ bioconda recipe checklist
 
 Stable urls
 ~~~~~~~~~~~
-While supported by conda, `git_url` and `git_rev` are not as stable as a git
+While supported by conda, ``git_url`` and ``git_rev`` are not as stable as a git
 tarball. Ideally, a github repo should have tagged releases that are accessible
 as tarballs from the "releases" section of the github repo. Correspondingly, a
 bitbucket repo should have have tagged versions that are accessible as tarballs
@@ -51,18 +51,17 @@ file to compute its sha256 hash, and copy this into the recipe, for example:
 
     wget -O- $URL | shasum -a 256
 
-Likewise use `md5sum` (Linux) or `md5` (OSX) on a file to compute its md5 hash,
+Likewise use ``md5sum`` (Linux) or ``md5`` (OSX) on a file to compute its md5 hash,
 and copy this into the recipe.
 
 .. _buildnum:
 
 Build numbers
 ~~~~~~~~~~~~~
-The build number (see `conda docs
-<http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string>`_)
-can be used to trigger a new build for a package whose version has not changed.
-This is useful for fixing errors in recipes. The first recipe for a new version
-should always have a build number of 0.
+The build number (see `conda docs <conda-build:meta-build>`) can be
+used to trigger a new build for a package whose version has not
+changed.  This is useful for fixing errors in recipes. The first
+recipe for a new version should always have a build number of 0.
 
 .. _bat-files:
 
@@ -100,13 +99,13 @@ Existing package exceptions
 If a package already exists in one of the dependent channels but is broken or
 cannot be used as-is, please first consider fixing the package in that channel.
 If this is not possible, please indicate this in the PR and notify
-@bioconda/core in the PR.
+``@bioconda/core`` in the PR.
 
 .. _appropriate-for-bioconda:
 
 Packages appropriate for bioconda
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-bioconda is a bioinformatics channel, so we prefer to host packages specific to
+Bioconda is a bioinformatics channel, so we prefer to host packages specific to
 this domain. If a bioinformatics recipe has more general dependencies, please
 consider opening a pull request with `conda-forge
 <https://conda-forge.github.io/#add_recipe>`_ which hosts general packages.
@@ -114,7 +113,7 @@ consider opening a pull request with `conda-forge
 The exception to this is with R packages. We are still coordinating with
 Anaconda and conda-forge about the best place to keep general R packages. In
 the meantime, R packages that are not specific to bioinformatics and that
-aren't already in the `conda-forge` channel can be added to bioconda.
+aren't already in the ``conda-forge`` channel can be added to bioconda.
 
 If uploading of an unreleased version is necessary, please follow the
 versioning scheme of conda for pre- and post-releases (e.g. using a, b, rc, and
@@ -135,18 +134,18 @@ add ``noarch: python`` to the ``build`` section of the ``meta.yaml`` file.
 Dependencies
 ~~~~~~~~~~~~
 
-There is currently no mechanism to define, in the `meta.yaml` file, that
+There is currently no mechanism to define, in the ``meta.yaml`` file, that
 a particular dependency should come from a particular channel. This means that
 a recipe must have its dependencies in one of the following:
 
 - as-yet-unbuilt recipes in the repo but that will be included in the PR
-- `bioconda` channel
-- `conda-forge` channel
+- ``bioconda`` channel
+- ``conda-forge`` channel
 - default Anaconda channel
 
 Otherwise, you will have to write the recipes for those dependencies and
-include them in the PR. One shortcut is to use `anaconda search -t conda
-<dependency name>` to look for other packages built by others. Inspecting those
+include them in the PR. One shortcut is to use ``anaconda search -t conda
+<dependency name>`` to look for other packages built by others. Inspecting those
 recipes can give some clues into building a version of the dependency for
 bioconda.
 
@@ -190,12 +189,11 @@ a command-line tool, in which case that should be tested as well.
   <https://github.com/bioconda/bioconda-recipes/tree/master/recipes/chanjo>`_
 
 
-By default, Python recipes (those that have `python` listed as a dependency)
+By default, Python recipes (those that have ``python`` listed as a dependency)
 must be successfully built and tested on Python 2.7, 3.6, and 3.7 in order to
 pass. However, many Python packages are not fully compatible across all Python
-versions. Use the `preprocessing selectors
-<http://conda.pydata.org/docs/building/meta-yaml.html#preprocessing-selectors>`_
-in the meta.yaml file along with the `build/skip` entry to indicate that
+versions. Use the `preprocessing selectors <conda-build:preprocess-selectors>`
+in the meta.yaml file along with the ``build/skip`` entry to indicate that
 a recipe should be skipped.
 
 For example, a recipe that only runs on Python 2.7 should include the
@@ -214,8 +212,7 @@ Or a package that only runs on Python 3.6 and 3.7:
       - python >=3
 
 Alternatively, for straightforward compatibility fixes you can apply a `patch
-in the meta.yaml`
-<http://conda.pydata.org/docs/building/meta-yaml.html#patches>`_.
+in the meta.yaml <conda-build:meta-yaml>`.
 
 
 .. _r-cran:
@@ -372,12 +369,12 @@ C/C++
 
 Build tools (e.g., ``autoconf``) and compilers (e.g., ``gcc``) should be
 specified in the build requirements. Compilers are handled via a special macro.
-E.g., `{{ compiler('c')}}` ensures that the correct version of `gcc` is used.
-For the C++ variant `g++`, you need to use `{{ compiler('cxx') }}`.
+E.g., `{{ compiler('c')}}` ensures that the correct version of ``gcc`` is used.
+For the C++ variant ``g++``, you need to use `{{ compiler('cxx') }}`.
 These rules apply for both Linux and macOS.
 
-Conda distinguishes between dependencies needed for building (the `build` section),
-and dependencies needed during build time (the `host` section).
+Conda distinguishes between dependencies needed for building (the ``build`` section),
+and dependencies needed during build time (the ``host`` section).
 For example, the following
 
 

--- a/docs/source/guidelines.rst
+++ b/docs/source/guidelines.rst
@@ -244,7 +244,7 @@ R (CRAN)
 
     The bioconda channel does not build for Windows. To keep recipes
     streamlined, please remove the "set posix" and "set native" lines described
-    above and convert the `test:commands:` block to only:
+    above and convert the ``test:commands:`` block to only:
 
     .. code-block:: yaml
 
@@ -369,8 +369,8 @@ C/C++
 
 Build tools (e.g., ``autoconf``) and compilers (e.g., ``gcc``) should be
 specified in the build requirements. Compilers are handled via a special macro.
-E.g., `{{ compiler('c')}}` ensures that the correct version of ``gcc`` is used.
-For the C++ variant ``g++``, you need to use `{{ compiler('cxx') }}`.
+E.g., ``{{ compiler('c')}}`` ensures that the correct version of ``gcc`` is used.
+For the C++ variant ``g++``, you need to use ``{{ compiler('cxx') }}``.
 These rules apply for both Linux and macOS.
 
 Conda distinguishes between dependencies needed for building (the ``build`` section),

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,18 +1,19 @@
 .. image:: bioconda.png
 
-**Bioconda** is a channel for the `conda
-<http://conda.pydata.org/docs/intro.html>`_ package manager
+**Bioconda** is a channel for the conda_ package manager
 specializing in bioinformatics software. Bioconda consists of:
 
-- a `repository of recipes
-  <https://github.com/bioconda/bioconda-recipes>`_ hosted on GitHub
-- a `build system <https://github.com/bioconda/bioconda-utils>`_ that
-  turns these recipes into conda packages
-- a `repository of more than 6000 bioinformatics packages
-  <https://anaconda.org/bioconda/>`_ ready to use with ``conda
-  install``
-- over 600 contributors and 450 members who add, modify, update and
+- a `repository of recipes`_ hosted on GitHub
+- a `build system`_ turning these recipes into conda packages
+- a `repository of packages`_ containing over 6000 bioinformatics
+  packages ready to use with ``conda install``
+- over 600 contributors and 500 members who add, modify, update and
   maintain the recipes
+
+.. _conda: https://conda.io/en/latest/index.html
+.. _`repository of recipes`: https://github.com/bioconda/bioconda-recipes
+.. _`build system`: https://github.com/bioconda/bioconda-utils
+.. _`repository of packages`: https://anacoda.org/bioconda/
 
 The conda package manager makes installing software a vastly more
 streamlined process. Conda is a combination of other package managers
@@ -21,8 +22,8 @@ apt-get, and homebrew.  Conda is both language- and OS-agnostic, and
 can be used to install C/C++, Fortran, Go, R, Python, Java etc
 programs on Linux, Mac OSX, and Windows.
 
-Conda allows separation of packages into repositories, or `channels`.
-The main `defaults` channel has a large number of common
+Conda allows separation of packages into repositories, or ``channels``.
+The main ``defaults`` channel has a large number of common
 packages. Users can add additional channels from which to install
 software packages not available in the defaults channel. Bioconda is
 one such channel specializing in bioinformatics software.
@@ -35,16 +36,20 @@ When using Bioconda please **cite our article**:
   Comprehensive Software Distribution for the Life Sciences". Nature
   Methods, 2018 doi::doi:`10.1038/s41592-018-0046-7`.
 
-Bioconda has been acknowledged by NATURE in their
-`technology blog <http://blogs.nature.com/naturejobs/2017/11/03/techblog-bioconda-promises-to-ease-bioinformatics-software-installation-woes/>`_.
+Bioconda has been acknowledged by NATURE in their `technology blog`_.
 
-Each package added to Bioconda also has a corresponding Docker  `BioContainer
-<https://biocontainers.pro>`_ automatically created and uploaded to Quay.io.
+.. _`technology blog`: http://blogs.nature.com/naturejobs/2017/11/03/techblog-bioconda-promises-to-ease-bioinformatics-software-installation-woes
+
+Each package added to Bioconda also has a corresponding Docker
+`BioContainer`_ automatically created and uploaded to `Quay.io`_. A
+list of these and other containers can be found at the `Biocontainers
+Registry`_.
+
+.. _`BioContainer`: https://biocontainers.pro
+.. _`Quay.io`: https://quay.io/organization/biocontainers
+.. _`BioContainers Registry`: https://biocontainers.pro/#/registry
 
 **Browse packages in the Bioconda channel:** :ref:`recipes`
-
-**Browse BioContainer packages:** `Biocontainers Registry UI
-<https://biocontainers.pro/#/registry>`_
 
 ----
 
@@ -89,8 +94,8 @@ other channels bioconda depends on. **It is important to add them in this
 order** so that the priority is set correctly (that is, conda-forge is highest
 priority).
 
-The `conda-forge` channel contains many general-purpose packages not already
-found in the `defaults` channel.
+The `conda-forge`_ channel contains many general-purpose packages not already
+found in the ``defaults`` channel.
 
 
 ::
@@ -98,6 +103,9 @@ found in the `defaults` channel.
     conda config --add channels defaults
     conda config --add channels bioconda
     conda config --add channels conda-forge
+
+.. _`conda-forge`: https://conda-forge.org
+
 
 3. Install packages
 -------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,26 +1,31 @@
 .. image:: bioconda.png
 
 **Bioconda** is a channel for the `conda
-<http://conda.pydata.org/docs/intro.html>`_  package manager specializing in
-bioinformatics software. Bioconda consists of:
+<http://conda.pydata.org/docs/intro.html>`_ package manager
+specializing in bioinformatics software. Bioconda consists of:
 
-- a `repository of recipes <https://github.com/bioconda/bioconda-recipes>`_ hosted on GitHub
-- a `build system <https://github.com/bioconda/bioconda-utils>`_ that turns these recipes into conda packages
+- a `repository of recipes
+  <https://github.com/bioconda/bioconda-recipes>`_ hosted on GitHub
+- a `build system <https://github.com/bioconda/bioconda-utils>`_ that
+  turns these recipes into conda packages
 - a `repository of more than 6000 bioinformatics packages
-  <https://anaconda.org/bioconda/>`_ ready to use with ``conda install``
-- over 600 contributors and 450 members who add, modify, update and maintain the recipes
+  <https://anaconda.org/bioconda/>`_ ready to use with ``conda
+  install``
+- over 600 contributors and 450 members who add, modify, update and
+  maintain the recipes
 
 The conda package manager makes installing software a vastly more
-streamlined process. Conda is a combination of other package managers you may
-have encountered, such as pip, CPAN, CRAN, Bioconductor, apt-get, and homebrew.
-Conda is both language- and OS-agnostic, and can be used to install C/C++,
-Fortran, Go, R, Python, Java etc programs on Linux, Mac OSX, and Windows.
+streamlined process. Conda is a combination of other package managers
+you may have encountered, such as pip, CPAN, CRAN, Bioconductor,
+apt-get, and homebrew.  Conda is both language- and OS-agnostic, and
+can be used to install C/C++, Fortran, Go, R, Python, Java etc
+programs on Linux, Mac OSX, and Windows.
 
 Conda allows separation of packages into repositories, or `channels`.
-The main `defaults` channel has a large number of common packages. Users can
-add additional channels from which to install software packages not available
-in the defaults channel. Bioconda is one such channel specializing in
-bioinformatics software.
+The main `defaults` channel has a large number of common
+packages. Users can add additional channels from which to install
+software packages not available in the defaults channel. Bioconda is
+one such channel specializing in bioinformatics software.
 
 When using Bioconda please **cite our article**:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -171,3 +171,4 @@ Contents:
     faqs
     build-system
     cb3
+    developer

--- a/docs/source/linting.rst
+++ b/docs/source/linting.rst
@@ -39,9 +39,9 @@ locally like this without having to make a commit::
 Skipping persistently on a per-recipe basis
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Sometimes a recipe will always fail linting. For example, in rare cases the
-source for a recipe may only be available as a `git_url` or may require
-`setuptools` as a runtime dependency. In these cases, add an `extra:
-skip-lints` list to the ``meta.yaml`` indicating which lints should be
+source for a recipe may only be available as a ``git_url`` or may require
+`setuptools` as a runtime dependency. In these cases, add an ``extra:
+skip-lints`` list to the ``meta.yaml`` indicating which lints should be
 skipped, for example::
 
     extra:
@@ -54,7 +54,7 @@ skipped, for example::
 Recipes duplicated in conda-forge
 ---------------------------------
 
-Sometimes when adding or updating a recipe in a pull request to `conda-forge`
+Sometimes when adding or updating a recipe in a pull request to ``conda-forge``
 the conda-forge linter will warn that a recipe with the same name already
 exists in bioconda. When this happens, usually the best thing to do is:
 
@@ -67,8 +67,8 @@ exists in bioconda. When this happens, usually the best thing to do is:
 Linting functions
 -----------------
 
-`in_other_channels`
-~~~~~~~~~~~~~~~~~~~
+``in_other_channels``
+~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The package exists in another dependent channel (currently
 conda-forge and defaults). This often happens when a general-use package
 was added to bioconda first but was subsequently added to one of the more
@@ -83,8 +83,8 @@ a bioconda-specific patch is required. However it is almost always better to
 fix or update the recipe in the other channel. Note that the package in the
 bioconda channel will remain in order to maintain reproducibility.
 
-`already_in_bioconda`
-~~~~~~~~~~~~~~~~~~~~~
+``already_in_bioconda``
+~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The current package version, build, and platform
 (linux/osx) already exists in the bioconda channel.
 
@@ -95,8 +95,8 @@ How to resolve: Increase the version number or `build number
 <https://conda.io/docs/building/meta-yaml.html#build-number-and-string>`_ as
 appropriate.
 
-`missing_home`
-~~~~~~~~~~~~~~
+``missing_home``
+~~~~~~~~~~~~~~~~
 Reason for failing: No homepage URL.
 
 Rationale: We want to make sure users can get additional information about
@@ -107,8 +107,8 @@ homepage is an unambiguous original source.
 How to resolve: Add the url in the `about section
 <https://conda.io/docs/building/meta-yaml.html#about-section>`_.
 
-`missing_summary`
-~~~~~~~~~~~~~~~~~
+``missing_summary``
+~~~~~~~~~~~~~~~~~~~
 Reason for failing: Missing a summary.
 
 Rationale: We want to provide a minimal amount of information about the
@@ -117,8 +117,8 @@ package.
 How to resolve: add a short descriptive summary in the `about
 section <https://conda.io/docs/building/meta-yaml.html#about-section>`_.
 
-`missing_license`
-~~~~~~~~~~~~~~~~~
+``missing_license``
+~~~~~~~~~~~~~~~~~~~
 Reason for failing: No license provided.
 
 Rationale: We need to ensure that adding the package to bioconda does not
@@ -128,8 +128,8 @@ How to resolve: Add the license in the `about section
 <https://conda.io/docs/building/meta-yaml.html#about-section>`_. There are some
 ways of accommodating some licenses; see the GATK package for one method.
 
-`missing_tests`
-~~~~~~~~~~~~~~~
+``missing_tests``
+~~~~~~~~~~~~~~~~~
 Reason for failing: No tests provided.
 
 Rationale: We need at least minimal tests to ensure the programs can be found
@@ -138,8 +138,8 @@ on the path to catch basic installation errors.
 How to resolve: Add basic tests to ensure the software gets installed; see
 :ref:`tests` for more info.
 
-`missing_hash`
-~~~~~~~~~~~~~~
+``missing_hash``
+~~~~~~~~~~~~~~~~
 Reason for failing: Missing a hash in the source section.
 
 Rationale: Hashes ensure that the source is downloaded correctly without being
@@ -149,8 +149,8 @@ How to resolve: Add a hash in the `source section
 <https://conda.io/docs/building/meta-yaml.html#source-section>`_. See
 :ref:`hashes` for more info.
 
-`should_be_noarch`
-~~~~~~~~~~~~~~~~~~
+``should_be_noarch``
+~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The package should be labelled as ``noarch``.
 
 Rationale: A ``noarch`` package should be created for pure Python packages,
@@ -167,8 +167,8 @@ generic packages (like a data package), add ``noarch: generic`` to the
 <https://www.continuum.io/blog/developer-blog/condas-new-noarch-packages>`_ for
 more details.
 
-`should_not_be_noarch`
-~~~~~~~~~~~~~~~~~~~~~~
+``should_not_be_noarch``
+~~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The package should **not** be labelled as ``noarch``.
 
 Rationale: The package defines gcc as a dependency, or it contains a build/skip
@@ -179,8 +179,8 @@ Python versions. This is typically not the case if you skip a Python version.
 
 How to resolve: Remove the ``noarch`` statement.
 
-`uses_git_url`
-~~~~~~~~~~~~~~
+``uses_git_url``
+~~~~~~~~~~~~~~~~
 Reason for failing: The source section uses a git URL.
 
 Rationale: While this is supported by conda, we prefer
@@ -192,8 +192,8 @@ How to resolve: Use a direct URL. Ideally a github repo should have tagged
 releases that are accessible as tarballs from the "releases" section of the
 github repo.
 
-`uses_perl_threaded`
-~~~~~~~~~~~~~~~~~~~~
+``uses_perl_threaded``
+~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The recipe has a dependency of ``perl-threaded``.
 
 Rationale: Previously bioconda used ``perl-threaded`` as a dependency for Perl
@@ -202,8 +202,8 @@ is updated, it will fail this check.
 
 How to resolve: Change ``perl-threaded`` to ``perl``.
 
-`uses_javajdk`
-~~~~~~~~~~~~~~
+``uses_javajdk``
+~~~~~~~~~~~~~~~~
 Reason for failing: The recipe has a dependency of ``java-jdk``.
 
 Rationale: Previously bioconda used ``java-jdk`` as a dependency for Java
@@ -212,8 +212,8 @@ recipes is updated, it will fail this check.
 
 How to resolve: Change ``java-jdk`` to ``openjdk``.
 
-`uses_setuptools` (currently disabled)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``uses_setuptools`` (currently disabled)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The recipe has ``setuptools`` as a run dependency.
 
 Rationale: ``setuptools`` is typically used to install dependencies for Python
@@ -229,8 +229,8 @@ To avoid this, make sure to carry ``console_scripts`` entry points from
 ``setup.py`` over to ``meta.yaml`` to replace them with scripts created by
 ``conda``/``conda-build`` which don't require ``pkg_resources``.
 
-`has_windows_bat_file`
-~~~~~~~~~~~~~~~~~~~~~~
+``has_windows_bat_file``
+~~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The recipe includes a ``.bat`` file.
 
 Rationale: Often when using one of the skeleton commands (``conda skeleton
@@ -240,8 +240,8 @@ clutter we try to remove them.
 
 How to resolve: Remove the ``.bat`` file from the recipe.
 
-`setup_py_install_args`
-~~~~~~~~~~~~~~~~~~~~~~~
+``setup_py_install_args``
+~~~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The recipe has ``setuptools`` as a build dependency, but
 ``build.sh`` needs to use certain arguments when running ``setup.py``.
 
@@ -260,8 +260,8 @@ to::
 
     $PYTHON setup.py install --single-version-externally-managed --record=record.txt
 
-`invalid_identifiers`
-~~~~~~~~~~~~~~~~~~~~~
+``invalid_identifiers``
+~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The recipe has an ``extra -> identifiers`` section with an
 invalid format.
 
@@ -278,8 +278,8 @@ In particular, ensure that each identifier starts with a type
 (`doi`, `biotools`, ...), followed by a colon and the identifier.
 Whitespace is not allowed.
 
-`deprecated_numpy_spec`
-~~~~~~~~~~~~~~~~~~~~~~~
+``deprecated_numpy_spec``
+~~~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The recipe contains ``numpy x.x`` in build or run requirements.
 
 Rationale: This kind of version pinning is deprecated, and numpy pinning is now
@@ -287,16 +287,16 @@ handled automatically by the system.
 
 How to resolve: Remove the ``x.x``.
 
-`should_not_use_fn`
-~~~~~~~~~~~~~~~~~~~
+``should_not_use_fn``
+~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: Recipe contains a ``fn:`` key in the ``source:`` section
 
 Rationale: Conda-build 3 no longer requres ``fn:``, and it is redundant with ``url:``.
 
 How to resolve: Remove the ``source: fn:`` key.
 
-`should_use_compilers`
-~~~~~~~~~~~~~~~~~~~~~~
+``should_use_compilers``
+~~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: The recipe has one of ``gcc``, ``llvm``, ``libgfortran``, or ``libgcc`` as dependencies.
 
 Rationale: Conda-build 3 now uses compiler tools, which are more up-to-date and
@@ -304,8 +304,8 @@ better-supported.
 
 How to resolve: Use ``{{ compiler() }}`` variables. See :ref:`compiler-tools` for details.
 
-`compilers_must_be_in_build`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``compilers_must_be_in_build``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Reason for failing: A ``{{ compiler() }}`` varaiable was found, but not in the ``build:`` section.
 
 Rational: The compiler tools must not be in ``host:`` or ``run:`` sections.
@@ -314,8 +314,8 @@ How to resolve: Move ``{{ compiler() }}`` variables to the ``build:`` section.
 
 
 ..
-    `bioconductor_37`
-    ~~~~~~~~~~~~~~~~~
+    ``bioconductor_37``
+    ~~~~~~~~~~~~~~~~~~~
     Reason for failing: The recipe specifies Bioconductor 3.7 or "release".
 
     Rationale: We cannot update Bioconductor packages yet -- see `#8947
@@ -331,16 +331,16 @@ For developers adding new linting functions:
 Lint functions are defined in ``bioconda_utils.lint_functions``. Each function
 accepts three arguments:
 
-- `recipe`, the path to the recipe
-- `meta`, the meta.yaml file parsed into a dictionary
-- `df`, a dataframe channel info, typically as returned from
-  `linting.channel_dataframe` and is expected to have the following columns:
+- ``recipe``, the path to the recipe
+- ``meta``, the meta.yaml file parsed into a dictionary
+- ``df``, a dataframe channel info, typically as returned from
+  ``linting.channel_dataframe`` and is expected to have the following columns:
   [build, build_number, name, version, license, platform, channel].
 
-We need `recipe` because some lint functions check files (e.g.,
-`has_windows_bat_file`). We need `meta` because even though we can parse it
-from `recipe` within each lint function, it's faster if we parse the meta.yaml
-once and pass it to many lint functions. We need `df` because we need channel
+We need ``recipe`` because some lint functions check files (e.g.,
+`has_windows_bat_file`). We need ``meta`` because even though we can parse it
+from ``recipe`` within each lint function, it's faster if we parse the meta.yaml
+once and pass it to many lint functions. We need ``df`` because we need channel
 info to figure out if a version or build number needs to be bumped relative to
 what's already in the channel.
 

--- a/docs/source/linting.rst
+++ b/docs/source/linting.rst
@@ -275,7 +275,7 @@ How to resolve: Ensure that the section is of the following format::
         - biotools:Snakemake
 
 In particular, ensure that each identifier starts with a type
-(`doi`, `biotools`, ...), followed by a colon and the identifier.
+(``doi``, ``biotools``, ...), followed by a colon and the identifier.
 Whitespace is not allowed.
 
 ``deprecated_numpy_spec``
@@ -338,7 +338,7 @@ accepts three arguments:
   [build, build_number, name, version, license, platform, channel].
 
 We need ``recipe`` because some lint functions check files (e.g.,
-`has_windows_bat_file`). We need ``meta`` because even though we can parse it
+``has_windows_bat_file``). We need ``meta`` because even though we can parse it
 from ``recipe`` within each lint function, it's faster if we parse the meta.yaml
 once and pass it to many lint functions. We need ``df`` because we need channel
 info to figure out if a version or build number needs to be bumped relative to

--- a/docs/source/static/style.css
+++ b/docs/source/static/style.css
@@ -56,3 +56,34 @@ a.conda-package::after {
 .field-list li:last-child:after {
     content: "";         /* except for the last item */
 }
+
+/* Corner Ribbon
+   Based on
+   http://unindented.org/articles/2009/10/github-ribbon-using-css-transforms/
+*/
+.git-ribbon {
+    background-color: #2cbe4e;
+    overflow: hidden;
+    /* top left corner of screen */
+    position: fixed;
+    left: -3em;
+    top: 2.5em;
+    /* 45 deg ccw rotation */
+    -moz-transform: rotate(-45deg);
+    -webkit-transform: rotate(-45deg);
+    /* shadow */
+    -moz-box-shadow: 0 0 1em #888;
+    -webkit-box-shadow: 0 0 1em #888;
+}
+.git-ribbon a {
+    border: 1px solid #faa;
+    color: #fff;
+    display: block;
+    font: bold 81.25% 'Helvetiva Neue', Helvetica, Arial, sans-serif;
+    margin: 0.05em 0 0.075em 0;
+    padding: 0.5em 3.5em;
+    text-align: center;
+    text-decoration: none;
+    /* shadow */
+    text-shadow: 0 0 0.5em #444;
+}

--- a/docs/source/static/style.css
+++ b/docs/source/static/style.css
@@ -41,20 +41,23 @@ a.conda-package::after {
 }
 
 /* Style field lists as comma separated block */
-.field-list ul {
+.field-list-wrapped ul {
     list-style: none;    /* no bullets */
     display: inline;     /* as word wrapped block */
     padding-left: 0px;   /* no indent */
 }
-.field-list li {
+.field-list-wrapped li {
     display: inline;     /* as word wrapped block */
     white-space: nowrap; /* no line breaks inside of list item */
 }
-.field-list li::after {
+.field-list-wrapped li::after {
     content: ", ";       /* add comma after each list item ... */
 }
-.field-list li:last-child:after {
+.field-list-wrapped li:last-child:after {
     content: "";         /* except for the last item */
+}
+.field-list-wrapped p {
+    display: inline;    /* as word wrapped block, even if sphinx/docutils emit p */
 }
 
 /* Corner Ribbon

--- a/docs/source/templates/layout.html
+++ b/docs/source/templates/layout.html
@@ -21,6 +21,14 @@
 
     <link rel="manifest" href="/manifest.json">
     <meta name="theme-color" content="#ffffff">
-    {{ super() }}
+{{ super() }}
 {% endblock %}
 
+{% block footer -%}
+    {{ super() }}
+{%- if git_edit_url -%}
+    <div class="git-ribbon">
+      <a href="{{git_ribbon_url}}" rel="me">{{git_ribbon_message}}</a>
+    </div>
+{%- endif -%}
+{%- endblock %}

--- a/docs/source/templates/layout.html
+++ b/docs/source/templates/layout.html
@@ -26,7 +26,7 @@
 
 {% block footer -%}
     {{ super() }}
-{%- if git_edit_url -%}
+{%- if git_ribbon_url -%}
     <div class="git-ribbon">
       <a href="{{git_ribbon_url}}" rel="me">{{git_ribbon_message}}</a>
     </div>

--- a/docs/source/templates/readme.rst_t
+++ b/docs/source/templates/readme.rst_t
@@ -36,7 +36,7 @@
    :versions: {{ package.versions | join(", ") }}
    {% for dependency in package.depends %}
    :depends {{dependency[0]}}: {{dependency[1]}}
-   {% endfor %}
+   {%- endfor %}
    :requirements:
 
    .. rubric:: Installation

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -77,7 +77,7 @@ ZLIB errors
 When building the package, you may get an error saying that zlib.h
 can't be found -- despite having zlib listed in the dependencies. The
 reason is that the location of :conda:package:`zlib` often has to be
-specified in the `build.sh` script, which can be done like this:
+specified in the ``build.sh`` script, which can be done like this:
 
 .. code-block:: bash
 
@@ -90,10 +90,11 @@ Or sometimes:
 
     export CPATH=${PREFIX}/include
 
-Sometimes Makefiles may specify these locations, in which case they need to be
-edited. See the `samtools` recipe for an example of this. It may take some
-tinkering to get the recipe to build; if it doesn't seem to work then please
-submit an issue or notify ``@bioconda/core`` for advice.
+Sometimes Makefiles may specify these locations, in which case they
+need to be edited. See the `samtools recipe` recipe for an
+example of this. It may take some tinkering to get the recipe to
+build; if it doesn't seem to work then please submit an issue or
+notify ``@bioconda/core`` for advice.
 
 .. _perl-or-python-not-found:
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -113,9 +113,9 @@ Here is an example that will replace the first line of a file
 It turns out that the version of `autoconf` that is packaged in the defaults
 channel still uses the hard-coded Perl. So if a tool uses `autoconf` for
 building, it is likely you will see this error and it will need some ``sed``
-commands. See `here
-<https://github.com/bioconda/bioconda-recipes/blob/4bc02d7b4d784c923481d8808ed83e048c01d3bb/recipes/exparna/build.sh>`_
-for an example to work from.
+commands. See `recipes/exparna/build.sh`_ for an example to work from.
+
+.. _`recipes/exparna/build.sh`: https://github.com/bioconda/bioconda-recipes/blob/4bc02d7b4d784c923481d8808ed83e048c01d3bb/recipes/exparna/build.sh
 
 .. _mulled-build-troubleshooting:
 
@@ -152,12 +152,12 @@ should only be used as a last resort. Cases where the extended base has been
 needed are:
 
 - Unicode support is required (especially if a package uses the ``click``
-  Python package under Python 3; see for example comments `here
-  <https://github.com/bioconda/bioconda-recipes/pull/5541#issuecomment-323755800>`_
-  and `here
-  <https://github.com/bioconda/bioconda-recipes/pull/6094#issuecomment-332272936>`_).
+  Python package under Python 3; see for example comments in `PR #5541`_ and `PR #6094`_).
 - ``libGL.so.1`` dependency
 - ``openssl`` dependency, e.g., through ``openmpi``
+
+.. _`PR #5541`: https://github.com/bioconda/bioconda-recipes/pull/5541#issuecomment-323755800
+.. _`PR #6094`: https://github.com/bioconda/bioconda-recipes/pull/6094#issuecomment-332272936
 
 To use the extended container, add the following to a recipe's ``meta.yaml``:
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -4,10 +4,10 @@ Troubleshooting failed recipes
 
 Reading bioconda-utils logs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-For failed recipes, usually the easiest thing to do is find the first `BIOCONDA
-ERROR`, and start reading the output below that line. The stdout and stderr for
-that failed build will end with the next `BIOCONDA` log line, likely
-a `BIOCONDA BUILD START` or `BIOCONDA BUILD SUMMARY` line.
+For failed recipes, usually the easiest thing to do is find the first ``BIOCONDA
+ERROR``, and start reading the output below that line. The stdout and stderr for
+that failed build will end with the next ``BIOCONDA`` log line, likely
+a ``BIOCONDA BUILD START`` or ``BIOCONDA BUILD SUMMARY`` line.
 Note that there are two tests: the tests performed by conda in the main
 environment, and if they pass, the mulled-build tests performed in a minimal
 docker container. For working with failures in mulled-build tests, see
@@ -73,10 +73,11 @@ then change it to this:
 
 ZLIB errors
 ~~~~~~~~~~~
-When building the package, you may get an error saying that zlib.h can't be
-found -- despite having zlib listed in the dependencies. The reason is that the
-location of `zlib` often has to be specified in the `build.sh` script, which
-can be done like this:
+
+When building the package, you may get an error saying that zlib.h
+can't be found -- despite having zlib listed in the dependencies. The
+reason is that the location of :conda:package:`zlib` often has to be
+specified in the `build.sh` script, which can be done like this:
 
 .. code-block:: bash
 
@@ -92,7 +93,7 @@ Or sometimes:
 Sometimes Makefiles may specify these locations, in which case they need to be
 edited. See the `samtools` recipe for an example of this. It may take some
 tinkering to get the recipe to build; if it doesn't seem to work then please
-submit an issue or notify `@bioconda/core` for advice.
+submit an issue or notify ``@bioconda/core`` for advice.
 
 .. _perl-or-python-not-found:
 

--- a/docs/source/updating.rst
+++ b/docs/source/updating.rst
@@ -25,7 +25,7 @@ additionally submit a pull request on your behalf:
       --create-pr
 
 By default, subrecipes  will be ignored for updating unless
-they specifically have the following in their `extra` block:
+they specifically have the following in their ``extra`` block:
 
 .. code-block:: yaml
 
@@ -33,9 +33,9 @@ they specifically have the following in their `extra` block:
       watch:
         enable: yes
 
-E.g., `packagename/meta.yaml` is the main recipe, and
-`packagename/0.5/meta.yaml` is a subrecipe. So `packagename/0.5/meta.yaml`
-needs the above `extra` block if it should ever be automatically updated.
+E.g., ``packagename/meta.yaml`` is the main recipe, and
+``packagename/0.5/meta.yaml`` is a subrecipe. So ``packagename/0.5/meta.yaml``
+needs the above ``extra`` block if it should ever be automatically updated.
 
 
 How it works
@@ -48,7 +48,7 @@ inner workings.
 The components
 ~~~~~~~~~~~~~~
 
-The `bioconda_utils.update.Recipe` object contains logic for finding and
+The `bioconda_utils.recipe.Recipe` object contains logic for finding and
 replacing text that may contain version information (such as within ``package:``
 and ``source:`` sections or Jinja set statements), for resetting build numbers,
 and for reading and writing recipes. Notably, reading and writing recipes here
@@ -62,9 +62,9 @@ handles other things like retrying after increasingly longer wait times when it
 encounters non-permanent HTTP errors.
 
 Subclasses of `bioconda_utils.update.Filter` are added to the scanner. They
-contain logic in their `apply` method. This method at least takes a recipe as
+contain logic in their ``apply`` method. This method at least takes a recipe as
 the first argument, and either returns a (possibly modified) recipe or raises
-a custom exception. The remainder of the `apply` function can do arbitrarily
+a custom exception. The remainder of the ``apply`` function can do arbitrarily
 complicated things, and will do so in the asyncio loop.
 
 Subclasses of `bioconda_utils.hosters.Hoster` use regular expressions to detect
@@ -76,7 +76,7 @@ Writing a filter
 ~~~~~~~~~~~~~~~~
 To add additional functionality to the scanner, create a filter in
 `bioconda_utils.update` and add it to the scanner in
-`bioconda_utils.cli.update()`. There are existing filters to exclude recipes
+`bioconda_utils.cli.autobump()`. There are existing filters to exclude recipes
 based on blacklist or subrecipe status, update a recipe based on the latest
 version found by a `Hoster` (see below), update checksums, figure out where to
 load a recipe from (i.e. master branch or an existing PR), create a new PR, and
@@ -107,7 +107,7 @@ be used to scan against existing recipes.
 
 Adding an attribute to the class with the suffix  ``_pattern`` allows the
 regular expression stored in that attribute to be subsituted into other regular
-expressions using `{placeholder}` format placeholders.
+expressions using ``{placeholder}`` format placeholders.
 
 Take, for example, the `Bioconductor` hoster which is commented here for
 explanation purposes:
@@ -155,7 +155,7 @@ To tie this all together:
   filter added, and because an `UpdateVersion` filter will check a recipe
   against all configured hosters, a Bioconductor recipe will match the above
   `url_pattern` for the `Bioconductor` hoster.
-- The hoster object will go to the site specified by `releases_format` and
+- The hoster object will go to the site specified by ``releases_format`` and
   scrape links that match `link_pattern`.
 - The `UpdateVersion` filter will inspect those links found by the hoster,
   figure out which is the most recent, and see if the existing recipe is


### PR DESCRIPTION
- adds API docs for `bioconda-utils`
  - plenty of docstrings repaired, but it's not pretty yet
  - confine some recipe CSS to avoid breaking autodoc styles
- adds `conda`, `conda-build` and `conda.io` to intersphinx list, making their references accessible
- adds **Edit me on GitHub** Ribbon with routing to the right source files (fixes #460)
- fixes for parallel docs build
- lots of rST vs MD bugs fixed - mostly single-backtick vs double-backtick problems.
