### PR TITLE
Add a uses_matplotlib linter check

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -50,7 +50,7 @@ alabaster=0.7.*
 docutils
 
 # The bioconductor skeleton needs this
-requests=2.20.*
+requests=2.22.*
 
 # for bot
 gunicorn=19.9.*        # web server

--- a/bioconda_utils/lint/check_deprecation.py
+++ b/bioconda_utils/lint/check_deprecation.py
@@ -56,3 +56,22 @@ class deprecated_numpy_spec(LintCheck):
         self.recipe.replace('numpy x.x', 'numpy',
                             within=('requirements', 'outputs'))
         return True
+
+
+class uses_matplotlib(LintCheck):
+    """The recipe uses ``matplotlib``, but ``matplotlib-base`` is recommended
+
+    The ``matplotlib`` dependency should be replaced with ``matplotlib-base``
+    unless the package explicitly needs the PyQt interactive plotting backend.
+
+    """
+    severity = WARNING
+
+    def check_deps(self, deps):
+        if 'matplotlib' in deps:
+            self.message(data=True)
+
+    def fix(self, _message, _data):
+        self.recipe.replace('matplotlib', 'matplotlib-base',
+                            within=('requirements', 'outputs'))
+        return True

--- a/docs/source/contributor/linting.rst
+++ b/docs/source/contributor/linting.rst
@@ -437,6 +437,13 @@ no longer work and need to be changed.
    ``conda_build_config.yaml`` way of automatic pinning. You can
    now just write ``numpy`` (without any special string appended).
 
+.. lint-check:: uses_matplotlib
+
+   The ``matplotlib`` package has been split into ``matplotlib``
+   and ``matplotlib-base``. The only difference is that
+   ``matplotlib`` contains an additional dependency on ``pyqt``,
+   which pulls in many other dependencies. In most cases, using
+   ``matplotlib-base`` is sufficient.
 
 Build helpers
 ~~~~~~~~~~~~~

--- a/test/lint_cases.yaml
+++ b/test/lint_cases.yaml
@@ -173,6 +173,9 @@ tests:
 - name: uses_openjdk_in_build_and_run
   add: { requirements: { run: [java-jdk], build: [java-jdk] } }
   expect: uses_javajdk
+- name: uses_matplotlib_in_run
+  add: { requirements: { run: [matplotlib] } }
+  expect: uses_matplotlib
 - name: uses_setuptools_in_build
   add: { requirements: { build: [setuptools] } }
 - name: uses_setuptools_in_run


### PR DESCRIPTION
See bioconda/bioconda-recipes#19996

In short: `matplotlib` should almost never be a dependency in a recipe, and `matplotlib-base` should be used instead.
