### PR TITLE
Dockerfile: set auto_update_conda=False to allow conda=4.7.5 to downgrade itself

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,10 @@ variables:
   build_docker_container: &build_docker_container
     run:
       name: Build the updated docker container
-      command: docker build -t bioconda-utils-build-env:latest ./
+      command: |
+        docker build -t bioconda-utils-build-env:latest ./
+        docker history bioconda-utils-build-env:latest
+        docker run --rm -t bioconda-utils-build-env:latest sh -lec 'type -t conda && conda info -a && conda list'
   autobump_run: &autobump_run
     name: Check recipes for new upstream releases
     command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN export PATH="/opt/conda/bin:${PATH}" && \
     sed -nE \
         -e 's/\s*#.*$//' \
         -e 's/^(conda([><!=~ ].+)?)$/\1/p' \
-        bioconda_utils-requirements.txt \
+        /tmp/repo/bioconda_utils/bioconda_utils-requirements.txt \
         | xargs -r conda install -y && \
     conda install -y --file /tmp/repo/bioconda_utils/bioconda_utils-requirements.txt && \
     conda clean -y -it

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ COPY ./bioconda_utils/bioconda_utils-requirements.txt /tmp/repo/bioconda_utils/
 RUN export PATH="/opt/conda/bin:${PATH}" && \
     conda config --add channels defaults && \
     conda config --add channels bioconda && \
-    conda config --add channels conda-forge
+    conda config --add channels conda-forge && \
+    conda config --set auto_update_conda False
 RUN export PATH="/opt/conda/bin:${PATH}" && \
     conda install --file /tmp/repo/bioconda_utils/bioconda_utils-requirements.txt && \
     conda clean -y --all

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ RUN export PATH="/opt/conda/bin:${PATH}" && \
     conda config --add channels conda-forge && \
     conda config --set auto_update_conda False
 RUN export PATH="/opt/conda/bin:${PATH}" && \
+    : 'Make sure we get the (working) conda we want before installing the rest.' && \
+    sed -nE \
+        -e 's/\s*#.*$//' \
+        -e 's/^(conda([><!=~ ].+)?)$/\1/p' \
+        bioconda_utils-requirements.txt \
+        | xargs -r conda install -y && \
     conda install --file /tmp/repo/bioconda_utils/bioconda_utils-requirements.txt && \
     conda clean -y --all
 COPY . /tmp/repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN export PATH="/opt/conda/bin:${PATH}" && \
         -e 's/^(conda([><!=~ ].+)?)$/\1/p' \
         bioconda_utils-requirements.txt \
         | xargs -r conda install -y && \
-    conda install --file /tmp/repo/bioconda_utils/bioconda_utils-requirements.txt && \
-    conda clean -y --all
+    conda install -y --file /tmp/repo/bioconda_utils/bioconda_utils-requirements.txt && \
+    conda clean -y -it
 COPY . /tmp/repo
 RUN export PATH="/opt/conda/bin:${PATH}" && \
     pip install /tmp/repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM condaforge/linux-anvil-comp7
-RUN sudo -n yum install -y openssh-clients
+RUN sudo -n yum install -y openssh-clients && \
+    sudo -n yum clean all && \
+    sudo -n rm -rf /var/cache/yum/*
 RUN mkdir -p /tmp/repo/bioconda_utils/
 COPY ./bioconda_utils/bioconda_utils-requirements.txt /tmp/repo/bioconda_utils/
 RUN export PATH="/opt/conda/bin:${PATH}" && \

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -10,7 +10,7 @@ ruamel_yaml=0.15.*   # Recipe YAML parsing
 pyaml=17.12.*        # Faster YAML parser (deprecate?)
 networkx=1.11
 pandas=0.23.*
-numpy=1.15.*
+libblas=*=*openblas  # Avoid large mkl package (pulled in by pandas)
 boltons=18.*
 jsonschema=2.6.*     # JSON schema verification
 


### PR DESCRIPTION
cf. https://gitter.im/bioconda/Lobby?at=5d1bb2d06933ed1a622a334a ff.

> That `Collecting package metadata (repodata.json)` looks like a change in `conda >=4.7.0` https://github.com/conda/conda/commit/1f2a1864199f35aefaade1ed1b8fe6333a73c8b5#diff-127bca0abbd39d90577af817c26af378R234 . But aren't we get conda `4.6.12` here, c.f., https://github.com/bioconda/bioconda-utils/blob/5ca450f4bc9462ca2472389aac000d96846e773b/bioconda_utils/bioconda_utils-requirements.txt#L3 ??

> Oh dear...
> ```
> >  docker pull bioconda/bioconda-utils-build-env &&  docker run --rm -it bioconda/bioconda-utils-build-env conda --version
> Using default tag: latest
> latest: Pulling from bioconda/bioconda-utils-build-env
> Digest: sha256:1bc2f91ac938dfb50283b77512ece61d4faaa9ef85a809c53095097e7c2f3b0a
> Status: Image is up to date for bioconda/bioconda-utils-build-env:latest
> conda 4.7.5
> ```
> https://circleci.com/gh/bioconda/bioconda-utils/5171?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link :
> ```
> ...
> conda install --file /tmp/repo/bioconda_utils/bioconda_utils-requirements.txt &&     conda clean -y --all
> ...
>   added / updated specs:
> ...
>     - conda==4.6.12
> ...
> The following packages will be DOWNGRADED:
> ...
>   conda                                        4.7.5-py37_0 --> 4.7.5-py36_0
> ...
> ```
> https://github.com/conda/conda/pull/8853
> https://github.com/conda/conda/issues/8824
> 
> > After updating conda to 4.7.5, conda can no longer be downgraded to a previous version using a version spec such as `conda install conda=4.6`. This behavior can be changed if the `auto_update_conda` configuration parameter is set to false.
> 
> So we could try setting `auto_update_conda` then.
