### PR TITLE
Add lint: check whether version starts with v

### DIFF
--- a/bioconda_utils/lint/check_policy.py
+++ b/bioconda_utils/lint/check_policy.py
@@ -123,3 +123,13 @@ class cran_packages_to_conda_forge(LintCheck):
                    for dep in deps):
                    self.message()
 
+
+class version_starts_with_v(LintCheck):
+    """The version string should not start with a "v" character
+
+    Version numbers in Conda recipes need to follow PEP 386
+
+    """
+    def check_recipe(self, recipe):
+        if recipe.get('package/version', '').startswith('v'):
+            self.message()

--- a/docs/source/contributor/linting.rst
+++ b/docs/source/contributor/linting.rst
@@ -289,6 +289,12 @@ Bioconda and it's recipe repository consistent and clean.
    package all of CRAN. For that reason, we only allow CRAN packages
    on Bioconda if they depend on other Bioconda packages.
 
+.. lint-check:: version_starts_with_v
+
+   Version numbers in Conda recipes need to follow PEP 386 and may
+   not start with a "v". With a "v", the uploaded package displays
+   incorrectly on the Anaconda website.
+
 
 Syntax
 ~~~~~~

--- a/test/lint_cases.yaml
+++ b/test/lint_cases.yaml
@@ -339,6 +339,9 @@ tests:
 - name: build_number_needs_bump
   expect: build_number_needs_bump
   add: { package: { version: 0.0.1 } }
+- name: version_starts_with_v
+  expect: version_starts_with_v
+  add: { package: { version: "v0.1" } }
 - name: in_other_channels
   expect: in_other_channels
   repodata: { conda-forge: { one: [{version: 0.1}], two: [version: 0.1] } }


### PR DESCRIPTION
See https://github.com/bioconda/bioconda-recipes/issues/19456

Since that issue has been opened, a couple more recipes have been added with the version number prefixed by `v`. This lint should prevent that.

Initially I thought this should go into `check_syntax` section, but since that’s only about the `extra` section, I ended up choosing `policy`, not sure if that is the best fit.

Ping @wholtz