### PR TITLE
feat: update mulled-test conda to 4.12

### DIFF
--- a/MulledDockerfile
+++ b/MulledDockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -qq --fix-missing && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh -o ~/miniconda.sh && \
+RUN curl -sL https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-x86_64.sh -o ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
     CONDA_AGGRESSIVE_UPDATE_PACKAGES= CONDA_AUTO_UPDATE_CONDA=0 \


### PR DESCRIPTION
The libmamba solver [may not be quite ready yet](https://github.com/conda/conda/labels/solver%3A%3Alibmamba), and I guess mamba would have been used already if it was possible. But why not match the conda version to the one in the requirements? At worst there's no more version differences, at best there are improvements in speed or memory usage.

I'm hoping this is a step in countering the root causes to #68, #660 and [recipes #33415](https://github.com/bioconda/bioconda-recipes/issues/33415)