### PR TITLE
utils.get_recipes: consider exclude in meta_yaml_found handling

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -800,14 +800,15 @@ def get_recipes(recipe_folder, package="*", exclude=None):
                      recipe_folder, package, p)
         path = os.path.join(recipe_folder, p)
         for new_dir in glob.glob(path):
-            meta_yaml_found = False
+            meta_yaml_found_or_excluded = False
             for dir_path, dir_names, file_names in os.walk(new_dir):
                 if any(fnmatch.fnmatch(dir_path[len(recipe_folder):], pat) for pat in exclude):
+                    meta_yaml_found_or_excluded = True
                     continue
                 if "meta.yaml" in file_names:
-                    meta_yaml_found = True
+                    meta_yaml_found_or_excluded = True
                     yield dir_path
-            if not meta_yaml_found and os.path.isdir(new_dir):
+            if not meta_yaml_found_or_excluded and os.path.isdir(new_dir):
                 logger.warn(
                     "No meta.yaml found in %s."
                     " If you want to ignore this directory, add it to the blacklist.",


### PR DESCRIPTION
follow up fix for gh-668 that let's the `autobump` not process `bioconductor-*` recipes.