### PR TITLE
Update bamtools pinning to a version that's been rebuilt

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -13,7 +13,7 @@ pin_run_as_build:
 htslib:
   - 1.9
 bamtools:
-  - 2.4.1
+  - 2.5.1
 libdeflate:
   - 1.0
 r_base:


### PR DESCRIPTION
2.4.1 was built with the old compilers, so everything that links against it can't get updated. The most recent version of bamtools we've built is 2.5.1, so I suggest pinning to that instead.