### PR TITLE
update-pinnings fixes

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -25,10 +25,10 @@ bamtools:
   - 2.5.1
 
 # NOTE: Workaround https://github.com/conda/conda-build/issues/3974 we slightly alter the values
-#       from conda-forge-pinnings here (appending a space that should be ignored later on).
+#       from conda-forge-pinnings here (inserting '.*' or ' ' which should be ignored later on).
 r_base:
-  - '4.0 '
+  - 4.0.*
 python:
-  - '2.7.* *_cpython '
-  - '3.6.* *_cpython '
-  - '3.7.* *_cpython '
+  - 2.7.*  *_cpython
+  - 3.6.*  *_cpython
+  - 3.7.*  *_cpython

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -582,7 +582,7 @@ def update_pinning(recipe_folder, config, packages="*",
 
     State = update_pinnings.State
 
-    for status, recip in zip(utils.parallel_iter(needs_bump, dag, "Processing..."), dag):
+    for status, recip in utils.parallel_iter(needs_bump, dag, "Processing..."):
         logger.debug("Recipe %s status: %s", recip, status)
         stats[status] += 1
         if status.needs_bump(bump_only_python):

--- a/bioconda_utils/update_pinnings.py
+++ b/bioconda_utils/update_pinnings.py
@@ -2,17 +2,11 @@
 Determine which packages need updates after pinning change
 """
 
-import re
-import sys
-import os.path
-import logging
-import collections
 import enum
+import logging
 import string
 
-import networkx as nx
-
-from .utils import RepoData, load_conda_build_config, parallel_iter
+from .utils import RepoData
 # FIXME: trim_build_only_deps is not exported via conda_build.api!
 #        Re-implement it here or ask upstream to export that functionality.
 from conda_build.metadata import trim_build_only_deps

--- a/bioconda_utils/update_pinnings.py
+++ b/bioconda_utils/update_pinnings.py
@@ -137,7 +137,7 @@ def check(recipe: Recipe, build_config, keep_metas=False) -> State:
       keep_metas: If true, `Recipe.conda_release` is not called
 
     Returns:
-      Tuple of state and a list of rendered MetaYaml variant objects
+      Tuple of state and a the input recipe
     """
     try:
         logger.debug("Calling Conda to render %s", recipe)
@@ -145,14 +145,14 @@ def check(recipe: Recipe, build_config, keep_metas=False) -> State:
         logger.debug("Finished rendering %s", recipe)
     except RecipeError as exc:
         logger.error(exc)
-        return State.FAIL
+        return State.FAIL, recipe
     except Exception as exc:
         logger.exception("update_pinnings.check failed with exception in api.render(%s):", recipe)
-        return State.FAIL
+        return State.FAIL, recipe
 
     if metas is None:
         logger.error("Failed to render %s. Got 'None' from recipe.conda_render()", recipe)
-        return State.FAIL
+        return State.FAIL, recipe
 
     flags = State(0)
     for meta, _, _ in metas:
@@ -170,4 +170,4 @@ def check(recipe: Recipe, build_config, keep_metas=False) -> State:
             flags |= State.BUMP
     if not keep_metas:
         recipe.conda_release()
-    return flags
+    return flags, recipe


### PR DESCRIPTION
Some fixes for `update-pinnings`.

IMPORTANT: The change from https://github.com/bioconda/bioconda-utils/pull/662/files#diff-2aed786d397cbb062fb58d1ff86a6950R26 caused different build strings for `r-base`-dependent packages because it triggered the logic from https://github.com/conda/conda-build/pull/3895. I hadn't thought of that before unfortunately.
Thankfully the last Bioconductor `bulk` work happened before that change. That means it should not affect terribly many recipes.