### PR TITLE
Properly sort semantic versions of bioconductor and change cargoport interaction

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -345,7 +345,7 @@ class BioCProjectPage(object):
         it exists.
         """
         url = cargoport_url(self.package, self.version, self.bioc_version)
-        response = requests.get(url)
+        response = requests.head(url)
         if response.status_code == 404:
             # This is expected if this is a new package or an updated version.
             # Cargo Port will archive a working URL upon merging

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -58,7 +58,8 @@ def bioconductor_versions():
     response = requests.get(url)
     bioc_config = yaml.load(response.text)
     versions = list(bioc_config["r_ver_for_bioc_ver"].keys())
-    versions = sorted(versions, key=float, reverse=True)
+    # Handle semantic version sorting like 3.10 and 3.9
+    versions = sorted(versions, key=lambda v: list(map(int, v.split('.'))), reverse=True)
     return versions
 
 

--- a/test/test_bioconductor_skeleton.py
+++ b/test/test_bioconductor_skeleton.py
@@ -152,7 +152,7 @@ def test_annotation_data(tmpdir, bioc_fetch):
 
 def test_experiment_data(tmpdir, bioc_fetch):
     bioconductor_skeleton.write_recipe('affyhgu133a2expr', str(tmpdir), config, recursive=False, packages=bioc_fetch)
-    meta = utils.load_first_metadata(str(tmpdir.join('bioconductor-affydata'))).meta
+    meta = utils.load_first_metadata(str(tmpdir.join('bioconductor-affyhgu133a2expr'))).meta
     assert any(dep.startswith('curl ') for dep in meta['requirements']['run'])
     assert len(meta['source']['url']) == 3
     assert not tmpdir.join('bioconductor-affydata', 'build.sh').exists()

--- a/test/test_bioconductor_skeleton.py
+++ b/test/test_bioconductor_skeleton.py
@@ -151,7 +151,7 @@ def test_annotation_data(tmpdir, bioc_fetch):
 
 
 def test_experiment_data(tmpdir, bioc_fetch):
-    bioconductor_skeleton.write_recipe('affydata', str(tmpdir), config, recursive=False, packages=bioc_fetch)
+    bioconductor_skeleton.write_recipe('affyhgu133a2expr', str(tmpdir), config, recursive=False, packages=bioc_fetch)
     meta = utils.load_first_metadata(str(tmpdir.join('bioconductor-affydata'))).meta
     assert any(dep.startswith('curl ') for dep in meta['requirements']['run'])
     assert len(meta['source']['url']) == 3

--- a/test/test_bioconductor_skeleton.py
+++ b/test/test_bioconductor_skeleton.py
@@ -151,13 +151,13 @@ def test_annotation_data(tmpdir, bioc_fetch):
 
 
 def test_experiment_data(tmpdir, bioc_fetch):
-    bioconductor_skeleton.write_recipe('affyhgu133a2expr', str(tmpdir), config, recursive=False, packages=bioc_fetch)
+    bioconductor_skeleton.write_recipe('Affyhgu133A2Expr', str(tmpdir), config, recursive=False, packages=bioc_fetch)
     meta = utils.load_first_metadata(str(tmpdir.join('bioconductor-affyhgu133a2expr'))).meta
     assert any(dep.startswith('curl ') for dep in meta['requirements']['run'])
     assert len(meta['source']['url']) == 3
-    assert not tmpdir.join('bioconductor-affydata', 'build.sh').exists()
-    assert tmpdir.join('bioconductor-affydata', 'post-link.sh').exists()
-    assert tmpdir.join('bioconductor-affydata', 'pre-unlink.sh').exists()
+    assert not tmpdir.join('bioconductor-affyhgu133a2expr', 'build.sh').exists()
+    assert tmpdir.join('bioconductor-affyhgu133a2expr', 'post-link.sh').exists()
+    assert tmpdir.join('bioconductor-affyhgu133a2expr', 'pre-unlink.sh').exists()
 
 
 def test_nonexistent_pkg(tmpdir, bioc_fetch):


### PR DESCRIPTION
This should close #525. This issue has only hit us since we in to double digit minor release versions of bioconductor now, but '3.10' should be sorted before '3.9' when we get the list of releases.