### PR TITLE
conda_build_config: clear CONDA_BUILD_SYSROOT and use exclusive_config_files

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -2,6 +2,10 @@
 # in
 # https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml
 
+# clear hard-coded default value for CONDA_BUILD_SYSROOT
+CONDA_BUILD_SYSROOT:
+  - ''
+
 pin_run_as_build:
   htslib:
     max_pin: x.x

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -456,17 +456,14 @@ def load_conda_build_config(platform=None, trim_skip=True):
     # get environment root
     env_root = PurePath(shutil.which("bioconda-utils")).parents[1]
     # set path to pinnings from conda forge package
-    config.exclusive_config_file = os.path.join(env_root,
-                                                "conda_build_config.yaml")
-    config.variant_config_files = [
+    config.exclusive_config_files = [
+        os.path.join(env_root, "conda_build_config.yaml"),
         os.path.join(
             os.path.dirname(__file__),
-            'bioconda_utils-conda_build_config.yaml')
+            'bioconda_utils-conda_build_config.yaml'),
     ]
-    for cfg in config.variant_config_files:
+    for cfg in chain(config.exclusive_config_files, config.variant_config_files or []):
         assert os.path.exists(cfg), ('error: {0} does not exist'.format(cfg))
-    assert os.path.exists(config.exclusive_config_file), (
-        "error: conda_build_config.yaml not found in environment root")
     if platform:
         config.platform = platform
     config.trim_skip = trim_skip
@@ -483,7 +480,7 @@ def get_conda_build_config_files(config=None):
     if config is None:
         config = load_conda_build_config()
     # TODO: open PR upstream for conda-build to support multiple exclusive_config_files
-    for file_path in ([config.exclusive_config_file] if config.exclusive_config_file else []):
+    for file_path in (config.exclusive_config_files or []):
         yield CondaBuildConfigFile('-e', file_path)
     for file_path in (config.variant_config_files or []):
         yield CondaBuildConfigFile('-m', file_path)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -866,7 +866,7 @@ def test_variants():
                   - 2.0
                 """))
     config = utils.load_conda_build_config()
-    config.exclusive_config_file = tmp
+    config.exclusive_config_files = [tmp]
 
     assert len(utils.load_all_meta(recipe, config)) == 2
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -37,6 +37,7 @@ TEST_LABEL = 'bioconda-utils-test'
 DOCKER_BASE_IMAGE = "bioconda/bioconda-utils-build-env:latest"
 
 SKIP_DOCKER_TESTS = sys.platform.startswith('darwin')
+SKIP_NOT_OSX = not sys.platform.startswith('darwin')
 
 if SKIP_DOCKER_TESTS:
     PARAMS = [False]
@@ -996,6 +997,49 @@ def test_nested_recipes(config_fixture):
     assert build_results
 
     assert len(list(utils.get_recipes(r.basedir))) == 4
+
+    for k, v in r.recipe_dirs.items():
+        for i in utils.built_package_paths(v):
+            assert os.path.exists(i)
+            ensure_missing(i)
+
+
+@pytest.mark.skipif(SKIP_NOT_OSX, reason='osx-only test')
+def test_conda_build_sysroot(config_fixture):
+    """
+    Test if CONDA_BUILD_SYSROOT is empty/unset and correctly set after compiler activation.
+    """
+    # conda-build >=3.18.0 sets CONDA_BUILD_SYSROOT to a hard-coded default path.
+    # We clear its value in our bioconda_utils-conda_build_config.yaml.
+    # With CONDA_BUILD_SYSROOT being empty, the activation script of clang_osx-64
+    # can set it to a valid path.
+    r = Recipes(
+        """
+        sysroot_var_is_unset_or_empty_without_c_compiler:
+          meta.yaml: |
+            package:
+              name: sysroot_var_is_unset_or_empty_without_c_compiler
+              version: 0.1
+            build:
+              script: '[ -z "${CONDA_BUILD_SYSROOT:-}" ]'
+        sysroot_is_existing_directory_with_c_compiler:
+          meta.yaml: |
+            package:
+              name: sysroot_is_existing_directory_with_c_compiler
+              version: 0.1
+            build:
+              script: 'test -d "${CONDA_BUILD_SYSROOT}"'
+            requirements:
+              build:
+                - {{ compiler('c') }}
+        """, from_string=True)
+    r.write_recipes()
+    build_result = build.build_recipes(r.basedir, config_fixture,
+                                       r.recipe_dirnames,
+                                       testonly=False,
+                                       force=False,
+                                       mulled_test=False)
+    assert build_result
 
     for k, v in r.recipe_dirs.items():
         for i in utils.built_package_paths(v):


### PR DESCRIPTION
Fixes https://github.com/bioconda/bioconda-recipes/pull/16402#issuecomment-511840128

```
    # conda-build >=3.18.0 sets CONDA_BUILD_SYSROOT to a hard-coded default path.
    # We clear its value in our bioconda_utils-conda_build_config.yaml.
    # With CONDA_BUILD_SYSROOT being empty, the activation script of clang_osx-64
    # can set it to a valid path.
```

Also fixes https://github.com/bioconda/bioconda-utils/issues/325 .