### PR TITLE
Fix #599, at least for vmatch

### DIFF
--- a/bioconda_utils/recipe.py
+++ b/bioconda_utils/recipe.py
@@ -272,8 +272,11 @@ class Recipe():
             return None
         if not variants:
             return None
-        if any(" " in v for v in variants):
-            # can't handle "[py2k or osx]" style things
+        for k in list(variants.keys()):
+            if " " in k:
+                # can't handle "[py2k or osx]" style things
+                del variants[k]
+        if not variants:
             return None
 
         new_lines = []


### PR DESCRIPTION
This simply disables the current "convert to list" work-around in the case of a space in a possible selector. In effect this lowers the false rate caused by using comments with a space after the `#`.