### PR TITLE
Parallel builds

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -290,15 +290,17 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
         logger.info("Nothing to be done.")
         return True
 
-    logger.info("Building and testing %s recipes in total", len(dag))
-
     skip_dependent = defaultdict(list)
-    dag = remove_cycles(dag, name2recipes, failed, skip_dependent)
-    subdag = get_subdags(dag, n_workers, worker_offset)
+    dag2 = remove_cycles(dag, name2recipes, failed, skip_dependent)
+    for n in dag.nodes():
+        if n not in dag2:
+            logger.info("{} removed".format(n))
+    subdag = get_subdags(dag2, n_workers, worker_offset)
     if not subdag:
         logger.info("Nothing to be done.")
         return True
-    logger.info("%i recipes to build: \n%s", len(subdag), "\n".join(subdag.nodes()))
+    return True
+    logger.info("%i recipes to build and test: \n%s", len(subdag), "\n".join(subdag.nodes()))
 
     recipe2name = {}
     for name, recipe_list in name2recipes.items():

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -183,34 +183,38 @@ def remove_cycles(dag, name2recipes, failed, skip_dependent):
     return dag.subgraph(name for name in dag if name not in nodes_in_cycles)
 
 
-def get_subdags(dag, testonly):
-    subdags_n = int(os.environ.get("SUBDAGS", 1))
-    subdag_i = int(os.environ.get("SUBDAG", 0))
-    if subdag_i >= subdags_n:
+def get_subdags(dag, n_workers, worker_offset):
+    if n_workers > 1 and worker_offset >= n_workers:
         raise ValueError(
-            "SUBDAG=%s (zero-based) but only SUBDAGS=%s "
-            "subdags are available")
+            "n-workers is less than the worker-offset given! "
+            "Either decrease --n-workers or decrease --worker-offset!")
 
     # Get connected subdags and sort by nodes
-    if testonly:
-        # use each node as a subdag (they are grouped into equal sizes below)
-        node_lists = sorted([[n] for n in nx.nodes(dag)])
+    if n_workers > 1:
+        root_nodes = sorted([k for k, v in dag.in_degree().items() if v == 0])
+        nodes = set()
+        found = set()
+        for idx, root_node in enumerate(root_nodes):
+            children = list(nx.dfs_successors(dag, root_node).values())
+            if len(children):
+                children = children[0]  # If there were no children this is [], otherwise [[child1, child2, ...]]
+            # This is the only obvious way of ensuring that a given node is included
+            # in exactly 1 subgraph
+            found.add(root_node)
+            if idx % n_workers == worker_offset:
+                nodes.add(root_node)
+                for child in children:
+                    if child not in found:
+                        nodes.add(child)
+            for child in children:
+                found.add(child)
+        logger.info("Should return sub-DAGs with {} nodes".format(len(nodes)))
+        subdags = dag.subgraph(list(nodes))
+        logger.info("Building and testing sub-DAGs %i in each group of %i, which is %i packages", worker_offset, n_workers, len(subdags.nodes()))
     else:
-        node_lists = [list(nodes) for nodes in nx.connected_components(dag.to_undirected())]
+        subdags = dag
 
-    # chunk subdags such that we have at most subdags_n many
-    if subdags_n < len(node_lists):
-        chunks = [[node for nodes in node_lists[i::subdags_n] for node in nodes]
-                  for i in range(subdags_n)]
-    else:
-        chunks = node_lists
-
-    if subdag_i >= len(chunks):
-        return dag.subgraph([])
-
-    subdag = dag.subgraph(chunks[subdag_i])
-    logger.info("Building and testing subdag %s of %s", subdag_i + 1, subdags_n)
-    return subdag
+    return subdags
 
 
 def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
@@ -222,7 +226,9 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
                   mulled_upload_target=None,
                   check_channels: List[str] = None,
                   do_lint: bool = None,
-                  lint_exclude: List[str] = None):
+                  lint_exclude: List[str] = None,
+                  n_workers: int = 1,
+                  worker_offset: int = 0):
     """
     Build one or many bioconda packages.
 
@@ -241,9 +247,13 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
       mulled_upload_target: If specified, upload the mulled docker image to the given target
         on quay.io.
       check_channels: Channels to check to see if packages already exist in them.
-        Fefaults to every channel in the config file except "defaults".
+        Defaults to every channel in the config file except "defaults".
       do_lint: Whether to run linter
       lint_exclude: List of linting functions to exclude.
+      n_workers: The number of parallel instances of bioconda-utils being run. The
+        sub-DAGs are then split into groups of n_workers size.
+      worker_offset: If n_workers is >1, then every worker_offset within a given group of
+        sub-DAGs will be processed.
     """
     if not recipes:
         logger.info("Nothing to be done.")
@@ -278,14 +288,29 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
         return True
 
     logger.info("Building and testing %s recipes in total", len(dag))
-    logger.info("Recipes to build: \n%s", "\n".join(dag.nodes()))
 
     skip_dependent = defaultdict(list)
-    subdag = get_subdags(dag, testonly)
-    subdag = remove_cycles(subdag, name2recipes, failed, skip_dependent)
-    if not subdag:
-        logger.info("Nothing to be done.")
-        return True
+    dag = remove_cycles(dag, name2recipes, failed, skip_dependent)
+    logger.info("failed {} skip_dependent {}".format(failed, skip_dependent))
+    found = set()
+    logger.info("A {}".format(len(dag)))
+    for i in range(n_workers):
+        subdag = get_subdags(dag, n_workers, i)
+        logger.info("B {}".format(len(subdag)))
+        if "perl-class-load" in subdag.nodes():
+            logger.info("contains perl-class-load")
+        for n in subdag.nodes():
+            #if n in found:
+            #    print("{} already found!".format(n))
+            found.add(n)
+        if not subdag:
+            logger.info("Nothing to be done.")
+            return True
+    #logger.info("Recipes to build: \n%s", "\n".join(subdag.nodes()))
+    #for n in dag.nodes():
+    #    if n not in found:
+    #        logger.info("missing {}".format(n))
+    return True
 
     recipe2name = {}
     for name, recipe_list in name2recipes.items():

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -291,15 +291,11 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
         return True
 
     skip_dependent = defaultdict(list)
-    dag2 = remove_cycles(dag, name2recipes, failed, skip_dependent)
-    for n in dag.nodes():
-        if n not in dag2:
-            logger.info("{} removed".format(n))
-    subdag = get_subdags(dag2, n_workers, worker_offset)
+    dag = remove_cycles(dag, name2recipes, failed, skip_dependent)
+    subdag = get_subdags(dag, n_workers, worker_offset)
     if not subdag:
         logger.info("Nothing to be done.")
         return True
-    return True
     logger.info("%i recipes to build and test: \n%s", len(subdag), "\n".join(subdag.nodes()))
 
     recipe2name = {}

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -401,12 +401,29 @@ def do_lint(recipe_folder, config, packages="*", cache=None, list_checks=False,
      already present in one of these channels will be skipped. The default is
      the first two channels specified in the config file. Note that this is
      ignored if you specify --git-range.''')
+@arg('--n-workers', type=int, default=1,
+     help='''The number of parallel workers that are in use. This is intended
+     for use in cases such as the "bulk" branch, where there are multiple
+     parallel workers building and uploading recipes. In essence, this causes
+     bioconda-utils to process every Nth sub-DAG, where N is the value you give
+     to this option. The default is 1, which is intended for cases where there
+     are NOT parallel workers (i.e., the majority of cases). This should
+     generally NOT be used in conjunctions with the --packages or --git-range
+     options!''')
+@arg('--worker-offset', type=int, default=0,
+     help='''This is only used if --nWorkers is >1. In that case, then each
+     instance of bioconda-utils will process every Nth sub-DAG. This option
+     gives the 0-based offset for that. For example, if "--n-workers 5 --worker-offset 0"
+     is used, then this instance of bioconda-utils will process the 1st, 6th,
+     11th, etc. sub-DAGs. Equivalently, using "--n-workers 5 --worker-offset 1"
+     will result in sub-DAGs 2, 7, 12, etc. being processed. If you use more
+     than one worker, then make sure to give each a different offset!''')
 @enable_logging()
 def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
           force=False, docker=None, mulled_test=False, build_script_template=None,
           pkg_dir=None, anaconda_upload=False, mulled_upload_target=None,
           build_image=False, keep_image=False, lint=False, lint_exclude=None,
-          check_channels=None):
+          check_channels=None, n_workers=1, worker_offset=0):
     cfg = utils.load_config(config)
     setup = cfg.get('setup', None)
     if setup:
@@ -451,7 +468,9 @@ def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
                             do_lint=lint,
                             lint_exclude=lint_exclude,
                             check_channels=check_channels,
-                            label=label)
+                            label=label,
+                            n_workers=n_workers,
+                            worker_offset=worker_offset)
     exit(0 if success else 1)
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -666,6 +666,18 @@ def test_skip_dependencies(config_fixture):
             ensure_missing(pkg)
 
 
+class TestSubdags(object):
+    def _build(self, recipes_fixture, config_fixture, n_workers, worker_offset):
+        build.build_recipes(recipes_fixture.basedir, config_fixture,
+                            recipes_fixture.recipe_dirnames,
+                            n_workers=n_workers, worker_offset=worker_offset,
+                            mulled_test=False)
+
+    def test_subdags_out_of_range(self, recipes_fixture, config_fixture):
+        with pytest.raises(ValueError):
+            self._build(recipes_fixture, config_fixture, 2, 4)
+
+
 @pytest.mark.skipif(SKIP_DOCKER_TESTS, reason='skipping on osx')
 def test_build_empty_extra_container():
     r = Recipes(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -666,24 +666,6 @@ def test_skip_dependencies(config_fixture):
             ensure_missing(pkg)
 
 
-class TestSubdags(object):
-    def _build(self, recipes_fixture, config_fixture):
-        build.build_recipes(recipes_fixture.basedir, config_fixture,
-                            recipes_fixture.recipe_dirnames,
-                            mulled_test=False)
-
-    def test_subdags_out_of_range(self, recipes_fixture, config_fixture):
-        with pytest.raises(ValueError):
-            with utils.temp_env({'SUBDAGS': '1', 'SUBDAG': '5'}):
-                self._build(recipes_fixture, config_fixture)
-
-    def test_subdags_more_than_recipes(self, caplog, recipes_fixture, config_fixture):
-        with caplog.at_level(logging.INFO):
-            with utils.temp_env({'SUBDAGS': '5', 'SUBDAG': '4'}):
-                    self._build(recipes_fixture, config_fixture)
-            assert 'Nothing to be done' in caplog.records[-1].getMessage()
-
-
 @pytest.mark.skipif(SKIP_DOCKER_TESTS, reason='skipping on osx')
 def test_build_empty_extra_container():
     r = Recipes(


### PR DESCRIPTION
This will eventually enable having more than one `bioconda-utils build` instance running at the same time. The basic idea is to partition the DAG on the root nodes into non-overlapping chunks. Workers can then process every Nth partition. The primary (sole?) conceived use of this is on the bulk branch.