### PR TITLE
Test env-execute/env-activate.sh in pkg_test

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -105,9 +105,9 @@ def build(recipe: str, pkg_paths: List[str] = None,
     is_noarch = bool(meta.get_value('build/noarch', default=False))
     use_base_image = meta.get_value('extra/container', {}).get('extended-base', False)
     if use_base_image:
-        base_image = 'quay.io/bioconda/base-glibc-debian-bash:2.0.0'
+        base_image = 'quay.io/bioconda/base-glibc-debian-bash:2.1.0'
     else:
-        base_image = 'quay.io/bioconda/base-glibc-busybox-bash:2.0.0'
+        base_image = 'quay.io/bioconda/base-glibc-busybox-bash:2.1.0'
 
     try:
         if docker_builder is not None:

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -18,7 +18,7 @@ from conda_build.metadata import MetaData
 logger = logging.getLogger(__name__)
 
 # TODO: Make this configurable in bioconda_utils.build and bioconda_utils.cli.
-MULLED_CONDA_IMAGE = "quay.io/bioconda/create-env:1.0.2"
+MULLED_CONDA_IMAGE = "quay.io/bioconda/create-env:2.0.0"
 
 
 def get_tests(path):
@@ -28,7 +28,10 @@ def get_tests(path):
     t.extractall(tmp)
     input_dir = os.path.join(tmp, 'info', 'recipe')
 
-    tests = []
+    tests = [
+        '/usr/local/env-execute true',
+        '. /usr/local/env-activate.sh',
+    ]
     recipe_meta = MetaData(input_dir)
 
     tests_commands = recipe_meta.get_value('test/commands')


### PR DESCRIPTION
Update create-env mulled image to 2.0.0:
- Add license information from package cache into containers
- Use /bin/bash for entrypoints

Update base images to 2.1.0:
- Debian 10.9 based