### PR TITLE
Docs update

### DIFF
--- a/.circleci/build-docs.sh
+++ b/.circleci/build-docs.sh
@@ -58,7 +58,7 @@ rm -r *
 
 # build docs and copy over to tmpdir
 cd ${DOCSOURCE}
-make clean html SPHINXOPTS="-T -j2" 2>&1 | grep -v "WARNING: nonlocal image URL found:"
+make clean html SPHINXOPTS="-T -j1" 2>&1 | grep -v "WARNING: nonlocal image URL found:"
 cp -r ${DOCHTML}/* $STAGING
 
 # add README.md

--- a/bioconda_utils/__init__.py
+++ b/bioconda_utils/__init__.py
@@ -30,6 +30,7 @@ Bioconda Utilities Package
    linting
    pkg_test
    recipe
+   sphinxext
    update
    update_pinnings
    upload

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -10,15 +10,15 @@ networkx=1.11
 pyaml=17.12.*
 requests=2.20.*
 sphinx
+sphinx-autodoc-typehints
+alabaster=0.7.*
 docutils
-sphinx_rtd_theme
 involucro=1.1.*
 pandas=0.23.*
 numpy=1.15.*
 pygithub=1.34.*
 colorlog=3.1.*
 six=1.11.*
-alabaster=0.7.*
 git=2.14.*
 conda-forge-pinning=2019.03.04
 python>=3.6

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -399,7 +399,7 @@ class BioCProjectPage(object):
     @property
     def cached_tarball(self):
         """
-        Downloads the tarball to the `cached_bioconductor_tarballs` dir if one
+        Downloads the tarball to the ``cached_bioconductor_tarballs`` dir if one
         hasn't already been downloaded for this package.
 
         This is because we need the whole tarball to determine which compilers
@@ -671,9 +671,9 @@ class BioCProjectPage(object):
 
     def pacified_description(self):
         """
-        Linting will fail if GIT_, HG_, or SVN_ appear in the description.
+        Linting will fail if ``GIT_``, ``HG_``, or ``SVN_`` appear in the description.
         This usually isn't an issue, except some microarray annotation packages
-        include HG_ in their summaries. The goal is to simply remove _ in such
+        include ``HG_`` in their summaries. The goal is to simply remove ``_`` in such
         cases.
         """
         description = self.packages[self.package]['Description']
@@ -695,11 +695,11 @@ class BioCProjectPage(object):
 
         However pyaml does not support comments, but if there are gcc and llvm
         dependencies then they need to be added with preprocessing selectors
-        for `# [linux]` and `# [osx]`.
+        for ``# [linux]`` and ``# [osx]``.
 
         We do this with a unique placeholder (not a jinja or $-based
         string.Template) so as to avoid conflicting with the conda jinja
-        templating or the `$R` in the test commands, and replace the text once
+        templating or the ``$R`` in the test commands, and replace the text once
         the yaml is written.
         """
 

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -241,8 +241,8 @@ class RecipeBuilder(object):
             Specify where packages should appear on the host.
 
             If **pkg_dir** is None, then a temporary directory will be
-            created once for each RecipeBuilder instance and that directory
-            will be used for each call to `RecipeBuilder.build()`. This allows
+            created once for each `RecipeBuilder` instance and that directory
+            will be used for each call to `RecipeBuilder.build_recipe()`. This allows
             subsequent recipes built by the container to see previous built
             recipes without polluting the host's conda-bld directory.
 
@@ -445,7 +445,7 @@ class RecipeBuilder(object):
             Path to recipe that contains meta.yaml
 
         build_args : str
-            Additional arguments to `conda build`. For example --channel,
+            Additional arguments to ``conda build``. For example --channel,
             --skip-existing, etc
 
         env : dict

--- a/bioconda_utils/githandler.py
+++ b/bioconda_utils/githandler.py
@@ -368,8 +368,18 @@ class GitHandler(GitHandlerBase):
                  dry_run=False,
                  home='bioconda/bioconda-recipes',
                  fork=None,
-                 allow_dirty=True) -> None:
-        repo = git.Repo(folder, search_parent_directories=True)
+                 allow_dirty=True,
+                 depth=1) -> None:
+        if os.path.exists(folder):
+            repo = git.Repo(folder, search_parent_directories=True)
+        else:
+            try:
+                os.mkdir(folder)
+                logger.error("cloning %s into %s", home, folder)
+                repo = git.Repo.clone_from(home, folder, depth=depth)
+            except git.GitCommandError:
+                os.rmdir(folder)
+                raise
         super().__init__(repo, dry_run, home, fork, allow_dirty)
 
         #: Branch to restore after running

--- a/bioconda_utils/sphinxext.py
+++ b/bioconda_utils/sphinxext.py
@@ -680,6 +680,26 @@ def generate_recipes(app):
 
 
 def add_ribbon(app, pagename, templatename, context, doctree):
+    """Adds "Edit me on GitHub" Ribbon to pages
+
+    This hooks into ``html-page-context`` event and adds the parameters
+    ``git_ribbon_url`` and ``git_ribbon_message`` to the context from
+    which the HTML templates (``layout.html``) are expanded.
+
+    It understands three types of pages:
+
+    - ``_autosummary`` and ``_modules`` prefixed pages are assumed to
+      be code and link to the ``bioconda-utils`` repo
+    - ``recipes/*/README`` pages are assumed to be recipes and link
+      to the ``meta.yaml``
+    - all others are assumed to be RST docs and link to the ``docs/source/``
+      folder in ``bioconda-utils``
+
+    TODO:
+      Fix hardcoding of values, should be a mapping that comes from
+      ``conf.py``.
+
+    """
     if templatename != 'page.html':
         return
     if pagename.startswith('_autosummary') or pagename.startswith('_modules'):
@@ -698,7 +718,6 @@ def add_ribbon(app, pagename, templatename, context, doctree):
     context['git_ribbon_message'] = "Edit me on GitHub"
 
 
-
 def setup(app):
     """Set up sphinx extension"""
     app.add_domain(CondaDomain)
@@ -711,7 +730,7 @@ def setup(app):
     app.add_config_value('bioconda_config_file', 'config.yml', 'env')
     app.add_config_value('bioconda_other_channels', {}, 'env')
     return {
-        'version': "0.0.0",
+        'version': "0.0.1",
         'parallel_read_safe': True,
         'parallel_write_safe': True
     }

--- a/bioconda_utils/sphinxext.py
+++ b/bioconda_utils/sphinxext.py
@@ -421,7 +421,14 @@ class CondaDomain(Domain):
         for key  in to_remove:
             del self.data['objects'][key]
 
-
+    def resolve_any_xref(self, env: BuildEnvironment, fromdocname: str,
+                         builder, target, node, contnode):
+        """Resolve references from "any" role."""
+        res = self.resolve_xref(env, fromdocname, builder, 'package', target, node, contnode)
+        if res:
+            return [('conda:package', res)]
+        else:
+            return []
 
     def resolve_xref(self, env: BuildEnvironment, fromdocname: str,
                      builder, role, target, node, contnode):

--- a/bioconda_utils/sphinxext.py
+++ b/bioconda_utils/sphinxext.py
@@ -392,7 +392,7 @@ class CondaDomain(Domain):
     object_types = {
         # ObjType(name, *roles, **attrs)
         'recipe': ObjType('recipe', 'recipe'),
-        'package': ObjType('package', 'package'),
+        'package': ObjType('package', 'package', 'depends'),
     }
     directives = {
         'recipe': CondaRecipe,
@@ -421,30 +421,12 @@ class CondaDomain(Domain):
         for key  in to_remove:
             del self.data['objects'][key]
 
+
+
     def resolve_xref(self, env: BuildEnvironment, fromdocname: str,
-                     builder, typ, target, node, contnode):
-        # docs copied from Domain class
-        """Resolve the pending_xref *node* with the given *typ* and *target*.
-
-        This method should return a new node, to replace the xref node,
-        containing the *contnode* which is the markup content of the
-        cross-reference.
-
-        If no resolution can be found, None can be returned; the xref node will
-        then given to the :event:`missing-reference` event, and if that yields no
-        resolution, replaced by *contnode*.
-
-        The method can also raise :exc:`sphinx.environment.NoUri` to suppress
-        the :event:`missing-reference` event being emitted.
-        """
-        if typ == 'depends':
-            # 'depends' role is handled just like a 'package' here (resolves the same)
-            typ = 'package'
-        elif typ == 'requiredby':
-            # 'requiredby' role type is deferred to missing_references stage
-            return None
-
-        for objtype in self.objtypes_for_role(typ):
+                     builder, role, target, node, contnode):
+        """Resolve the ``pending_xref`` **node** with the given **role** and **target**."""
+        for objtype in self.objtypes_for_role(role) or []:
             if (objtype, target) in self.data['objects']:
                 node = make_refnode(
                     builder, fromdocname,

--- a/bioconda_utils/sphinxext.py
+++ b/bioconda_utils/sphinxext.py
@@ -73,7 +73,8 @@ def underline_filter(text):
     """Jinja2 filter adding =-underline to row of text
 
     >>> underline_filter("headline")
-    "headline\n========"
+    "headline\\n========"
+
     """
     return text + "\n" + "=" * len(text)
 
@@ -170,9 +171,9 @@ class Renderer:
 class RequirementsField(GroupedField):
     """Field Type for ``.. conda:package::`` for specifying dependencies
 
-    This does two things different than `GroupedField`:
+    This does two things different than ``GroupedField``:
 
-    - No `--` inserted between argument and value
+    - No ``--`` inserted between argument and value
     - Entry added to domain data ``backrefs`` so that we can
       use the requirements to collect required-by data later.
     """
@@ -200,7 +201,7 @@ class RequirementsField(GroupedField):
 class RequiredByField(Field):
     """Field Type for directive ``.. conda:package::`` for showing required-by
 
-    This just creates the field name and field body with a `pending_xref` in the
+    This just creates the field name and field body with a ``pending_xref`` in the
     body that will later be filled with the reverse dependencies by
     `resolve_required_by_xrefs`
     """
@@ -220,11 +221,11 @@ class RequiredByField(Field):
 
 def resolve_required_by_xrefs(app, env, node, contnode):
     """Now that all recipes and packages have been parsed, we are called here
-    for each `pending_xref` node that sphinx has not been able to resolve.
+    for each ``pending_xref`` node that sphinx has not been able to resolve.
 
-    We handle specifically the `requiredby` reftype created by the
-    `RequiredByField` fieldtype allowed in ``conda:package::`
-    directives, where we replace the `pendinf_ref` node with a bullet
+    We handle specifically the ``requiredby`` reftype created by the
+    `RequiredByField` fieldtype allowed in ``conda:package::``
+    directives, where we replace the ``pending_ref`` node with a bullet
     list of reference nodes pointing to the package pages that
     "depended" on the package.
     """
@@ -246,7 +247,7 @@ def resolve_required_by_xrefs(app, env, node, contnode):
 
 
 class CondaObjectDescription(ObjectDescription):
-    """Base class for `ObjectDescription`s in the `CondaDomain`"""
+    """Base class for ``ObjectDescription`` types in the `CondaDomain`"""
     typename = "[UNKNOWN]"
 
     option_spec = {
@@ -316,8 +317,8 @@ class CondaObjectDescription(ObjectDescription):
         return "{} ({})".format(name, self.objtype)
 
     def before_content(self):
-        """We register ourselves in the `ref_context` so that a later
-        call to :depends:`packagename` knows within which package
+        """We register ourselves in the ``ref_context`` so that a later
+        call to ``:depends:`packagename``` knows within which package
         the dependency was added"""
         self.env.ref_context['conda:'+self.typename] = self.names[-1]
 
@@ -334,19 +335,19 @@ class CondaPackage(CondaObjectDescription):
     This directive takes two specialized field types, ``requirements``
     and ``depends``:
 
-    ```
-    .. conda:package:: mypkg1
+    .. code:: rst
 
-       :depends mypkg2: 2.0
-       :depends mypkg3:
-       :requirements:
-    ```
+        .. conda:package:: mypkg1
 
-    `:depends pkgname: [version]`
+           :depends mypkg2: 2.0
+           :depends mypkg3:
+           :requirements:
+
+    ``:depends pkgname: [version]``
        Adds a dependency to the package.
 
-    `:requirements:`
-       Lists packages which referenced this package via `:depends pkgname:`
+    ``:requirements:``
+       Lists packages which referenced this package via ``:depends pkgname:``
 
     """
     typename = "package"
@@ -359,11 +360,14 @@ class CondaPackage(CondaObjectDescription):
 
 
 class RecipeIndex(Index):
+    """Index of Recipes"""
+
     name = "recipe_index"
     localname = "Recipe Index"
     shortname = "Recipes"
 
     def generate(self, docnames: Optional[List[str]] = None):
+        """build index"""
         content = {}
 
         objects = sorted(self.domain.data['objects'].items())
@@ -407,7 +411,6 @@ class CondaDomain(Domain):
     ]
 
     def clear_doc(self, docname: str):
-        # docs copied from Domain class
         """Remove traces of a document in the domain-specific inventories."""
         if 'objects' not in self.data:
             return
@@ -470,17 +473,14 @@ class CondaDomain(Domain):
         return None  # triggers missing-reference
 
     def get_objects(self):
-        # docs copied from Domain class
-        """Return an iterable of "object descriptions", which are tuples with
-        five items:
+        """Yields "object description" 5-tuples
 
-        * `name`     -- fully qualified name
-        * `dispname` -- name to display when searching/linking
-        * `type`     -- object type, a key in ``self.object_types``
-        * `docname`  -- the document where it is to be found
-        * `anchor`   -- the anchor name for the object
-        * `priority` -- how "important" the object is (determines placement
-          in search results)
+        ``name``:     fully qualified name
+        ``dispname``: name to display when searching/linking
+        ``type``:     object type, a key in ``self.object_types``
+        ``docname``:  the document where it is to be found
+        ``anchor``:   the anchor name for the object
+        ``priority``: search priority
 
           - 1: default priority (placed before full-text matches)
           - 0: object is important (placed before default-priority objects)
@@ -602,10 +602,13 @@ def generate_readme(recipe_basedir, output_dir, folder, repodata, renderer):
 
 
 def generate_recipes(app):
-    """
-    Go through every folder in the `bioconda-recipes/recipes` dir,
-    have a README.rst file generated and generate a recipes.rst from
-    the collected data.
+    """Generates recipe RST files
+
+    - Checks out repository
+    - Prepares `RepoData`
+    - Selects recipes (if BIOCONDA_FILTER_RECIPES in environment)
+    - Dispatches calls to `generate_readme` for each recipe
+    - Removes old RST files
     """
     source_dir = app.env.srcdir
     doctree_dir = app.env.doctreedir  # .../build/doctrees

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1260,7 +1260,7 @@ class RepoData:
             seconds = 0
 
         if self._df is None or seconds > self.cache_timeout:
-            self._df = self._load_channel_dataframe()
+            self._df = self._load_channel_dataframe_cached()
             self._df_ts = datetime.datetime.now()
         return self._df
 

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1,7 +1,7 @@
 """
 Utility Functions and Classes
 
-This module collects small pieces of code used throughout `bioconda_utils`.
+This module collects small pieces of code used throughout :py:mod:`bioconda_utils`.
 """
 import os
 import re

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -55,8 +55,6 @@ clean:
 
 .PHONY: html
 html:
-	if [ ! -e bioconda-recipes ]; then git clone --depth=1 https://github.com/bioconda/bioconda-recipes.git bioconda-recipes; fi
-	(cd bioconda-recipes && git pull origin master)
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/source/cb3.rst
+++ b/docs/source/cb3.rst
@@ -71,9 +71,8 @@ After:
 
 .. seealso::
 
-    See the `requirements section
-    <https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#requirements-section>`_
-    of the conda docs for more info.
+    See the `requirements section <conda-build:requirements>` of the
+    conda docs for more info.
 
 
 .. _compiler-tools:
@@ -141,19 +140,17 @@ After:
 
 .. seealso::
 
-    - The `compiler tools
-      <https://conda.io/docs/user-guide/tasks/build-packages/compiler-tools.html>`_
-      section of the conda docs has much more info.
+    - The `compiler tools <conda-build:compiler-tools>` section of the
+      conda docs has much more info.
 
     - The default compiler options are defined by conda-build in the
       `variants.DEFAULT_COMPILERS
       <https://github.com/conda/conda-build/blob/master/conda_build/variants.py#L42>`_
       variable.
 
-    - More details on "strong" and "weak" exports (using examples of libpng and
-      libgcc) can be found in the `export runtime requirements
-      <https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#export-runtime-requirements>`_
-      conda documentation.
+    - More details on "strong" and "weak" exports (using examples of
+      libpng and libgcc) can be found in the `export runtime
+      requirements <conda-build:run_exports>` conda documentation.
 
 
 .. warning::
@@ -197,11 +194,11 @@ is the concept of "variants". Variants are a generalized way of specifying one
 or more specific versions, and they come with many weird and wonderful ways to
 specify constraints. Specifying variants generally takes the form of writing
 a YAML file. We have adopted the variants defined by conda-forge by installing
-their ``conda-forge-pinning`` conda package in our build environment.
+their `conda-forge-pinning` conda package in our build environment.
 Technically, that package unpacks the config YAML into our conda environment so
 that it can be used for building all recipes. You can see this file at
 `conda_build_config.yaml
-<https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml>`_
+<https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml>`_.
 
 The second major advance in conda-build 3 is the the concept of "run exports".
 The idea here is to specify that any time a dependency (``zlib``, in our running example)
@@ -256,9 +253,8 @@ After:
 
 .. seealso::
 
-    The `build variants
-    <https://conda.io/docs/user-guide/tasks/build-packages/variants.html#>`_
-    section of the conda docs has much more information.
+    The `conda-build:resources/variants` section of the conda docs has
+    much more information.
 
     We share the packages pinned by conda-forge, which can be found in their
     `conda_build_config.yaml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,17 +23,18 @@ def setup(app):
 #needs_sphinx = '1.0'
 
 extensions = [
-    'generate_docs',
+    'bioconda_utils.sphinxext',
+
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
-
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
+
     'celery.contrib.sphinx',
 ]
 
@@ -302,6 +303,12 @@ extlinks = {
 # autogenerate autodoc stubs via autosummary
 autosummary_generate = True
 
-# placate assertion in utils.RepoData()
-from bioconda_utils import utils
-utils.load_config('../bioconda-recipes/config.yml')
+# Bioconda Sphinx Extension Config:
+# Git Url for repository containing recipes
+bioconda_repo_url = 'https://github.com/bioconda/bioconda-recipes.git'
+
+# Path within that repository to folder containing recipes
+# bioconda_recipes_path = 'recipes'
+
+# Path within that repository to bioconda config file
+# bioconda_config_file = 'config.yml'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -322,3 +322,8 @@ bioconda_repo_url = 'https://github.com/bioconda/bioconda-recipes.git'
 
 # Path within that repository to bioconda config file
 # bioconda_config_file = 'config.yml'
+
+# Formats for linkout to other channels
+bioconda_other_channels = {
+    'conda-forge': 'https://github.com/conda-forge/{}-feedstock'
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -292,6 +292,7 @@ intersphinx_mapping = {
     'conda.io': ('https://conda.io/en/latest', None),
     'conda-build': ('https://conda.io/projects/conda-build/en/latest/', None),
     'conda': ('https://conda.io/projects/conda/en/latest/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
 }
 
 # We are using the `extlinks` extension to render links for identifiers:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -303,6 +303,15 @@ extlinks = {
 # autogenerate autodoc stubs via autosummary
 autosummary_generate = True
 
+# combine docstrings for __init__ and class:
+autoclass_content = "both"
+
+# keep order from file (options: alphabetical, groupwise (by type), source)
+autodoc_member_order = "source"
+
+# default flags for autodoc statements
+autodoc_default_flags = ['members', 'undoc-members', 'show-inheritance']
+
 # Bioconda Sphinx Extension Config:
 # Git Url for repository containing recipes
 bioconda_repo_url = 'https://github.com/bioconda/bioconda-recipes.git'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,8 +5,6 @@ import datetime
 import os
 import sys
 
-import sphinx_rtd_theme
-
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
+    'sphinx.ext.autosectionlabel',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
@@ -300,6 +301,9 @@ extlinks = {
     'biotools': ('https://bio.tools/%s', ''),
     'doi': ('https://doi.org/%s', ''),
 }
+
+# add document name before automatic section title reference
+autosectionlabel_prefix_document = True
 
 # autogenerate autodoc stubs via autosummary
 autosummary_generate = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
-
+    'sphinx_autodoc_typehints',  # must be loaded after napoleon
     'celery.contrib.sphinx',
 ]
 

--- a/docs/source/contrib-setup.rst
+++ b/docs/source/contrib-setup.rst
@@ -61,8 +61,7 @@ installing the Circle CI client allows you to test your recipes before pushing
 them by simulating the online Circle CI tests locally. Resolving problems
 locally before pushing changes will conserve online build time and quota.
 
-Installation instructions can be found `here
-<https://circleci.com/docs/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros>`_.
+Installation instructions can be found `here <https://circleci.com/docs/2.0/local-cli>`_.
 
 .. note::
 

--- a/docs/source/contribute-a-recipe.rst
+++ b/docs/source/contribute-a-recipe.rst
@@ -33,8 +33,8 @@ Check out a new branch (here the branch is arbitrarily named "my-recipe"):
     git checkout -b my-recipe
 
 and write one or more recipes. The `conda-build docs
-<http://conda.pydata.org/docs/building/recipe.html>`_ are the authoritative
-source for information on building a recipe.
+<conda-build:index>` are the authoritative source for information on
+building a recipe.
 
 Please familiarize yourself with the :ref:`guidelines` for details on
 bioconda-specific policies.

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -40,9 +40,9 @@ users can install them with ``conda install``.
 
 .. seealso::
 
-    The `conda package specification <http://conda.pydata.org/docs/spec.html>`_
-    has details on exactly what a package contains and how it is installed into
-    an environment.
+    The `conda-build:resources/package-spec` has details on exactly
+    what a package contains and how it is installed into an
+    environment.
 
 Continuous integration (Circle CI)
 ----------------------------------

--- a/docs/source/generate_docs.py
+++ b/docs/source/generate_docs.py
@@ -5,6 +5,7 @@ This module builds the documentation for our recipes
 
 import os
 import os.path as op
+import re
 from typing import Any, Dict, List, Tuple, Optional
 
 from jinja2.sandbox import SandboxedEnvironment
@@ -615,6 +616,15 @@ def generate_recipes(app):
     repodata.df  # pylint: disable=pointless-statement
     recipes: List[Dict[str, Any]] = []
     recipe_dirs = os.listdir(RECIPE_DIR)
+
+    if 'BIOCONDA_FILTER_RECIPES' in os.environ:
+        limiter = os.environ['BIOCONDA_FILTER_RECIPES']
+        try:
+            recipe_dirs = recipe_dirs[:int(limiter)]
+        except ValueError:
+            match = re.compile(limiter)
+            recipe_dirs = [recipe for recipe in recipe_dirs
+                           if match.search(recipe)]
 
     if parallel_available and len(recipe_dirs) > 5:
         nproc = app.parallel

--- a/docs/source/guidelines.rst
+++ b/docs/source/guidelines.rst
@@ -222,8 +222,8 @@ R (CRAN)
 
 .. note::
 
-    If you have conda-build 3 installed locally and use ``conda skeleton``,
-    please see :ref:`cb3-recipes-in-cb2`.
+   The majority of R packages on CRAN are generic and should therefore be submitted
+   at Conda-Forge.
 
 .. note::
 
@@ -269,8 +269,6 @@ If the recipe was created using ``conda skeleton cran`` or the
 probably sufficient. Otherwise see the examples below to see how tests are
 performed for R packages.
 
-- typical R recipe from CRAN: `r-locfit
-  <https://github.com/bioconda/bioconda-recipes/tree/master/recipes/r-locfit>`_
 - recipe for R package not on CRAN, also with patch: `spp
   <https://github.com/bioconda/bioconda-recipes/tree/master/recipes/r-spp>`_
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -91,7 +91,7 @@ Or sometimes:
     export CPATH=${PREFIX}/include
 
 Sometimes Makefiles may specify these locations, in which case they
-need to be edited. See the `samtools recipe` recipe for an
+need to be edited. See the `samtools` recipe for an
 example of this. It may take some tinkering to get the recipe to
 build; if it doesn't seem to work then please submit an issue or
 notify ``@bioconda/core`` for advice.

--- a/docs/source/updating.rst
+++ b/docs/source/updating.rst
@@ -154,9 +154,9 @@ To tie this all together:
 - The scanner checks all recipes. Because it has the `UpdateVersion`
   filter added, and because an `UpdateVersion` filter will check a recipe
   against all configured hosters, a Bioconductor recipe will match the above
-  `url_pattern` for the `Bioconductor` hoster.
+  `Hoster.url_pattern` for the `Bioconductor` hoster.
 - The hoster object will go to the site specified by ``releases_format`` and
-  scrape links that match `link_pattern`.
+  scrape links that match `Hoster.link_pattern`.
 - The `UpdateVersion` filter will inspect those links found by the hoster,
   figure out which is the most recent, and see if the existing recipe is
   up-to-date. If a more recent link was found, use that and write the new


### PR DESCRIPTION
- adds BIOCONDA_FILTER_RECIPES to avoid rebuilding all recipe data locally
- moves `generate_docs` to `bioconda_utils.sphinxext`
- removes a bunch of constants and makes them configurable in `conf.py`
- fixes a bunch more links
- improve api docs
- autogenerate sectionlabels
- fix regression in repodata (disk cache accidentally disabled)
