### PR TITLE
git https to ssh

### DIFF
--- a/docs/source/contributor/setup.rst
+++ b/docs/source/contributor/setup.rst
@@ -36,14 +36,14 @@ To start working on a recipe (new or existing), you first need to get
 a local copy of the repo on your computer. Make sure you have ``git``
 installed, and then run::
 
-  git clone https://github.com/<USERNAME>/bioconda-recipes.git
-
+  git clone git@github.com:<USERNAME>/bioconda-recipes.git
+  
 This will create a folder ``bioconda-recipes``. To be able to update
 this folder more easily with changes made to our repository, add
 the main bioconda-recipes repo as an upstream remote::
 
     cd bioconda-recipes
-    git remote add upstream https://github.com/bioconda/bioconda-recipes.git
+    git remote add upstream git@github.com:bioconda/bioconda-recipes.git
 
 
 3. Continue with or without local builds


### PR DESCRIPTION
Since GitHub has removed password authentication, using `https` will prompt users to use their password and get errors in the future. I'd suggest switching to `ssh` to avoid this confusion and a headache for users to figure things out; this change will automatically solve the issue for users with ssh authentication already setup.