### PR TITLE
Add Docs: Only support python v3.6 and v3.7

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -1,3 +1,7 @@
+# Some of Bioconda's supported versions are described
+# in ../docs/source/user/versions.rst
+# so please keep that documentation up to date as they change
+
 # Additional bioconda-specific pinnings to use in addition to those specified
 # in
 # https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -1,3 +1,7 @@
+# Some of Bioconda's supported versions are described
+# in ../docs/source/user/versions.rst
+# so please keep that documentation up to date as they change
+
 # basics
 python>=3.7
 conda=4.8.3

--- a/docs/source/user/index.rst
+++ b/docs/source/user/index.rst
@@ -5,3 +5,4 @@ User Docs
 .. toctree::
 
    install
+   versions

--- a/docs/source/user/versions.rst
+++ b/docs/source/user/versions.rst
@@ -14,6 +14,12 @@ Python
 Bioconda only supports python 2.7, 3.6 and 3.7. The community is currently working on adding support for
 python 3.8.
 
+(The exception to this is Bioconda packages which declare `noarch: python` and only depend on
+such packages - those packages can be installed in an environment with any version of python
+they say they can support.
+However many python packages in Bioconda depend on other Bioconda packages with architecture specific
+builds, such as `pysam`, and so do not meet this criteria.)
+
 Unsupported versions
 --------------------
 If the version of a package you wish to use is not supported because it is too old, please upgrade to a newer

--- a/docs/source/user/versions.rst
+++ b/docs/source/user/versions.rst
@@ -11,7 +11,7 @@ Bioconda only supports 64-bit Linux and Mac OS
 
 Python
 ------
-Bioconda only supports python 3.6 and 3.7. The community is currently working on adding support for
+Bioconda only supports python 2.7, 3.6 and 3.7. The community is currently working on adding support for
 python 3.8.
 
 Unsupported versions

--- a/docs/source/user/versions.rst
+++ b/docs/source/user/versions.rst
@@ -1,0 +1,29 @@
+
+Versions Supported in Bioconda
+==============================
+Bioconda only supports some versions of conda packages.
+Here is an incomplete list of the dependencies that might be relevant to your
+conda environment.
+
+Operating Systems
+-----------------
+Bioconda only supports 64-bit Linux and Mac OS
+
+Python
+------
+Bioconda only supports python 3.6 and 3.7. The community is currently working on adding support for
+python 3.8.
+
+Unsupported versions
+--------------------
+If the version of a package you wish to use is not supported because it is too old, please upgrade to a newer
+version so that you can use Bioconda.
+
+If the version you wish to use is not supported because it is too new:
+
+* If it is a small piece of software, please consider
+  :doc:`contributing it to Bioconda <../contributor/index>`
+* If it is a large piece of software (like the python language) ask about
+  feasibility, timelines, and how you can help on the
+  `Bioconda gitter <https://gitter.im/bioconda/Lobby>`_
+


### PR DESCRIPTION
I added a package to Bioconda, and then flailed for quite a while not understanding why it wouldn't build against python=3.5 or python=3.8. If these are not supported, somewhere in the docs should say so. With this change, that's now true, and there's now a place to list similar information for other important software (maybe R?).