### PR TITLE
fix: Don't use conda build --output for finding output file names in …

### DIFF
--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -105,8 +105,9 @@ conda config --add channels file://{self.container_staging} 2> >(
 conda mambabuild {self.conda_build_args} {self.container_recipe}/meta.yaml 2>&1
 
 # copy all built packages to the staging area
-# Use conda mambabuild for consistency and speed
-cp `conda mambabuild {self.conda_build_args} {self.container_recipe}/meta.yaml --output | grep tar.bz2` {self.container_staging}/{arch}
+cp /opt/conda/conda-bld/*/*.tar.bz2 {self.container_staging}/{arch}
+#While technically better, this is slower and more prone to breaking
+#cp `conda mambabuild {self.conda_build_args} {self.container_recipe}/meta.yaml --output | grep tar.bz2` {self.container_staging}/{arch}
 conda index {self.container_staging}
 # Ensure permissions are correct on the host.
 HOST_USER={self.user_info[uid]}


### PR DESCRIPTION
…the docker container