### PR TITLE
fix: wrong usage of lstrip in ellipsize_recipes

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -290,7 +290,7 @@ def ellipsize_recipes(recipes: Collection[str], recipe_folder: str,
         append = ", ..."
     else:
         append = ""
-    return ' ('+', '.join(recipe.lstrip(recipe_folder).lstrip('/')
+    return ' ('+', '.join(recipe.replace(recipe_folder,'').lstrip('/')
                      for recipe in recipes) + append + ')'
 
 


### PR DESCRIPTION
lstrip treats the argument as SET of characters to trim.
With the default of "recipes/" it would cut all the recipes that start with "r", "e", .. or "/". 