### PR TITLE
Add --keep-old-work option to keep work directory

### DIFF
--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -1,5 +1,5 @@
 name: Github Action Tests
-on: [push]
+on: [push, pull_request]
 jobs:
   test-linux:
     name: Shorter linux tests

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -222,7 +222,8 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
                   mulled_upload_target=None,
                   check_channels: List[str] = None,
                   do_lint: bool = None,
-                  lint_exclude: List[str] = None):
+                  lint_exclude: List[str] = None,
+                  keep_old_work: bool = False):
     """
     Build one or many bioconda packages.
 
@@ -244,6 +245,7 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
         Fefaults to every channel in the config file except "defaults".
       do_lint: Whether to run linter
       lint_exclude: List of linting functions to exclude.
+      keep_old_work: Do not remove anything from environment, even after successful build and test.
     """
     if not recipes:
         logger.info("Nothing to be done.")
@@ -364,7 +366,8 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
                         upload.mulled_upload(img, mulled_upload_target)
 
         # remove traces of the build
-        conda_build_purge()
+        if not keep_old_work:
+            conda_build_purge()
 
     if failed or failed_uploads:
         logger.error('BUILD SUMMARY: of %s recipes, '

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -401,12 +401,14 @@ def do_lint(recipe_folder, config, packages="*", cache=None, list_checks=False,
      already present in one of these channels will be skipped. The default is
      the first two channels specified in the config file. Note that this is
      ignored if you specify --git-range.''')
+@arg('--keep-old-work', action='store_true', help='''Do not remove anything
+from environment, even after successful build and test.''')
 @enable_logging()
 def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
           force=False, docker=None, mulled_test=False, build_script_template=None,
           pkg_dir=None, anaconda_upload=False, mulled_upload_target=None,
           build_image=False, keep_image=False, lint=False, lint_exclude=None,
-          check_channels=None):
+          check_channels=None, keep_old_work=False):
     cfg = utils.load_config(config)
     setup = cfg.get('setup', None)
     if setup:
@@ -451,7 +453,8 @@ def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
                             do_lint=lint,
                             lint_exclude=lint_exclude,
                             check_channels=check_channels,
-                            label=label)
+                            label=label,
+                            keep_old_work=keep_old_work)
     exit(0 if success else 1)
 
 


### PR DESCRIPTION
Currently, when `bioconda-utils build` does not complete successfully, the work directory created in ${CONDA_PREFIX}/conda-bld is still removed, which can hinder debugging (e.g., any config.log gets removed). 

It would be helpful to have an option like `conda build --keep-old-work`; this PR (I think) roughly implements similar behavior for `bioconda-utils build` (but if there are differences in behavior, it would be OK to rename the option avoid confusion).