### PR TITLE
requirements: Loosen git=2.14.* pin

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -26,7 +26,7 @@ conda-forge-pinning=2021.05.28.18.39.39
 anaconda-client=1.6.*  # anaconda_upload
 involucro=1.1.*        # mulled test and container build
 skopeo=0.1.35          # docker upload
-git=2.14.*             # well - git
+git=2.*                # well - git
 
 # hosters - special regex not supported by RE
 regex=2018.08.29


### PR DESCRIPTION
With that tight 2.14 pin we get an old openssl=1.0.2u in the build
container which leads to some certificate issues for HTTPS connections.