### PR TITLE
Update to linux-anvil-cos7-x86_64 build base and new base container images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,10 @@ variables:
     run:
       name: Build the updated docker container
       command: |
-        docker build -t quay.io/bioconda/bioconda-utils-build-env:latest ./
-        docker history quay.io/bioconda/bioconda-utils-build-env:latest
-        docker run --rm -t quay.io/bioconda/bioconda-utils-build-env:latest sh -lec 'type -t conda && conda info -a && conda list'
-        docker build -t quay.io/bioconda/bioconda-utils-test-env:latest -f ./Dockerfile.test ./
+        docker build -t quay.io/bioconda/bioconda-utils-build-env-cos7:latest ./
+        docker history quay.io/bioconda/bioconda-utils-build-env-cos7:latest
+        docker run --rm -t quay.io/bioconda/bioconda-utils-build-env-cos7:latest sh -lec 'type -t conda && conda info -a && conda list'
+        docker build -t quay.io/bioconda/bioconda-utils-test-env-cos7:latest -f ./Dockerfile.test ./
   autobump_run: &autobump_run
     name: Check recipes for new upstream releases
     command: |

--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -19,10 +19,10 @@ jobs:
         python setup.py install
     - name: Build docker container
       run: |
-        docker build -t quay.io/bioconda/bioconda-utils-build-env:latest ./
-        docker history quay.io/bioconda/bioconda-utils-build-env:latest
-        docker run --rm -t quay.io/bioconda/bioconda-utils-build-env:latest sh -lec 'type -t conda && conda info -a && conda list'
-        docker build -t quay.io/bioconda/bioconda-utils-test-env:latest -f ./Dockerfile.test ./
+        docker build -t quay.io/bioconda/bioconda-utils-build-env-cos7:latest ./
+        docker history quay.io/bioconda/bioconda-utils-build-env-cos7:latest
+        docker run --rm -t quay.io/bioconda/bioconda-utils-build-env-cos7:latest sh -lec 'type -t conda && conda info -a && conda list'
+        docker build -t quay.io/bioconda/bioconda-utils-test-env-cos7:latest -f ./Dockerfile.test ./
     - name: Run tests '${{ matrix.py_test_marker }}'
       run: |
         if git diff --name-only origin/master...HEAD | grep -vE ^docs; then

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -21,7 +21,7 @@ jobs:
       id: buildah-build
       uses: redhat-actions/buildah-build@v2
       with:
-        image: bioconda-utils-build-env
+        image: bioconda-utils-build-env-cos7
         tags: >-
           latest
           ${{ github.event.release && github.event.release.tag_name || github.sha }}

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,10 @@
-FROM quay.io/bioconda/bioconda-utils-build-env
+FROM quay.io/bioconda/bioconda-utils-build-env-cos7
 # Retrieve index and set TTL to make it last over the duration of the test.
-RUN \
+RUN . /opt/conda/etc/profile.d/conda.sh && \
     conda search bioconda-utils > /dev/null && \
-    conda config --set local_repodata_ttl 3600
+    conda config --set local_repodata_ttl 3600 && \
+    find /opt/conda \
+      \! -group lucky \
+      -exec chgrp --no-dereference lucky {} + \
+      \! -type l \
+      -exec chmod g=u {} +

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -105,9 +105,9 @@ def build(recipe: str, pkg_paths: List[str] = None,
     is_noarch = bool(meta.get_value('build/noarch', default=False))
     use_base_image = meta.get_value('extra/container', {}).get('extended-base', False)
     if use_base_image:
-        base_image = 'quay.io/bioconda/base-glibc-debian-bash:1.1.0'
+        base_image = 'quay.io/bioconda/base-glibc-debian-bash:2.0.0'
     else:
-        base_image = 'quay.io/bioconda/base-glibc-busybox-bash:1.1.0'
+        base_image = 'quay.io/bioconda/base-glibc-busybox-bash:2.0.0'
 
     try:
         if docker_builder is not None:

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -104,7 +104,10 @@ def build(recipe: str, pkg_paths: List[str] = None,
     meta = utils.load_first_metadata(recipe, finalize=False)
     is_noarch = bool(meta.get_value('build/noarch', default=False))
     use_base_image = meta.get_value('extra/container', {}).get('extended-base', False)
-    base_image = 'bioconda/extended-base-image' if use_base_image else None
+    if use_base_image:
+        base_image = 'quay.io/bioconda/base-glibc-debian-bash:1.1.0'
+    else:
+        base_image = 'quay.io/bioconda/base-glibc-busybox-bash:1.1.0'
 
     try:
         if docker_builder is not None:

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -122,10 +122,17 @@ chown $HOST_USER:$HOST_USER {self.container_staging}/{arch}/*
 # in the bioconda-utils repo.
 
 DOCKERFILE_TEMPLATE = \
-"""
+r"""
 FROM {docker_base_image}
 {proxies}
-RUN /opt/conda/bin/conda install -y conda={conda_ver} conda-build={conda_build_ver}
+RUN \
+    /opt/conda/bin/conda install -y conda={conda_ver} conda-build={conda_build_ver} \
+    && \
+    find /opt/conda \
+      \! -group lucky \
+      -exec chgrp --no-dereference lucky {{}} + \
+      \! -type l \
+      -exec chmod g=u {{}} +
 """  # noqa: E122 continuation line missing indentation or outdented
 
 
@@ -164,7 +171,7 @@ class RecipeBuilder(object):
         keep_image=False,
         build_image=False,
         image_build_dir=None,
-        docker_base_image='quay.io/bioconda/bioconda-utils-build-env:{}'.format(__version__.replace('+', '_'))
+        docker_base_image='quay.io/bioconda/bioconda-utils-build-env-cos7:{}'.format(__version__.replace('+', '_'))
     ):
         """
         Class to handle building a custom docker container that can be used for
@@ -246,7 +253,7 @@ class RecipeBuilder(object):
 
         docker_base_image : str or None
             Name of base image that can be used in **dockerfile_template**.
-            Defaults to 'quay.io/bioconda/bioconda-utils-build-env:bioconda-utils-version'
+            Defaults to 'quay.io/bioconda/bioconda-utils-build-env-cos7:bioconda-utils-version'
         """
         self.requirements = requirements
         self.conda_build_args = ""

--- a/bioconda_utils/involucro
+++ b/bioconda_utils/involucro
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+exec involucro \
+    -set POSTINSTALL='create-env --conda=: /usr/local' \
+    "${@}"

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -18,7 +18,7 @@ from conda_build.metadata import MetaData
 logger = logging.getLogger(__name__)
 
 # TODO: Make this configurable in bioconda_utils.build and bioconda_utils.cli.
-MULLED_CONDA_IMAGE = "quay.io/dpryan79/mulled_container:latest"
+MULLED_CONDA_IMAGE = "quay.io/bioconda/create-env:1.0.1"
 
 
 def get_tests(path):
@@ -154,10 +154,10 @@ def test_package(
     cmd += shlex.split(mulled_args)
 
     # galaxy-lib always downloads involucro, unless it's in cwd or its path is explicitly given.
-    # TODO: This should go into galaxy-lib. Once it is fixed upstream, remove this here.
-    involucro_path = which('involucro')
-    if involucro_path:
-        cmd += ['--involucro-path', involucro_path]
+    # We inject a POSTINSTALL to the involucro command with a small wrapper to
+    # create activation / entrypoint scripts for the container.
+    involucro_path = os.path.join(os.path.dirname(__file__), 'involucro')
+    cmd += ['--involucro-path', involucro_path]
 
     logger.debug('mulled-build command: %s' % cmd)
 

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -18,7 +18,7 @@ from conda_build.metadata import MetaData
 logger = logging.getLogger(__name__)
 
 # TODO: Make this configurable in bioconda_utils.build and bioconda_utils.cli.
-MULLED_CONDA_IMAGE = "quay.io/bioconda/create-env:1.0.1"
+MULLED_CONDA_IMAGE = "quay.io/bioconda/create-env:1.0.2"
 
 
 def get_tests(path):

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -1,7 +1,0 @@
-#!/bin/bash -il
-
-# Source everything that needs to be.
-. /opt/bioconda-utils/docker-entrypoint-source
-
-# Run whatever the user wants.
-exec "$@"

--- a/docker-entrypoint-source
+++ b/docker-entrypoint-source
@@ -1,2 +1,0 @@
-# Enable devtoolset-2 compilers and activate /opt/conda/bin
-. /opt/docker/bin/entrypoint_source

--- a/docs/source/contributor/build-system.rst
+++ b/docs/source/contributor/build-system.rst
@@ -29,7 +29,7 @@ need to create the entire bioconda-build system environment from scratch for
 each build.
 
 When testing locally with ``circleci build``, we use the
-``quay.io/bioconda/bioconda-utils-build-env`` Docker container to avoid changing the
+``quay.io/bioconda/bioconda-utils-build-env-cos7`` Docker container to avoid changing the
 local system. This container is defined by `this Dockerfile
 <https://github.com/bioconda/bioconda-utils/blob/master/Dockerfile>`_.
 
@@ -69,7 +69,7 @@ Configure the environment
     - package with that version number and build number does not exist in
       bioconda channel (we check the channel for each of the changed recipes)
 
-- Download the configured Docker container (currently based on CentOS 6)
+- Download the configured Docker container (currently based on CentOS 7)
     - default configured in ``bioconda-utils: docker_utils.py``
 
 - Build a new, temporary Docker container
@@ -97,8 +97,8 @@ Configure the environment
   `galaxy-lib <https://github.com/galaxyproject/galaxy-lib>`_). This acts as
   a more stringent test than ``conda-build`` alone. The BusyBox container
   purposefully is missing many system libraries (like libgcc) that may be
-  present in the CentOS 6 container. Note that it is common for a package to
-  build in the CentOS 6 container but fail in the BusyBox container. When this
+  present in the CentOS 7 container. Note that it is common for a package to
+  build in the CentOS 7 container but fail in the BusyBox container. When this
   happens, it is often because a dependency needs to be added to the recipe.
 
 - Upon successfully testing the package in the BusyBox container, we have a branch point:

--- a/test/test_case.yaml
+++ b/test/test_case.yaml
@@ -5,7 +5,8 @@ one:
       version: "0.1"
   build.sh: |
     #!/bin/bash
-    ls ${PREFIX}
+    touch "${PREFIX}/file-one"
+    ls "${PREFIX}"
 two:
   meta.yaml: |
     package:
@@ -20,10 +21,11 @@ three:
       name: three
       version: "0.1"
     requirements:
-      build:
+      host:
         - "one"
   build.sh: |
     #!/bin/bash
-    ls ${PREFIX}
+    ls "${PREFIX}"
+    ls "${PREFIX}/file-one"
 
 # vim: ts=2 sw=2

--- a/test/test_pkg_test.py
+++ b/test/test_pkg_test.py
@@ -101,7 +101,8 @@ def test_pkg_test_conda_image():
     # Inspects the installing conda version by writing $PREFIX/conda-version as
     # a post-link step -- but only if we are actually doing mulled tests, i.e.,
     # when $PREFIX == /usr/local.
-    recipe = dedent("""
+    conda_version = '4.9.2'
+    recipe = dedent(f"""
         one:
           meta.yaml: |
             package:
@@ -109,14 +110,14 @@ def test_pkg_test_conda_image():
               version: 0.1
             test:
               commands:
-                - '[ "${PREFIX}" != /usr/local ] || cat /usr/local/conda-version'
-                - '[ "${PREFIX}" != /usr/local ] || grep -F ''conda 4.3.11'' /usr/local/conda-version'
+                - '[[ "${{PREFIX}}" != /usr/local ]] || cat /usr/local/conda-version'
+                - '[[ "${{PREFIX}}" != /usr/local ]] || grep -F ''conda {conda_version}'' /usr/local/conda-version'
           post-link.sh: |
             #!/bin/bash
-            if [ "${PREFIX}" == /usr/local ] ; then
-                /opt/conda/bin/conda --version > /usr/local/conda-version
+            if [[ "${{PREFIX}}" == /usr/local ]] ; then
+                /opt/*/bin/conda --version > /usr/local/conda-version
             fi
     """)  # noqa: E501: line too long
     built_packages = _build_pkg(recipe)
     for pkg in built_packages:
-        pkg_test.test_package(pkg, conda_image="continuumio/miniconda3:4.3.11")
+        pkg_test.test_package(pkg, conda_image=f"quay.io/bioconda/create-env:1.0.1-{conda_version}")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -37,7 +37,7 @@ TEST_LABEL = 'bioconda-utils-test'
 # docker, once without). On OSX, only the non-docker runs.
 
 # Docker ref for build container
-DOCKER_BASE_IMAGE = "quay.io/bioconda/bioconda-utils-test-env:latest"
+DOCKER_BASE_IMAGE = "quay.io/bioconda/bioconda-utils-test-env-cos7:latest"
 
 SKIP_DOCKER_TESTS = sys.platform.startswith('darwin')
 SKIP_NOT_OSX = not sys.platform.startswith('darwin')


### PR DESCRIPTION
1. Use condaforge/linux-anvil-cos7-x86_64 as build base

   - Update the build base system to Centos 7.
   - Use the "conda" user from the conda-forge base image during build.
     Write access to /opt/conda is given to "conda" via a group "lucky".
     -> Make sure to `chgrp` (change group) and `chmod g=u` (copy (root)
     users' permission to group) when changing /opt/conda in the image!
   - Add back libGL.so.1 to the build container.
     So it can be used for linking as well as non-container-based tests.

2. Use new base images and env creation container

   Base images are:
   - standard: quay.io/bioconda/base-glibc-busybox-bash:2.0.0 ~~1.1.0~~
   - extended: quay.io/bioconda/base-glibc-debian-bash:2.0.0 ~~1.1.0~~

   Container for environment creation via mulled:
   - quay.io/bioconda/create-env
     In conjunction with the entrypoints from the base images above and a
     postinstall step we inject, new containers will run in activated envs.
