### PR TITLE
fix: add -L to curl commands used in bioconductor data pkgs

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -1248,7 +1248,7 @@ def write_recipe(package, recipe_dir, config, force=False, bioc_version=None,
 
             SUCCESS=0
             for URL in ${URLS[@]}; do
-              curl $URL > $TARBALL
+              curl -L $URL > $TARBALL
               [[ $? == 0 ]] || continue
 
               # Platform-specific md5sum checks.


### PR DESCRIPTION
The packages have been largely fixed in https://github.com/bioconda/bioconda-recipes/tree/bulk-bioconductor-data, but this way new packages will also have `-L`.