### PR TITLE
fix: Update to the most recent conda-build so git_url works again

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -5,7 +5,7 @@
 # basics
 python>=3.7
 conda=4.11.0
-conda-build=3.21.4
+conda-build=3.21.8
 conda-verify=3.1.*
 argh=0.26.*          # CLI
 colorlog=3.1.*       # Logging


### PR DESCRIPTION
Fix things like https://dev.azure.com/bioconda/bioconda-recipes/_build/results?buildId=12373&view=logs&jobId=e14e69ff-a0ae-55c4-b71d-229b239cfb2f&j=e14e69ff-a0ae-55c4-b71d-229b239cfb2f&t=7df82132-b284-504b-53d6-7d3e63519572