### PR TITLE
Set a default MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -9,6 +9,8 @@
 # clear hard-coded default value for CONDA_BUILD_SYSROOT
 CONDA_BUILD_SYSROOT:
   - ''
+MACOSX_DEPLOYMENT_TARGET:
+  - '10.9'
 
 pin_run_as_build:
   htslib:


### PR DESCRIPTION
This can be overridden in recipes' conda_build_config.yaml files.
(We have ensure that no MACOSX_DEPLOYMENT_TARGET env var is set
beforehand for this to work since conda-build prioritizes the env var.)

fixes gh-688