### PR TITLE
Update bioconductor skeleton and pinnings

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -16,8 +16,12 @@ pin_run_as_build:
     min_pin: x.x
 
 htslib:
-  - 1.9
+  - 1.10
 bamtools:
   - 2.5.1
 r_base:
-  - 3.6
+  - 4.0
+python:
+  - 3.6.* *_cpython
+  - 3.7.* *_cpython
+  - 3.8.* *_cpython

--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -22,6 +22,6 @@ bamtools:
 r_base:
   - 4.0
 python:
+  - 2.7.* *_cpython
   - 3.6.* *_cpython
   - 3.7.* *_cpython
-  - 3.8.* *_cpython

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -1,7 +1,7 @@
 # basics
 python>=3.7
 conda=4.6.14
-conda-build=3.18.12
+conda-build=3.19.2
 conda-verify=3.1.*
 argh=0.26.*          # CLI
 colorlog=3.1.*       # Logging

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -15,7 +15,7 @@ boltons=18.*
 jsonschema=2.6.*     # JSON schema verification
 
 # pinnings
-conda-forge-pinning=2019.09.27
+conda-forge-pinning=2020.05.02.14.58.15
 
 # tools
 anaconda-client=1.6.*  # anaconda_upload

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -901,7 +901,7 @@ class BioCProjectPage(object):
         # Handle libblas and liblapack, which all compiled packages
         # are assumed to need
         additional_host_deps = []
-        if self.linkingto != [] or any(['c', 'cxx', 'fortran'] in self._cb3_build_reqs.keys()):
+        if self.linkingto != [] or len(set(['c', 'cxx', 'fortran']).intersection(self._cb3_build_reqs.keys())) > 0:
             additional_host_deps.append('libblas')
             additional_host_deps.append('liblapack')
 

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -901,7 +901,7 @@ class BioCProjectPage(object):
         # Handle libblas and liblapack, which all compiled packages
         # are assumed to need
         additional_host_deps = []
-        if self.linkingtO() != [] or any(['c', 'cxx', 'fortran'] in self._cb3_build_reqs.keys()):
+        if self.linkingto != [] or any(['c', 'cxx', 'fortran'] in self._cb3_build_reqs.keys()):
             additional_host_deps.append('libblas')
             additional_host_deps.append('liblapack')
 

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -898,6 +898,13 @@ class BioCProjectPage(object):
 
         DEPENDENCIES = sorted(self.dependencies)
 
+        # Handle libblas and liblapack, which all compiled packages
+        # are assumed to need
+        additional_host_deps = []
+        if self.linkingtO() != [] or any(['c', 'cxx', 'fortran'] in self._cb3_build_reqs.keys()):
+            additional_host_deps.append('libblas')
+            additional_host_deps.append('liblapack')
+
         additional_run_deps = []
         if self.is_data_package:
             additional_run_deps.append('curl')


### PR DESCRIPTION
The skeleton updates should add blas and lapack as host dependencies for all compiled packages. This should prevent a repeat of the last "can't link to libopenblasp" errors that kept popping up on OSX.