### PR TITLE
conda-forge-pinning, htslib and libdeflate updates

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -22,9 +22,9 @@ pin_run_as_build:
     min_pin: x.x
 
 htslib:
-  - 1.12
+  - 1.14
 libdeflate:
-  - 1.7
+  - 1.9
 bamtools:
   - 2.5.1
 

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -20,7 +20,7 @@ boltons=18.*
 jsonschema=2.6.*     # JSON schema verification
 
 # pinnings
-conda-forge-pinning=2021.05.28.18.39.39
+conda-forge-pinning=2022.01.13.01.57.35
 
 # tools
 anaconda-client=1.6.*  # anaconda_upload


### PR DESCRIPTION
Update htslib pinning to 1.14, libdeflate to 1.9 and conda-forge-pinning to something from today.