### PR TITLE
logging: Add workaround for conda>=4.7.0 custom logging

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -35,8 +35,16 @@ import backoff
 import yaml
 import jinja2
 from jinja2 import Environment, PackageLoader
+
+# FIXME(upstream): For conda>=4.7.0 initialize_logging is (erroneously) called
+#                  by conda.core.index.get_index which messes up our logging.
+# => Prevent custom conda logging init before importing anything conda-related.
+import conda.gateways.logging
+conda.gateways.logging.initialize_logging = lambda: None
+
 from conda_build import api
 from conda.exports import VersionOrder
+
 from jsonschema import validate
 from colorlog import ColoredFormatter
 from boltons.funcutils import FunctionBuilder


### PR DESCRIPTION
IDK why, but for some reason `conda>=4.7.0` initializes its custom logging although it is not supposed to when run "via API".
refs:
- https://github.com/conda/conda/blob/b7bd38660104973da7900d0eb09fb326fb998c0d/conda/core/index.py#L52
- https://github.com/conda/conda/blob/b7bd38660104973da7900d0eb09fb326fb998c0d/conda/gateways/logging.py#L157-L159

Reported in https://github.com/bioconda/bioconda-recipes/pull/22854.

This PR adds a simple workaround.
"It ain't pretty, but functional."