### PR TITLE
fix: Update htslib pinning to 1.15

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -22,7 +22,7 @@ pin_run_as_build:
     min_pin: x.x
 
 htslib:
-  - 1.14
+  - 1.15
 
 bamtools:
   - 2.5.1


### PR DESCRIPTION
HTSlib 1.15 was released on Monday.

Samtools and bcftools users will expect samtools and bcftools to be built against htslib-1.15 (at present they have been built against 1.14 — it's surprising that this has worked; usually new samtools and bcftools releases require new htslib API functions, so such a build fails).

To avoid issues such as bioconda/bioconda-recipes#30296 and to avoid having non-sam/bcftools packages depend on outdated versions of htslib, we should bump the HTSlib pinning when new HTSlib releases come out.

This PR does that bumping for HTSlib 1.15. If this approach is accepted, when a new bioconda-utils is available, we can rebuild all htslib-requiring bioconda packages (including samtools and bcftools) with the new htslib release.