### PR TITLE
Ensure bioconda-utils uses the same version build container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,10 @@ variables:
     run:
       name: Build the updated docker container
       command: |
-        docker build -t bioconda/bioconda-utils-build-env:latest ./
-        docker history bioconda/bioconda-utils-build-env:latest
-        docker run --rm -t bioconda/bioconda-utils-build-env:latest sh -lec 'type -t conda && conda info -a && conda list'
-        docker build -t bioconda/bioconda-utils-test-env:latest -f ./Dockerfile.test ./
+        docker build -t quay.io/bioconda/bioconda-utils-build-env:latest ./
+        docker history quay.io/bioconda/bioconda-utils-build-env:latest
+        docker run --rm -t quay.io/bioconda/bioconda-utils-build-env:latest sh -lec 'type -t conda && conda info -a && conda list'
+        docker build -t quay.io/bioconda/bioconda-utils-test-env:latest -f ./Dockerfile.test ./
   autobump_run: &autobump_run
     name: Check recipes for new upstream releases
     command: |

--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -19,10 +19,10 @@ jobs:
         python setup.py install
     - name: Build docker container
       run: |
-        docker build -t bioconda/bioconda-utils-build-env:latest ./
-        docker history bioconda/bioconda-utils-build-env:latest
-        docker run --rm -t bioconda/bioconda-utils-build-env:latest sh -lec 'type -t conda && conda info -a && conda list'
-        docker build -t bioconda/bioconda-utils-test-env:latest -f ./Dockerfile.test ./
+        docker build -t quay.io/bioconda/bioconda-utils-build-env:latest ./
+        docker history quay.io/bioconda/bioconda-utils-build-env:latest
+        docker run --rm -t quay.io/bioconda/bioconda-utils-build-env:latest sh -lec 'type -t conda && conda info -a && conda list'
+        docker build -t quay.io/bioconda/bioconda-utils-test-env:latest -f ./Dockerfile.test ./
     - name: Run tests '${{ matrix.py_test_marker }}'
       run: |
         if git diff --name-only origin/master...HEAD | grep -vE ^docs; then

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM bioconda/bioconda-utils-build-env
+FROM quay.io/bioconda/bioconda-utils-build-env
 # Retrieve index and set TTL to make it last over the duration of the test.
 RUN \
     conda search bioconda-utils > /dev/null && \

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -118,7 +118,7 @@ chown $HOST_USER:$HOST_USER {self.container_staging}/{arch}/*
 # This template can be used for last-minute changes to the docker image, such
 # as adding proxies.
 #
-# The default image is created automatically on DockerHub using the Dockerfile
+# The default image is created automatically for releases using the Dockerfile
 # in the bioconda-utils repo.
 
 DOCKERFILE_TEMPLATE = \
@@ -164,7 +164,7 @@ class RecipeBuilder(object):
         keep_image=False,
         build_image=False,
         image_build_dir=None,
-        docker_base_image='bioconda/bioconda-utils-build-env:{}'.format(__version__)
+        docker_base_image='quay.io/bioconda/bioconda-utils-build-env:{}'.format(__version__)
     ):
         """
         Class to handle building a custom docker container that can be used for
@@ -246,7 +246,7 @@ class RecipeBuilder(object):
 
         docker_base_image : str or None
             Name of base image that can be used in **dockerfile_template**.
-            Defaults to 'bioconda/bioconda-utils-build-env:bioconda-utils-version'
+            Defaults to 'quay.io/bioconda/bioconda-utils-build-env:bioconda-utils-version'
         """
         self.requirements = requirements
         self.conda_build_args = ""

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -164,7 +164,7 @@ class RecipeBuilder(object):
         keep_image=False,
         build_image=False,
         image_build_dir=None,
-        docker_base_image='quay.io/bioconda/bioconda-utils-build-env:{}'.format(__version__)
+        docker_base_image='quay.io/bioconda/bioconda-utils-build-env:{}'.format(__version__.replace('+', '_'))
     ):
         """
         Class to handle building a custom docker container that can be used for

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -61,6 +61,7 @@ import conda
 import conda_build
 
 from . import utils
+from . import __version__
 
 import logging
 logger = logging.getLogger(__name__)
@@ -163,7 +164,7 @@ class RecipeBuilder(object):
         keep_image=False,
         build_image=False,
         image_build_dir=None,
-        docker_base_image='bioconda/bioconda-utils-build-env:latest'
+        docker_base_image='bioconda/bioconda-utils-build-env:{}'.format(__version__)
     ):
         """
         Class to handle building a custom docker container that can be used for
@@ -245,7 +246,7 @@ class RecipeBuilder(object):
 
         docker_base_image : str or None
             Name of base image that can be used in **dockerfile_template**.
-            Defaults to 'bioconda/bioconda-utils-build-env:latest'
+            Defaults to 'bioconda/bioconda-utils-build-env:bioconda-utils-version'
         """
         self.requirements = requirements
         self.conda_build_args = ""

--- a/docs/source/contributor/build-system.rst
+++ b/docs/source/contributor/build-system.rst
@@ -29,7 +29,7 @@ need to create the entire bioconda-build system environment from scratch for
 each build.
 
 When testing locally with ``circleci build``, we use the
-``bioconda/bioconda-utils-build-env`` Docker container to avoid changing the
+``quay.io/bioconda/bioconda-utils-build-env`` Docker container to avoid changing the
 local system. This container is defined by `this Dockerfile
 <https://github.com/bioconda/bioconda-utils/blob/master/Dockerfile>`_.
 

--- a/docs/source/contributor/building-locally.rst
+++ b/docs/source/contributor/building-locally.rst
@@ -20,7 +20,7 @@ You can execute an almost exact copy of our Linux build pipeline by
 folder where your copy of ``bioconda-recipes`` resides::
 
     # Ensure the build container is up-to-date
-    docker pull bioconda/bioconda-utils-build-env:latest
+    docker pull quay.io/bioconda/bioconda-utils-build-env:latest
 
     # Run the build locally
     circleci build

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -37,7 +37,7 @@ TEST_LABEL = 'bioconda-utils-test'
 # docker, once without). On OSX, only the non-docker runs.
 
 # Docker ref for build container
-DOCKER_BASE_IMAGE = "bioconda/bioconda-utils-test-env:latest"
+DOCKER_BASE_IMAGE = "quay.io/bioconda/bioconda-utils-test-env:latest"
 
 SKIP_DOCKER_TESTS = sys.platform.startswith('darwin')
 SKIP_NOT_OSX = not sys.platform.startswith('darwin')


### PR DESCRIPTION
This now no longer uses :latest, but rather whatever its version is when pulling the docker build container.