### PR TITLE
Use normal severity for uses_matplotlib lint

### DIFF
--- a/bioconda_utils/lint/check_deprecation.py
+++ b/bioconda_utils/lint/check_deprecation.py
@@ -65,8 +65,6 @@ class uses_matplotlib(LintCheck):
     unless the package explicitly needs the PyQt interactive plotting backend.
 
     """
-    severity = WARNING
-
     def check_deps(self, deps):
         if 'matplotlib' in deps:
             self.message(data=True)


### PR DESCRIPTION
With severity set to only 'warning', the linter check is ineffective
because the CI run is marked as passing. And if there’s a green check mark
in the GitHub UI, there’s no reason to check the CI logs, which is the only
place the warning appears.