### PR TITLE
fix: avoid latest markupsafe if using old jinja

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -48,6 +48,7 @@ pyjwt=1.7.*               # githubhandler (JWT signing)
 beautifulsoup4=4.6.*
 galaxy-lib>=18.9.1
 jinja2>=2.10.1,<2.11.a0
+markupsafe<2.1           # markupsafe 2.1 breaks jinja2
 
 # docs
 sphinx>=4.1


### PR DESCRIPTION
As per pallets/markupsafe#282 / pallets/markupsafe#283 markupsafe v2.1 breaks Jinja2 < 3.0, which causes problems like https://github.com/bioconda/bioconda-recipes/pull/33263