### PR TITLE
feat: linter for missing space in dependency version contraints

### DIFF
--- a/bioconda_utils/lint/check_syntax.py
+++ b/bioconda_utils/lint/check_syntax.py
@@ -4,8 +4,49 @@ These checks verify syntax (schema), in particular for the ``extra``
 section that is otherwise free-form.
 
 """
+import re
 
 from . import LintCheck, ERROR, WARNING, INFO
+
+
+class version_constraints_missing_whitespace(LintCheck):
+    """Packages and their version constraints must be space separated
+
+    Example::
+
+        host:
+            python >=3
+
+    """
+    def check_recipe(self, recipe):
+        check_paths = []
+        for section in ('build', 'run', 'host'):
+            check_paths.append(f'requirements/{section}')
+
+        constraints = re.compile("(.*?)([<=>].*)")
+        for path in check_paths:
+            for n, spec in enumerate(recipe.get(path, [])):
+                has_constraints = constraints.search(spec)
+                if has_constraints:
+                    space_separated = has_constraints[1].endswith(" ")
+                    if not space_separated:
+                        self.message(section=f"{path}/{n}", data=True)
+
+    def fix(self, _message, _data):
+        check_paths = []
+        for section in ('build', 'run', 'host'):
+            check_paths.append(f'requirements/{section}')
+
+        constraints = re.compile("(.*?)([<=>].*)")
+        for path in check_paths:
+            for spec in self.recipe.get(path, []):
+                has_constraints = constraints.search(spec)
+                if has_constraints:
+                    space_separated = has_constraints[1].endswith(" ")
+                    if not space_separated:
+                        dep, ver = has_constraints.groups()
+                        self.recipe.replace(spec, f"{dep} {ver}", within='requirements')
+        return True
 
 
 class extra_identifiers_not_list(LintCheck):

--- a/test/lint_cases.yaml
+++ b/test/lint_cases.yaml
@@ -285,6 +285,11 @@ tests:
   add_files:
     build.sh: |
       $PYTHON setup.py install
+- name: version_constraints_whitespace_ok
+  add: { requirements: { run: ['one >1', 'two >=1', 'three >1,<2'] } }
+- name: version_constraints_whitespace_missing
+  expect: version_constraints_missing_whitespace
+  add: { requirements: { run: ['one>1'] } }
 - name: extra_identifiers_ok
   add: { extra: { identifiers: ['doi:123'] } }
 - name: extra_identifiers_not_list


### PR DESCRIPTION
Identify missing whitespace between a package and its version constraints, before it causes a cryptic error in the build phase.
Also implements the `fix` method, and adds lint test cases.

notes: `check_recipe` was used instread of `check_deps` because the latter removes version constraints.

resolves #789