### PR TITLE
feat: Update htslib and conda-forge pinnings

### DIFF
--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -20,7 +20,7 @@ jobs:
       uses: bioconda/bioconda-actions/bioconda_utils_setup_conda/@master
     - name: Install bioconda-utils
       run: |
-        python setup.py install
+        python setup.py install -r test-requirements.txt
     - name: Build docker container
       run: |
         docker build -t quay.io/bioconda/bioconda-utils-build-env-cos7:latest ./

--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -20,7 +20,7 @@ jobs:
       uses: bioconda/bioconda-actions/bioconda_utils_setup_conda/@master
     - name: Install bioconda-utils
       run: |
-        python setup.py install -r test-requirements.txt
+        python setup.py install
     - name: Build docker container
       run: |
         docker build -t quay.io/bioconda/bioconda-utils-build-env-cos7:latest ./

--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -22,7 +22,7 @@ pin_run_as_build:
     min_pin: x.x
 
 htslib:
-  - 1.15
+  - 1.16
 
 bamtools:
   - 2.5.1

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -22,7 +22,7 @@ jsonschema=2.6.*     # JSON schema verification
 simplejson           # Used by bioconda bot worker (NEEDED?)
 
 # pinnings
-conda-forge-pinning=2022.02.18.13.24.38
+conda-forge-pinning=2022.08.25.15.20.42
 
 # tools
 anaconda-client=1.6.*  # anaconda_upload


### PR DESCRIPTION
Pin htslib 1.16, which was released in mid August. Updating this pinning (and deploying the resulting bioconda-utils release and rebuilding htslib) is a prerequisite for releasing new samtools (cf bioconda/bioconda-recipes#36525) and bcftools (cf bioconda/bioconda-recipes#36524) packages.

Update conda-forge-pinning to the most recent release; in particular, so that libdeflate (used by htslib) is pinned to 1.13, as per recent conda-forge packages. Currently we pin libdeflate 1.10, which will surely soon drop out of _conda-forge/current_repodata.json_ which would result in a resurgence of bioconda/bioconda-recipes#24199.