### PR TITLE
Create our own container for mulled testing.

### DIFF
--- a/MulledDockerfile
+++ b/MulledDockerfile
@@ -1,0 +1,27 @@
+FROM debian:latest
+
+#  $ docker build -f MulledDockerfile -t bioconda/mulled_container:latest
+#  $ docker run --rm -it bioconda/mulled_container:latest /bin/bash
+#  $ docker push bioconda/mulled_container:latest
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH /opt/conda/bin:$PATH
+
+RUN apt-get update --fix-missing && \
+    apt-get install -y wget bzip2 ca-certificates curl git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc
+
+ENV TINI_VERSION v0.16.1
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+RUN chmod +x /usr/bin/tini
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/bin/bash" ]

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -17,7 +17,7 @@ from conda_build.metadata import MetaData
 logger = logging.getLogger(__name__)
 
 # TODO: Make this configurable in bioconda_utils.build and bioconda_utils.cli.
-MULLED_CONDA_IMAGE = "dpryan79/mulled_container:latest"
+MULLED_CONDA_IMAGE = "quay.io/dpryan79/mulled_container:latest"
 
 
 def get_tests(path):

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -17,7 +17,7 @@ from conda_build.metadata import MetaData
 logger = logging.getLogger(__name__)
 
 # TODO: Make this configurable in bioconda_utils.build and bioconda_utils.cli.
-MULLED_CONDA_IMAGE = "bioconda/mulled_container:latest"
+MULLED_CONDA_IMAGE = "dpryan79/mulled_container:latest"
 
 
 def get_tests(path):

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -17,7 +17,7 @@ from conda_build.metadata import MetaData
 logger = logging.getLogger(__name__)
 
 # TODO: Make this configurable in bioconda_utils.build and bioconda_utils.cli.
-MULLED_CONDA_IMAGE = "continuumio/miniconda3:4.5.12"
+MULLED_CONDA_IMAGE = "bioconda/mulled_container:latest"
 
 
 def get_tests(path):


### PR DESCRIPTION
This won't pass testing until the container is actually uploaded of course. `MulledDockerfile` is an updated version of `continuumio/miniconda3` with a new conda inside. This container fixes issues like https://github.com/bioconda/bioconda-recipes/pull/14472 locally for me at least (I can reproduce those issues locally with the default `continuumio/miniconda3` container).