### PR TITLE
Update versions doc wording per feedback

### DIFF
--- a/docs/source/user/versions.rst
+++ b/docs/source/user/versions.rst
@@ -22,8 +22,7 @@ builds, such as `pysam`, and so do not meet this criteria.)
 
 Unsupported versions
 --------------------
-If there is a version of a dependency you wish to build against that Bioconda does not currently support
-plesase reach out to the `Bioconda gitter <https://gitter.im/bioconda/Lobby>`_ for more information
+If there is a version of a dependency you wish to build against that Bioconda does not currently support,
+please reach out to the `Bioconda Gitter <https://gitter.im/bioconda/Lobby>`_ for more information
 about if supporting that version is feasible, if work on that is already being done, and how you
 can help.
-

--- a/docs/source/user/versions.rst
+++ b/docs/source/user/versions.rst
@@ -1,7 +1,7 @@
 
 Versions Supported in Bioconda
 ==============================
-Bioconda only supports some versions of conda packages.
+The Bioconda build system only supports some versions of common software dependencies.
 Here is an incomplete list of the dependencies that might be relevant to your
 conda environment.
 
@@ -22,14 +22,8 @@ builds, such as `pysam`, and so do not meet this criteria.)
 
 Unsupported versions
 --------------------
-If the version of a package you wish to use is not supported because it is too old, please upgrade to a newer
-version so that you can use Bioconda.
-
-If the version you wish to use is not supported because it is too new:
-
-* If it is a small piece of software, please consider
-  :doc:`contributing it to Bioconda <../contributor/index>`
-* If it is a large piece of software (like the python language) ask about
-  feasibility, timelines, and how you can help on the
-  `Bioconda gitter <https://gitter.im/bioconda/Lobby>`_
+If there is a version of a dependency you wish to build against that Bioconda does not currently support
+plesase reach out to the `Bioconda gitter <https://gitter.im/bioconda/Lobby>`_ for more information
+about if supporting that version is feasible, if work on that is already being done, and how you
+can help.
 


### PR DESCRIPTION
Fix wording based on feedback from @mbargull on the [initial PR](https://github.com/bioconda/bioconda-utils/pull/664) for this page. Been meaning to do this for a while, just got around to it. This simplifies the unsupported versions section - it just points people to the gitter instead of trying to triage possible outcomes here.