### PR TITLE
chore!: update pinnings to python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,21 +177,6 @@ jobs:
 
 workflows:
   version: 2
-  # workflow for testing pushes and PRs
-  bioconda-utils-test:
-    jobs:
-      # - test-linux:
-      #     context: org-global
-      # - test-linux (long_running_1):
-      #     context: org-global
-      # - test-linux (long_running_2):
-      #     context: org-global
-      #- test-macos:
-      #    context: org-global
-      - build-docs:
-          context: org-global
-      #- autobump-test:
-      #    context: org-global
   # regular runs of build-docs
   bioconda-utils-build-docs:
      triggers:

--- a/README.md
+++ b/README.md
@@ -27,4 +27,3 @@ See the help for the `bioconda-utils` command-line interface for details:
 ```bash
 bioconda-utils -h
 ```
-

--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ See the help for the `bioconda-utils` command-line interface for details:
 ```bash
 bioconda-utils -h
 ```
+

--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -46,6 +46,7 @@ python_impl:
   - cpython
   - cpython
   - cpython
+  - cpython
 numpy:
   - 1.19.*
   - 1.17.*

--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -34,6 +34,7 @@ r_base:
 
 python:
   - 3.9.*  *_cpython
+  - 3.9.*  *_cpython
   - 3.8.*  *_cpython
   - 3.7.*  *_cpython
   - 3.6.*  *_cpython


### PR DESCRIPTION
The intent here is to update pinnings to python 3.10, but only to be used on the bulk branch to rebuild packages as needed.

The specific steps involved here are:

- include python 3.10 in the pinnings (this PR)
- cut a new bioconda-utils release (when the Release Please PR is merged)
- let autobump bot pick up the new release
- merge the updated package PR in bioconda-recipes
- update common.sh (to point to newly-created bioconda-utils version) *but only in the bulk branch of bioconda-common*. The bulk branch of bioconda-recipes will read from the bulk branch of bioconda-common.