### PR TITLE
 Installation for MacOS: use curl instead of wget

### DIFF
--- a/docs/source/user/install.rst
+++ b/docs/source/user/install.rst
@@ -16,12 +16,12 @@ package. The Python 3 version is recommended.
 
 On MacOS, run::
 
-   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+   curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
    sh Miniconda3-latest-MacOSX-x86_64.sh
 
 On Linux, run::
 
-   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+   curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
    sh Miniconda3-latest-Linux-x86_64.sh
 
 Follow the instructions in the installer. If you encounter problems,


### PR DESCRIPTION
See issue #643 - For consistency, change also the instructions for Linux.