### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+miniconda


### PR DESCRIPTION
Same as gh-582 with added `.dockerignore`. (I didn't add this to gh-582 since this is less important to include.)

We don't have to include `.git/` in the container image and even less so the local Miniconda installation created by `.circleci/setup.sh`.

If this does not exclude enough, we could also create a cleaner build context via:
```sh
mkdir ./docker-build-context
git archive HEAD | tar -xC ./docker-build-context
docker build -t bioconda-utils-build-env:latest ./docker-build-context
rm -rf ./docker-build-context
```