### PR TITLE
requirements: update to conda=4.8.3 + conda-build issue 3974 workaround

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -33,6 +33,9 @@ if [[ ! -d $WORKSPACE/miniconda ]]; then
     conda config --system --add channels bioconda
     conda config --system --add channels conda-forge
 
+    conda config --system --remove repodata_fns current_repodata.json || true
+    conda config --system --prepend repodata_fns repodata.json
+
     # step 3: install bioconda-utils and test requirements
     conda install -y --file bioconda_utils/bioconda_utils-requirements.txt --file test-requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,15 @@ ENV PATH="/opt/conda/bin:${PATH}"
 RUN conda config --add channels defaults && \
     conda config --add channels bioconda && \
     conda config --add channels conda-forge && \
+    { conda config --remove repodata_fns current_repodata.json || true ; } && \
+    conda config --prepend repodata_fns repodata.json && \
     conda config --set auto_update_conda False
 RUN : 'Make sure we get the (working) conda we want before installing the rest.' && \
-    : 'FIXME: temporary workaround: install conda=4.8.2 due to solver stalls with conda=4.6.14' && \
-    : '       (actual conda version gets still installed via bioconda_utils-requirements.txt!)' && \
-    conda install -y conda=4.8.2 && \
-    : sed -nE \
-    :     -e 's/\s*#.*$//' \
-    :     -e 's/^(conda([><!=~ ].+)?)$/\1/p' \
-    :     /tmp/repo/bioconda_utils/bioconda_utils-requirements.txt \
-    :     | xargs -r conda install -y
+    sed -nE \
+        -e 's/\s*#.*$//' \
+        -e 's/^(conda([><!=~ ].+)?)$/\1/p' \
+        /tmp/repo/bioconda_utils/bioconda_utils-requirements.txt \
+        | xargs -r conda install -y
 RUN conda install -y --file /tmp/repo/bioconda_utils/bioconda_utils-requirements.txt
 RUN conda clean -y -it
 COPY . /tmp/repo

--- a/MulledDockerfile
+++ b/MulledDockerfile
@@ -18,11 +18,6 @@ RUN apt-get update -qq --fix-missing && \
 RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh -o ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    echo "conda activate base" >> ~/.bashrc && \
-    { conda config --remove repodata_fns current_repodata.json || true ; } && \
-    conda config --prepend repodata_fns repodata.json && \
     CONDA_AGGRESSIVE_UPDATE_PACKAGES= CONDA_AUTO_UPDATE_CONDA=0 \
         conda install -y conda-forge::tini && \
     conda clean -ya
@@ -31,6 +26,11 @@ RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86
 FROM base
 
 COPY --from=builder /opt/conda /opt/conda
+RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc && \
+    { conda config --remove repodata_fns current_repodata.json || true ; } && \
+    conda config --prepend repodata_fns repodata.json
 COPY ./Mulled_entrypoint /opt/container-entrypoint
 
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/container-entrypoint"]

--- a/MulledDockerfile
+++ b/MulledDockerfile
@@ -12,12 +12,14 @@ RUN apt-get update --fix-missing && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh -O ~/miniconda.sh && \
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    echo "conda activate base" >> ~/.bashrc
+    echo "conda activate base" >> ~/.bashrc && \
+    { conda config --remove repodata_fns current_repodata.json || true ; } && \
+    conda config --prepend repodata_fns repodata.json
 
 ENV TINI_VERSION v0.16.1
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini

--- a/MulledDockerfile
+++ b/MulledDockerfile
@@ -1,29 +1,37 @@
-FROM debian:latest
+FROM debian:10-slim as base
 
 #  $ docker build -f MulledDockerfile -t bioconda/mulled_container:latest
 #  $ docker run --rm -it bioconda/mulled_container:latest /bin/bash
 #  $ docker push bioconda/mulled_container:latest
-
+#
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PATH /opt/conda/bin:$PATH
 
-RUN apt-get update --fix-missing && \
-    apt-get install -y wget bzip2 ca-certificates curl git && \
+
+FROM base as builder
+
+RUN apt-get update -qq --fix-missing && \
+    apt-get install -qqy --no-install-recommends bzip2 ca-certificates curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh -O ~/miniconda.sh && \
+RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh -o ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
     { conda config --remove repodata_fns current_repodata.json || true ; } && \
-    conda config --prepend repodata_fns repodata.json
+    conda config --prepend repodata_fns repodata.json && \
+    CONDA_AGGRESSIVE_UPDATE_PACKAGES= CONDA_AUTO_UPDATE_CONDA=0 \
+        conda install -y conda-forge::tini && \
+    conda clean -ya
 
-ENV TINI_VERSION v0.16.1
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
-RUN chmod +x /usr/bin/tini
 
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
+FROM base
+
+COPY --from=builder /opt/conda /opt/conda
+COPY ./Mulled_entrypoint /opt/container-entrypoint
+
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/container-entrypoint"]
 CMD [ "/bin/bash" ]

--- a/Mulled_entrypoint
+++ b/Mulled_entrypoint
@@ -1,0 +1,4 @@
+# /bin/bash -l
+
+conda activate base
+exec "${@}"

--- a/Mulled_entrypoint
+++ b/Mulled_entrypoint
@@ -1,5 +1,4 @@
-# /bin/bash -l
+#!/bin/bash -l
 
-. /opt/conda/etc/profile.d/conda.sh
 conda activate base
 exec "${@}"

--- a/Mulled_entrypoint
+++ b/Mulled_entrypoint
@@ -1,4 +1,5 @@
 # /bin/bash -l
 
+. /opt/conda/etc/profile.d/conda.sh
 conda activate base
 exec "${@}"

--- a/app/Dockerfile.web
+++ b/app/Dockerfile.web
@@ -9,6 +9,8 @@ COPY ./bioconda_utils/bioconda_utils-requirements.txt /tmp/requirements.txt
 RUN conda config --add channels defaults && \
     conda config --add channels bioconda && \
     conda config --add channels conda-forge && \
+    { conda config --remove repodata_fns current_repodata.json || true ; } && \
+    conda config --prepend repodata_fns repodata.json && \
     echo nomkl >> /tmp/requirements.txt && \
     echo binutils >> /tmp/requirements.txt && \
     conda install -y --file /tmp/requirements.txt && \

--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -19,9 +19,12 @@ htslib:
   - 1.10
 bamtools:
   - 2.5.1
+
+# NOTE: Workaround https://github.com/conda/conda-build/issues/3974 we slightly alter the values
+#       from conda-forge-pinnings here (appending a space that should be ignored later on).
 r_base:
-  - 4.0
+  - '4.0 '
 python:
-  - 2.7.* *_cpython
-  - 3.6.* *_cpython
-  - 3.7.* *_cpython
+  - '2.7.* *_cpython '
+  - '3.6.* *_cpython '
+  - '3.7.* *_cpython '

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -1,6 +1,6 @@
 # basics
 python>=3.7
-conda=4.6.14
+conda=4.8.3
 conda-build=3.19.2
 conda-verify=3.1.*
 argh=0.26.*          # CLI

--- a/test/test_bioconductor_skeleton.py
+++ b/test/test_bioconductor_skeleton.py
@@ -1,5 +1,14 @@
 import pytest
 
+# TODO: Remove this once bioarchive is up again.
+from datetime import datetime
+from functools import partial
+SKIP_DUE_TO_BIOARCHIVE_OUTAGE = partial(
+    pytest.mark.skipif,
+    datetime.now() < datetime(2020, 6, 22),
+    reason='temporarily skipped due to bioarchive.galaxyproject.org outage',
+)
+
 from bioconda_utils import bioconductor_skeleton
 from bioconda_utils import cran_skeleton
 from bioconda_utils import utils
@@ -100,6 +109,7 @@ def test_find_best_bioc_version():
         bioconductor_skeleton.BioCProjectPage('BioBase', pkg_version='2.37.2')
 
 
+@SKIP_DUE_TO_BIOARCHIVE_OUTAGE
 def test_pkg_version():
 
     # version specified, but not bioc version
@@ -137,12 +147,14 @@ def test_bioarchive_exists_but_not_bioconductor():
         bioconductor_skeleton.BioCProjectPage('BioBase', pkg_version='2.37.2')
 
 
+@SKIP_DUE_TO_BIOARCHIVE_OUTAGE
 def test_bioarchive_exists():
     # package found on both bioconductor and bioarchive.
     b = bioconductor_skeleton.BioCProjectPage('DESeq', pkg_version='1.26.0')
     assert b.bioarchive_url == 'https://bioarchive.galaxyproject.org/DESeq_1.26.0.tar.gz'
 
 
+@SKIP_DUE_TO_BIOARCHIVE_OUTAGE
 def test_annotation_data(tmpdir, bioc_fetch):
     bioconductor_skeleton.write_recipe('AHCytoBands', str(tmpdir), config, recursive=False, packages=bioc_fetch)
     meta = utils.load_first_metadata(str(tmpdir.join('bioconductor-ahcytobands'))).meta
@@ -153,6 +165,7 @@ def test_annotation_data(tmpdir, bioc_fetch):
     assert tmpdir.join('bioconductor-ahcytobands', 'pre-unlink.sh').exists()
 
 
+@SKIP_DUE_TO_BIOARCHIVE_OUTAGE
 def test_experiment_data(tmpdir, bioc_fetch):
     bioconductor_skeleton.write_recipe('Affyhgu133A2Expr', str(tmpdir), config, recursive=False, packages=bioc_fetch)
     meta = utils.load_first_metadata(str(tmpdir.join('bioconductor-affyhgu133a2expr'))).meta


### PR DESCRIPTION
This updates our requirement to `conda=4.8.3`... and removes `current_repodata.json` from the config where possible.

We also have to adjust https://github.com/bioconda/bioconda-recipes/blob/8b019e7be9dbc87b3419f93b5a2afcf6a1411466/.circleci/setup.sh#L77 then. (And things for `bulk`.)