### PR TITLE
lint: add trigger for missing_meta_yaml

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -800,11 +800,20 @@ def get_recipes(recipe_folder, package="*", exclude=None):
                      recipe_folder, package, p)
         path = os.path.join(recipe_folder, p)
         for new_dir in glob.glob(path):
+            meta_yaml_found = False
             for dir_path, dir_names, file_names in os.walk(new_dir):
                 if any(fnmatch.fnmatch(dir_path[len(recipe_folder):], pat) for pat in exclude):
                     continue
                 if "meta.yaml" in file_names:
+                    meta_yaml_found = True
                     yield dir_path
+            if not meta_yaml_found and os.path.isdir(new_dir):
+                logger.warn(
+                    "No meta.yaml found in %s."
+                    " If you want to ignore this directory, add it to the blacklist.",
+                    new_dir
+                )
+                yield new_dir
 
 
 def get_latest_recipes(recipe_folder, config, package="*"):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,9 @@
 import contextlib
 import datetime
-import tempfile
 import os
 import os.path as op
+import shutil
+import tempfile
 from copy import deepcopy
 
 from ruamel_yaml import YAML
@@ -155,5 +156,17 @@ def recipe_dir(recipes_folder: py.path.local, tmpdir: py.path.local,
         for fname, data in case['add_files'].items():
             with recipe_dir.join(fname).open('w') as fdes:
                 fdes.write(data)
+
+    if 'move_files' in case:
+        for src, dest in case['move_files'].items():
+            src_path = recipe_dir.join(src)
+            if not dest:
+                if os.path.isdir(src_path):
+                    shutil.rmtree(src_path)
+                else:
+                    os.remove(src_path)
+            else:
+                dest_path = recipe_dir.join(dest)
+                shutil.move(src_path, dest_path)
 
     yield recipe_dir

--- a/test/lint_cases.yaml
+++ b/test/lint_cases.yaml
@@ -57,6 +57,14 @@ setup:
 
 tests:
 - name: minimal_recipe
+- name: missing_meta_yaml
+  move_files:
+    meta.yaml: ''
+  expect: missing_meta_yaml
+- name: meta_yml
+  move_files:
+    meta.yaml: meta.yml
+  expect: missing_meta_yaml
 - name: empty_build_section
   remove: build
   expect: [should_be_noarch_generic, missing_build_number]


### PR DESCRIPTION
Fixes issue reported in https://github.com/bioconda/bioconda-recipes/pull/22992, i.e.,
recipe file ending with `.yml` instead of `.yaml` but not being detected by the linter.