### PR TITLE
feat: schedule docs on GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,9 @@ variables:
         docker run --rm -t quay.io/bioconda/bioconda-utils-build-env-cos7:latest sh -lec 'type -t conda && conda info -a && conda list'
         docker build -t quay.io/bioconda/bioconda-utils-test-env-cos7:latest -f ./Dockerfile.test ./
 
-  # TODO: migrate to GitHub Actions
+  # NOTE: We want this to stay on CircleCI (rather than run on Azure Pipelines
+  # or GitHub Actions) so that we avoid additional workload on those other
+  # services (which currently take care of PRs and bulk branch respectively)
   autobump_run: &autobump_run
     name: Check recipes for new upstream releases
     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,17 +178,17 @@ jobs:
 workflows:
   version: 2
   # regular runs of build-docs
-  bioconda-utils-build-docs:
-     triggers:
-       - schedule:
-           cron: "0 0,6 * * *"
-           filters:
-             branches:
-               only:
-                 - master
-     jobs:
-       - build-docs:
-           context: org-global
+  # bioconda-utils-build-docs:
+  #    triggers:
+  #      - schedule:
+  #          cron: "0 0,6 * * *"
+  #          filters:
+  #            branches:
+  #              only:
+  #                - master
+  #    jobs:
+  #      - build-docs:
+  #          context: org-global
   # regular runs of autobump
   bioconda-utils-autobump:
      triggers:

--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -6,7 +6,6 @@ concurrency:
 
 jobs:
   test-linux:
-    if: ${{ false }}
     name: Linux tests
     runs-on: ubuntu-latest
     strategy:
@@ -36,7 +35,6 @@ jobs:
             echo "Skipping pytest - only docs modified"
         fi
   test-macosx:
-    if: ${{ false }}
     name: OSX tests
     runs-on: macOS-latest
     steps:
@@ -54,7 +52,6 @@ jobs:
             echo "Skipping pytest - only docs modified"
         fi
   autobump-test:
-    if: ${{ false }}
     name: autobump test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -6,6 +6,7 @@ concurrency:
 
 jobs:
   test-linux:
+    if: ${{ false }}
     name: Linux tests
     runs-on: ubuntu-latest
     strategy:
@@ -35,6 +36,7 @@ jobs:
             echo "Skipping pytest - only docs modified"
         fi
   test-macosx:
+    if: ${{ false }}
     name: OSX tests
     runs-on: macOS-latest
     steps:
@@ -52,6 +54,7 @@ jobs:
             echo "Skipping pytest - only docs modified"
         fi
   autobump-test:
+    if: ${{ false }}
     name: autobump test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,7 @@ jobs:
         conda activate ./env
         (cd docs && make html)
         touch docs/build/html/.nojekyll
+        tar -czf docs.tar.gz docs/build/html
 
     # Upload the built docs as an artifact for inspection (even on PRs). This
     # will show up in the Actions web interface.
@@ -35,7 +36,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: doc
-        path: docs/build/html
+        path: docs.tar.gz
 
     # Start the SSH agent so that subsequent steps don't need additional SSH
     # setup. The private key has been added as a secret to this repo (the one

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 on:
   push:
   schedule:
-    - cron: '05 14 * * *'
+    - cron: '05 19 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,7 +31,7 @@ jobs:
         set -euo pipefail
         eval "$(conda shell.bash hook)"
         conda activate ./env
-        (cd docs && make clean html SPHINXOPTS="-T -j1" 2>&1 | grep -v "WARNING nonlocal image URL found:")
+        (cd docs && make clean html SPHINXOPTS="-T -j1"
         touch docs/build/html/.nojekyll
         tar -czf docs.tar.gz docs/build/html
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,9 @@
 name: docs
-on: [push]
+on
+ - push
+ - schedule:
+    - cron: '05 14 * * *'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
           --channel bioconda \
           --strict-channel-priority
 
-        conda activate ./env 
+        conda activate ./env
         python setup.py install
 
     # Build docs here
@@ -30,7 +30,7 @@ jobs:
       run: |
         eval "$(conda shell.bash hook)"
         conda activate ./env
-        (cd docs && make clean html SPHINXOPTS="-T -j1")
+        (cd docs && BIOCONDA_FILTER_RECIPES=5 make clean html SPHINXOPTS="-T -j1")
         touch docs/build/html/.nojekyll
         tar -czf docs.tar.gz docs/build/html
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         eval "$(conda shell.bash hook)"
         conda activate ./env
-        (cd docs && make clean html SPHINXOPTS="-T -j1"
+        (cd docs && make clean html SPHINXOPTS="-T -j1")
         touch docs/build/html/.nojekyll
         tar -czf docs.tar.gz docs/build/html
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,6 @@ jobs:
     # Build docs here
     - name: build docs
       run: |
-        set -euo pipefail
         eval "$(conda shell.bash hook)"
         conda activate ./env
         (cd docs && make clean html SPHINXOPTS="-T -j1"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,7 @@ jobs:
     # Build docs here
     - name: build docs
       run: |
+        set -euo pipefail
         eval "$(conda shell.bash hook)"
         conda activate ./env
         (cd docs && make clean html SPHINXOPTS="-T -j1" 2>&1 | grep -v "WARNING nonlocal image URL found:")

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: docs
-on
- - push
- - schedule:
+on:
+  push:
+  schedule:
     - cron: '05 14 * * *'
 
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 on:
   push:
   schedule:
-    - cron: '05 19 * * *'
+    - cron: '05 20 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         eval "$(conda shell.bash hook)"
         conda activate ./env
-        (cd docs && BIOCONDA_FILTER_RECIPES=5 make clean html SPHINXOPTS="-T -j1")
+        (cd docs && make clean html SPHINXOPTS="-T -j1")
         touch docs/build/html/.nojekyll
         tar -czf docs.tar.gz docs/build/html
 

--- a/bioconda_utils/__init__.py
+++ b/bioconda_utils/__init__.py
@@ -27,7 +27,6 @@ Bioconda Utilities Package
    hosters
    pkg_test
    recipe
-   sphinxext
    autobump
    update_pinnings
    upload

--- a/docs/source/_ext/bioconda_sphinx_ext.py
+++ b/docs/source/_ext/bioconda_sphinx_ext.py
@@ -218,7 +218,7 @@ class RequirementsField(GroupedField):
             backrefs.add((env.docname, source))
 
         fieldbody = nodes.field_body('', listnode)
-        fieldbody.set_class('field-list-wrapped')
+        fieldbody['classes'].append('field-list-wrapped')
         return nodes.field('', fieldname, fieldbody)
 
 

--- a/docs/source/_ext/bioconda_sphinx_ext.py
+++ b/docs/source/_ext/bioconda_sphinx_ext.py
@@ -264,7 +264,7 @@ def resolve_required_by_xrefs(app, env, node, contnode):
                                       classes=['xref', 'backref'])
             refnode = make_refnode(app.builder, docname,
                                    back_docname, back_target, name_node)
-            refnode.set_class('conda-package')
+            refnode['classes'].append('conda-package')
             par += refnode
             listnode += nodes.list_item('', par)
         return listnode
@@ -468,7 +468,7 @@ class CondaDomain(Domain):
                     self.data['objects'][objtype, target][0],
                     self.data['objects'][objtype, target][1],
                     contnode, target + ' ' + objtype)
-                node.set_class('conda-package')
+                node['classes'].append('conda-package')
                 return node
 
             if objtype == "package":

--- a/docs/source/contributor/linting.rst
+++ b/docs/source/contributor/linting.rst
@@ -149,10 +149,6 @@ anything essential.
    The build number should be ``0`` for any new version and
    incremented with each revised build published.
 
-.. lint-check:: version_constraints_missing_whitespace
-
-   Version constraints in the meta.yaml must have spaces between the package
-   name and the constraint. E.g., not `python>=3.8` but instead `python >=3.8`.
 
 
 Noarch or not noarch
@@ -329,6 +325,10 @@ These checks ensure that the ``extra`` section conforms to our
    The recipe is trying to skip a lint with an unknown name. Check
    the list here for the correct name.
 
+.. lint-check:: version_constraints_missing_whitespace
+
+   Version constraints in the meta.yaml must have spaces between the package
+   name and the constraint.
 
 Recipe Parsing
 ~~~~~~~~~~~~~~

--- a/docs/source/contributor/linting.rst
+++ b/docs/source/contributor/linting.rst
@@ -149,6 +149,11 @@ anything essential.
    The build number should be ``0`` for any new version and
    incremented with each revised build published.
 
+.. lint-check:: version_constraints_missing_whitespace
+
+   Version constraints in the meta.yaml must have spaces between the package
+   name and the constraint. E.g., not `python>=3.8` but instead `python >=3.8`.
+
 
 Noarch or not noarch
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Consolidating the documentation-building to a single location (GitHub Actions) rather than the current case of on CircleCI when scheduled but GH on push to master.

This also fixes a deprecation error in the recent distutils version used here that was otherwise preventing docs from being generated, and adds previously missing docs for the new version whitespace lint.