### PR TITLE
Autobump updates

### DIFF
--- a/.circleci/build-docs.sh
+++ b/.circleci/build-docs.sh
@@ -29,7 +29,7 @@ DOCHTML=$DOCSOURCE/build/html
 # tmpdir to which built docs will be copied
 STAGING=/tmp/${GITHUB_USERNAME}-docs
 
-# Build docs only if travis-ci is testing this branch:
+# Deploy docs only from this branch (i.e. on commit)
 BUILD_DOCS_FROM_BRANCH="master"
 
 # ----------------------------------------------------------------------------
@@ -75,7 +75,7 @@ if git diff --quiet; then
     exit 0
 fi
 
-if [[ $CIRCLE_BRANCH != master ]]; then
+if [[ $CIRCLE_BRANCH != $BUILD_DOCS_FROM_BRANCH ]]; then
     echo "Not pushing docs because not on branch '$BUILD_DOCS_FROM_BRANCH'"
     exit 0
 fi

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -714,8 +714,10 @@ def clean_cran_skeleton(recipe, no_windows=False):
      building packages present in other channels. Set to 'none' to disable
      check.''')
 @arg('--ignore-blacklists', help='''Do not exclude recipes from blacklist''')
-@arg('--no-fetch-requirements', help='''Do not try to determine upstream
-     requirements''')
+@arg('--fetch-requirements',
+     help='''Try to fetch python requirements. Please note that this requires
+     downloading packages and executing setup.py, so presents a potential
+     security problem.''')
 @arg('--cache', help='''To speed up debugging, use repodata cached locally in
      the provided filename. If the file does not exist, it will be created
      the first time. Caution: The cache will not be updated if
@@ -753,7 +755,7 @@ def autobump(recipe_folder, config, packages='*', cache=None,
              failed_urls=None, unparsed_urls=None, recipe_status=None,
              exclude_subrecipes=None, exclude_channels='conda-forge',
              ignore_blacklists=False,
-             no_fetch_requirements=False,
+             fetch_requirements=False,
              check_branch=False, create_branch=False, create_pr=False,
              only_active=False, no_shuffle=False,
              max_updates=0, parallel=100, dry_run=False,
@@ -812,7 +814,7 @@ def autobump(recipe_folder, config, packages='*', cache=None,
 
     if not no_check_version_update:
         scanner.add(autobump.UpdateVersion, hosters.Hoster.select_hoster, unparsed_urls)
-        if not no_fetch_requirements:
+        if fetch_requirements:
             scanner.add(autobump.FetchUpstreamDependencies)
         scanner.add(autobump.UpdateChecksums, failed_urls)
 

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -785,6 +785,8 @@ def autobump(recipe_folder, config, packages='*', cache=None,
                                cache_fn=cache and cache + "_scan.pkl",
                                max_inflight=parallel,
                                status_fn=recipe_status)
+    scanner.add(autobump.ExcludeDisabled)
+
     if not ignore_blacklists:
         scanner.add(autobump.ExcludeBlacklisted, recipe_folder, config_dict)
     if exclude_subrecipes != "never":

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -781,50 +781,71 @@ def autobump(recipe_folder, config, packages='*', cache=None,
             recipe_folder, packages, not no_shuffle,
             config_dict, cache_fn=cache and cache + "_dag.pkl")
 
+    # Setup scanning pipeline
     scanner = autobump.Scanner(recipe_source,
                                cache_fn=cache and cache + "_scan.pkl",
                                max_inflight=parallel,
                                status_fn=recipe_status)
+
+    # Always exclude recipes that were explicitly disabled
     scanner.add(autobump.ExcludeDisabled)
 
+    # Exclude packages that are on the blacklist
     if not ignore_blacklists:
         scanner.add(autobump.ExcludeBlacklisted, recipe_folder, config_dict)
+
+    # Exclude sub-recipes
     if exclude_subrecipes != "never":
         scanner.add(autobump.ExcludeSubrecipe,
                     always=exclude_subrecipes == "always")
+
+    # Exclude recipes with dependencies pending an update
     if not no_check_pending_deps:
         scanner.add(autobump.ExcludeDependencyPending, recipe_source.dag)
 
+    # Load recipe
     git_handler = None
     if check_branch or create_branch or create_pr or only_active:
+        # We need to take the recipe from the git repo. This
+        # loads the bump/<recipe> branch if available
         git_handler = githandler.BiocondaRepo(recipe_folder, dry_run)
         git_handler.checkout_master()
         if only_active:
             scanner.add(autobump.ExcludeNoActiveUpdate, git_handler)
         scanner.add(autobump.GitLoadRecipe, git_handler)
     else:
+        # Just load from local file system
         scanner.add(autobump.LoadRecipe)
 
+    # Exclude recipes that are present in "other channels"
     if exclude_channels != ["none"]:
         if not isinstance(exclude_channels, list):
             exclude_channels = [exclude_channels]
         scanner.add(autobump.ExcludeOtherChannel, exclude_channels,
                     cache and cache + "_repodata.txt")
 
+    # Test if due to pinnings, the package hash would change and a rebuild
+    # has become necessary. If so, bump the buildnumber.
     if not no_check_pinnings:
         scanner.add(autobump.CheckPinning, bump_only_python)
 
+    # Check for new versions and update the SHA afterwards
     if not no_check_version_update:
         scanner.add(autobump.UpdateVersion, hosters.Hoster.select_hoster, unparsed_urls)
         if fetch_requirements:
+            # This attempts to determine dependencies exported by PyPi packages,
+            # requires running setup.py, so only enabled on request.
             scanner.add(autobump.FetchUpstreamDependencies)
         scanner.add(autobump.UpdateChecksums, failed_urls)
 
+    # Write the recipe. For making PRs, the recipe should be written to a branch
+    # of its own.
     if create_branch or create_pr:
         scanner.add(autobump.GitWriteRecipe, git_handler)
     else:
         scanner.add(autobump.WriteRecipe)
 
+    # Create a PR for the branch
     if create_pr:
         token = os.environ.get("GITHUB_TOKEN")
         if not token and not dry_run:
@@ -834,9 +855,14 @@ def autobump(recipe_folder, config, packages='*', cache=None,
             token, dry_run, "bioconda", "bioconda-recipes")
         scanner.add(autobump.CreatePullRequest, git_handler, github_handler)
 
+    # Terminate the scanning pipeline after x recipes have reached this point.
     if max_updates:
         scanner.add(autobump.MaxUpdates, max_updates)
+
+    # And go.
     scanner.run()
+
+    # Cleanup
     if git_handler:
         git_handler.close()
 

--- a/bioconda_utils/recipe.py
+++ b/bioconda_utils/recipe.py
@@ -134,8 +134,6 @@ class Recipe():
         "compiler": lambda x: f"compiler_{x}",
     }
 
-    #: Name of key under ``extra`` containing config
-    EXTRA_CONFIG = "autobump"
 
     def __init__(self, recipe_dir, recipe_folder):
         if not recipe_dir.startswith(recipe_folder):
@@ -181,15 +179,6 @@ class Recipe():
     def dir(self):
         """Path to recipe folder"""
         return os.path.join(self.basedir, self.reldir)
-
-    @property
-    def config(self):
-        """Per-recipe configuration parameters
-
-        These are the values set in ``extra:`` under the key
-        defined as `Recipe.EXTRA_CONFIG` (default is ``watch``).
-        """
-        return self.meta.get("extra", {}).get(self.EXTRA_CONFIG, {})
 
     def __str__(self) -> str:
         return self.reldir


### PR DESCRIPTION
- CLI: disable fetching pypi requirements by default. It runs unknown code (setup.py), and should be explicitly enabled if desired.
- Janitoring: Remove `recipe.Recipe.config` which was just the `autobump.config`.
- Docs: actually use the variable pointing to master branch