### PR TITLE
Don't pass in CONDA_* env variables, they break conda 4.6

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -182,7 +182,6 @@ jinja_silent_undef = Environment(
 # Patterns of allowed environment variables that are allowed to be passed to
 # conda-build.
 ENV_VAR_WHITELIST = [
-    'CONDA_*',
     'PATH',
     'LC_*',
     'LANG',
@@ -191,7 +190,6 @@ ENV_VAR_WHITELIST = [
 
 # Of those that make it through the whitelist, remove these specific ones
 ENV_VAR_BLACKLIST = [
-    'CONDA_PREFIX',
 ]
 
 # Of those, also remove these when we're running in a docker container

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -574,7 +574,7 @@ def test_sandboxed():
     }
     with utils.sandboxed_env(env):
         print(os.environ)
-        assert os.environ('PATH') == '/foo/bar'
+        assert os.environ['PATH'] == '/foo/bar'
         assert 'CONDA_ARBITRARY_VAR' not in os.environ
         assert 'TRAVIS_ARBITRARY_VAR' not in os.environ
         assert 'GITHUB_TOKEN' not in os.environ
@@ -788,6 +788,7 @@ def test_conda_forge_pins(caplog, config_fixture):
 
     for k, v in r.recipe_dirs.items():
         for i in utils.built_package_paths(v):
+            print(os.listdir(os.path.dirname(i)))
             assert os.path.exists(i)
             ensure_missing(i)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -773,7 +773,7 @@ def test_conda_forge_pins(caplog, config_fixture):
               version: 0.1
             requirements:
               run:
-                - zlib {{ zlib }}
+                - zlib
         """, from_string=True)
     r.write_recipes()
     build_result = build.build_recipes(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -524,7 +524,7 @@ def test_rendering_sandboxing():
 
     r.write_recipes()
     env = {
-        # First one is allowed, others are not
+        # None of these should be passed to the recipe
         'CONDA_ARBITRARY_VAR': 'conda-val-here',
         'TRAVIS_ARBITRARY_VAR': 'travis-val-here',
         'GITHUB_TOKEN': 'asdf',
@@ -563,42 +563,10 @@ def test_rendering_sandboxing():
             )
         assert "'GITHUB_TOKEN' is undefined" in str(excinfo.value)
 
-    r = Recipes(
-        """
-        two:
-          meta.yaml: |
-            package:
-              name: two
-              version: 0.1
-            extra:
-              var2: {{ CONDA_ARBITRARY_VAR }}
-
-    """, from_string=True)
-    r.write_recipes()
-
-    with utils.temp_env(env):
-        pkg_paths = utils.built_package_paths(r.recipe_dirs['two'])
-        for pkg in pkg_paths:
-            ensure_missing(pkg)
-
-        build.build(
-            recipe=r.recipe_dirs['two'],
-            recipe_folder='.',
-            pkg_paths=pkg_paths,
-            mulled_test=False,
-        )
-
-        for pkg in pkg_paths:
-            t = tarfile.open(pkg)
-            tmp = tempfile.mkdtemp()
-            target = 'info/recipe/meta.yaml'
-            t.extract(target, path=tmp)
-            contents = yaml.safe_load(open(os.path.join(tmp, target)).read())
-            assert contents['extra']['var2'] == 'conda-val-here', contents
-
 
 def test_sandboxed():
     env = {
+        'PATH': '/foo/bar',
         'CONDA_ARBITRARY_VAR': 'conda-val-here',
         'TRAVIS_ARBITRARY_VAR': 'travis-val-here',
         'GITHUB_TOKEN': 'asdf',
@@ -606,7 +574,8 @@ def test_sandboxed():
     }
     with utils.sandboxed_env(env):
         print(os.environ)
-        assert os.environ['CONDA_ARBITRARY_VAR'] == 'conda-val-here'
+        assert os.environ('PATH') == '/foo/bar'
+        assert 'CONDA_ARBITRARY_VAR' not in os.environ
         assert 'TRAVIS_ARBITRARY_VAR' not in os.environ
         assert 'GITHUB_TOKEN' not in os.environ
         assert 'BUILDKITE_TOKEN' not in os.environ

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -773,7 +773,7 @@ def test_conda_forge_pins(caplog, config_fixture):
               version: 0.1
             requirements:
               run:
-                - zlib
+                - zlib {{ zlib }}
         """, from_string=True)
     r.write_recipes()
     build_result = build.build_recipes(


### PR DESCRIPTION
This should fix some issues like in #505 where people get errors like:

23:52:01 BIOCONDA ERROR STDOUT+STDERR:

```
# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/opt/conda/lib/python3.6/site-packages/conda/cli/main.py", line 138, in main
        return activator_main()
      File "/opt/conda/lib/python3.6/site-packages/conda/activate.py", line 945, in main
        print(activator.execute(), end='')
      File "/opt/conda/lib/python3.6/site-packages/conda/activate.py", line 177, in execute
        return getattr(self, self.command)()
      File "/opt/conda/lib/python3.6/site-packages/conda/activate.py", line 154, in activate
        builder_result = self.build_activate(self.env_name_or_prefix)
      File "/opt/conda/lib/python3.6/site-packages/conda/activate.py", line 279, in build_activate
        return self._build_activate_stack(env_name_or_prefix, False)
      File "/opt/conda/lib/python3.6/site-packages/conda/activate.py", line 337, in _build_activate_stack
        deactivate_scripts = self._get_deactivate_scripts(old_conda_prefix)
      File "/opt/conda/lib/python3.6/site-packages/conda/activate.py", line 605, in _get_deactivate_scripts
        prefix, 'etc', 'conda', 'deactivate.d', '*' + self.script_extension
      File "/opt/conda/lib/python3.6/posixpath.py", line 80, in join
        a = os.fspath(a)
    TypeError: expected str, bytes or os.PathLike object, not NoneType
```

The cause of this ends up being one or more `CONDA_*` environment variables that are passed into docker. Conda since version 4.6 sees some of these and tries to run activation scripts. Since the paths described in those variables will likely not exist, one ends up getting the error above. I've found locally that just `unset`ting the various CONDA_* variables solves the problem and that there seems to be more than one that triggers this.

@epruesse @daler @bgruening Do any of you know the original reason behind whitelisting `CONDA_*`?