### PR TITLE
Update pinning: py3.8, conda-forge-pinning=2020.08.29.21.09.48

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -29,6 +29,28 @@ bamtools:
 r_base:
   - 4.0.*
 python:
-  - 2.7.*  *_cpython
-  - 3.6.*  *_cpython
+  - 3.8.*  *_cpython
   - 3.7.*  *_cpython
+  - 3.6.*  *_cpython
+  - 2.7.*  *_cpython
+
+# conda-forge-pinning>=2020.07.13.05.23.11 uses clang=10.
+# We still pin clang=9 here and will update to clang=10 when we update to gcc=9.
+# (Note that with bioconda-utils update-pinning we don't look at osx changes.
+#  Hence, if we update clang alongside gcc, we get more consistent behavior.)
+c_compiler:
+  - gcc                        # [linux]
+  - clang                      # [osx]
+c_compiler_version:            # [unix]
+  - 9                          # [osx]
+  - 7                          # [linux64 or aarch64]
+cxx_compiler:
+  - gxx                        # [linux]
+  - clangxx                    # [osx]
+cxx_compiler_version:          # [unix]
+  - 9                          # [osx]
+  - 7                          # [linux64 or aarch64]
+fortran_compiler:              # [unix or win64]
+  - gfortran                   # [(linux64 or osx)]
+fortran_compiler_version:      # [unix or win64]
+  - 7                          # [linux64 or osx or aarch64]

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -4,7 +4,7 @@
 
 # basics
 python>=3.7
-conda=4.8.3
+conda=4.8.4
 conda-build=3.19.2
 conda-verify=3.1.*
 argh=0.26.*          # CLI
@@ -19,7 +19,7 @@ boltons=18.*
 jsonschema=2.6.*     # JSON schema verification
 
 # pinnings
-conda-forge-pinning=2020.05.02.14.58.15
+conda-forge-pinning=2020.08.29.21.09.48
 
 # tools
 anaconda-client=1.6.*  # anaconda_upload

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -593,7 +593,7 @@ def update_pinning(recipe_folder, config, packages="*",
             recip.save()
         elif status.failed():
             logger.info("Failed to inspect %s", recip)
-            hadErrors.add(recipe)
+            hadErrors.add(recip)
         else:
             logger.info('OK: %s', recip)
 

--- a/bioconda_utils/graph.py
+++ b/bioconda_utils/graph.py
@@ -103,10 +103,10 @@ def build_from_recipes(recipes):
     for recipe in recipes:
         for package in recipe.package_names:
             package2recipes.setdefault(package, set()).add(recipe)
-            recipe_list.append(recipe)
+        recipe_list.append(recipe)
 
     dag = nx.DiGraph()
-    dag.add_nodes_from(recipe.reldir for recipe in recipes)
+    dag.add_nodes_from(recipe for recipe in recipe_list)
     dag.add_edges_from(
         (recipe2, recipe)
         for recipe in recipe_list


### PR DESCRIPTION
Fixes/updates to `bioconda-utils update-pinning` and pinning updates to include Python 3.8 in our build matrix.