### PR TITLE
fix: The dependency graph should use the run-time requirements too!

### DIFF
--- a/bioconda_utils/graph.py
+++ b/bioconda_utils/graph.py
@@ -89,6 +89,7 @@ def build(recipes, config, blacklist=None, restrict=True):
             for dep in set(chain(
                 get_inner_deps(get_deps(meta, "build")),
                 get_inner_deps(get_deps(meta, "host")),
+                get_inner_deps(get_deps(meta, "run")),
             ))
         )
 


### PR DESCRIPTION
If we add stuff in run-time requirements they end up getting ignored when making the dependency graph. That can lead to some "fun" out of order failures for PRs with multiple packages.

Xref: https://github.com/bioconda/bioconda-recipes/pull/33805