### PR TITLE
Fix licenses copying for Biocontainers

### DIFF
--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -18,7 +18,7 @@ from conda_build.metadata import MetaData
 logger = logging.getLogger(__name__)
 
 # TODO: Make this configurable in bioconda_utils.build and bioconda_utils.cli.
-MULLED_CONDA_IMAGE = "quay.io/bioconda/create-env:2.0.0"
+MULLED_CONDA_IMAGE = "quay.io/bioconda/create-env:2.1.0"
 
 
 def get_tests(path):


### PR DESCRIPTION
Small fix regarding license copying into the containers.
`bioconda/create-env:2.0.0` used `cp -l` for licenses which does not work for bind mounted volumes like we use via mulled.
`bioconda/create-env:2.1.0` drops the `-l` and just copies the license files.
Plus, with `2.0.0` errors during those copying were not caught properly, i.e., copying failed because of the hard-linking issue but the build only logged this, but did not fail as intended.