### PR TITLE
Bump conda-build requirement

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -1,7 +1,7 @@
 # basics
 python>=3.7
 conda=4.6.14
-conda-build=3.18.9
+conda-build=3.18.12
 conda-verify=3.1.*
 argh=0.26.*          # CLI
 colorlog=3.1.*       # Logging


### PR DESCRIPTION
This can wait for conda-build 3.19.0 to get tagged. It should apparently fix the currently broken `noarch: python` builds.