### PR TITLE
requirements: revert to conda-build=3.17.8

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -1,7 +1,7 @@
 # basics
 python>=3.6
 conda=4.6.14
-conda-build=3.18.7
+conda-build=3.17.8
 conda-verify=3.1.*
 argh=0.26.*          # CLI
 colorlog=3.1.*       # Logging


### PR DESCRIPTION
**DON'T MERGE**

This is just in case conda-forge decides to pull(=mark as `broken`) `conda-build=3.18.7` and we have to adjust quickly.

Issues with `conda-build=3.18.7` are `run_exports` related.
refs:
https://gitter.im/conda-forge/conda-forge.github.io?at=5d2f995d5fa7895c431d1061
https://github.com/conda/conda-build/issues/3610
https://github.com/conda/conda-build/pull/3611