### PR TITLE
build: catch both UnsatisfiableError, DependencyNeedsBuildingError

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -10,9 +10,8 @@ import itertools
 
 from typing import List
 
-# TODO: UnsatisfiableError is not yet in exports for conda 4.5.4
-# from conda.exports import UnsatisfiableError
-from conda.exceptions import UnsatisfiableError
+from conda.exports import UnsatisfiableError
+from conda_build.exceptions import DependencyNeedsBuildingError
 import networkx as nx
 import pandas
 
@@ -324,7 +323,7 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
             for pkg in nx.algorithms.descendants(subdag, name):
                 skip_dependent[pkg].append(recipe)
             continue
-        except UnsatisfiableError as exc:
+        except (UnsatisfiableError, DependencyNeedsBuildingError) as exc:
             logger.error('BUILD ERROR: could not determine dependencies for recipe %s: %s',
                          recipe, exc)
             failed.append(recipe)


### PR DESCRIPTION
Bulk builds fail completely due to https://github.com/conda/conda-build/pull/4001 .
Even with that patch (submitted as https://github.com/conda-forge/conda-build-feedstock/pull/140 too), we have to catch `DependencyNeedsBuildingError`.