### PR TITLE
Fix involucro wrapper missing in sdist/wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,6 @@ include bioconda_utils/config.schema.yaml
 include bioconda_utils/templates/*
 include bioconda_utils/templates/css/*
 include bioconda_utils/maintainers.yaml
+include bioconda_utils/involucro
 include versioneer.py
 include bioconda_utils/_version.py

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -157,6 +157,8 @@ def test_package(
     # We inject a POSTINSTALL to the involucro command with a small wrapper to
     # create activation / entrypoint scripts for the container.
     involucro_path = os.path.join(os.path.dirname(__file__), 'involucro')
+    if not os.path.exists(involucro_path):
+        raise RuntimeError('internal involucro wrapper missing')
     cmd += ['--involucro-path', involucro_path]
 
     logger.debug('mulled-build command: %s' % cmd)


### PR DESCRIPTION
Small fix for environment activation in the containers.

I tried out `quay.io/biocontainers/bowtie2:2.4.2--py39hc9c6fcd_2` and noticed the activation script was empty.
What happened was that the wrapper which instructs the activation script to be built wasn't included in the sdist/wheel and as such `mulled-build` downloaded `involucro` by itself. I.e., the built container image is fine, just didn't include the activation script (as all older images do anyway).