### PR TITLE
Ensure mulled tests run Bash (for activate script)

### DIFF
--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -60,7 +60,7 @@ def get_tests(path):
     tests = tests.replace('$PREFIX', '/usr/local')
     tests = tests.replace('${PREFIX}', '/usr/local')
 
-    return tests
+    return f"bash -c {shlex.quote(tests)}"
 
 
 def get_image_name(path):


### PR DESCRIPTION
In gh-707 I added `'. /usr/local/env-activate.sh'` to the tests. Mulled runs the test via `sh -c VAR.TEST` and as such uses `sh` which is `dash` in the extended base container, causing activation scripts with Bashisms to fail the test.