### PR TITLE
requirements: update gitpython>=3.0.8,3.0.*

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -34,9 +34,10 @@ backoff=1.6.*      # retrying of failed API calls
 cachetools=3.0.*   # request caching (NEEDED?)
 
 # client API wrappers
-gitpython=2.1.*    # githandler
-gidgethub=3.0.*    # githubhandler
-pyjwt=1.7.*        # githubhandler (JWT signing)
+gitpython>=3.0.8,3.0.*    # githandler
+                          # needs >=3.0.8 due to https://github.com/conda-forge/staged-recipes/issues/10874
+gidgethub=3.0.*           # githubhandler
+pyjwt=1.7.*               # githubhandler (JWT signing)
 
 # unknown
 beautifulsoup4=4.6.*


### PR DESCRIPTION
Older `gitpython` builds are broken when a newer `gitdb2` is installed.
See https://github.com/conda-forge/staged-recipes/issues/10874 and the linked issues therein for details.