### PR TITLE
fix: duplicate logging

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -215,6 +215,8 @@ def setup_logger(name: str = 'bioconda_utils', loglevel: Union[str, int] = loggi
     """
     new_logger = logging.getLogger(name)
     root_logger = logging.getLogger()
+    if root_logger.hasHandlers():
+        root_logger.handlers.clear()
 
     if logfile:
         if isinstance(logfile_level, str):


### PR DESCRIPTION
`bioconda_utils.utils.setup_logger()` adds a StreamHandler to the root logger. In the current setup, the original StreamHandler is left around, duplicating each message. This PR solves logging duplication caused by bioconda-utils. 

before:
```
INFO:bioconda_utils.cli:Considering total of 8389 recipes.
15:45:45 BIOCONDA INFO Considering total of 8389 recipes.
```

after:
```
15:46:04 BIOCONDA INFO Considering total of 8389 recipes.
```

note: conda_build _also_ causes logging duplication, but those cannot be fixed externally (`conda_build.utils.get_logger()` resets its logger every time it is called, and it's called everywhere)