### PR TITLE
fix: use mambaforge for autobump jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,14 +35,13 @@ jobs:
           command: |
             source .circleci/common.sh
             git checkout ${BIOCONDA_UTILS_TAG}
-            curl -L -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VER}-Linux-x86_64.sh
-            bash miniconda.sh -b -p ./miniconda
-            conda config --system --add channels defaults
-            conda config --system --add channels bioconda
-            conda config --system --add channels conda-forge
-            conda install -y mamba
+            curl -L -o mambaforge.sh https://github.com/conda-forge/miniforge/releases/download/${MAMBAFORGE_VER}/Mambaforge-${MAMBAFORGE_VER}-Linux-x86_64.sh
+            bash mambaforge.sh -b -p ./mambaforge
+            mamba config --system --add channels defaults
+            mamba config --system --add channels bioconda
+            mamba config --system --add channels conda-forge
             mamba install -y --file bioconda_utils/bioconda_utils-requirements.txt --file test-requirements.txt
-            conda clean -y --all
+            mamba clean -y --all
             python setup.py install
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,13 +35,14 @@ jobs:
           command: |
             source .circleci/common.sh
             git checkout ${BIOCONDA_UTILS_TAG}
-            curl -L -o mambaforge.sh https://github.com/conda-forge/miniforge/releases/download/${MAMBAFORGE_VER}/Mambaforge-${MAMBAFORGE_VER}-Linux-x86_64.sh
-            bash mambaforge.sh -b -p ./mambaforge
-            mamba config --system --add channels defaults
-            mamba config --system --add channels bioconda
-            mamba config --system --add channels conda-forge
+            curl -L -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VER}-Linux-x86_64.sh
+            bash miniconda.sh -b -p ./miniconda
+            conda config --system --add channels defaults
+            conda config --system --add channels bioconda
+            conda config --system --add channels conda-forge
+            conda install -y mamba
             mamba install -y --file bioconda_utils/bioconda_utils-requirements.txt --file test-requirements.txt
-            mamba clean -y --all
+            conda clean -y --all
             python setup.py install
 
       - save_cache:

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -20,7 +20,7 @@ libblas=*=*openblas  # Avoid large mkl package (pulled in by pandas)
 boltons=18.*
 jsonschema=2.6.*     # JSON schema verification
 simplejson           # Used by bioconda bot worker (NEEDED?)
-pyopenssl=22.0.*     # avoid this bug https://askubuntu.com/questions/1428181/module-lib-has-no-attribute-x509-v-flag-cb-issuer-check
+pyopenssl>=22        # avoid this bug https://askubuntu.com/questions/1428181/module-lib-has-no-attribute-x509-v-flag-cb-issuer-check
 
 # pinnings
 conda-forge-pinning=2022.08.25.15.20.42

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -20,6 +20,7 @@ libblas=*=*openblas  # Avoid large mkl package (pulled in by pandas)
 boltons=18.*
 jsonschema=2.6.*     # JSON schema verification
 simplejson           # Used by bioconda bot worker (NEEDED?)
+pyopenssl=22.0.*     # avoid this bug https://askubuntu.com/questions/1428181/module-lib-has-no-attribute-x509-v-flag-cb-issuer-check
 
 # pinnings
 conda-forge-pinning=2022.08.25.15.20.42


### PR DESCRIPTION
autobump fails since a couple of days, with to this error in the setup dependencies step:
```
Preparing transaction: - \ | / - \ done
Verifying transaction: / - \ | / - \ | / - \ | / - done
Executing transaction: | / - \ | / - b''
\ | b''
/ - \ | / - \ | / - \ | / - \ | / - \ | / - \ | / - \ | / - \ | / - done
Traceback (most recent call last):
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/exceptions.py", line 1082, in __call__
    return func(*args, **kwargs)
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/cli/main.py", line 87, in _main
    exit_code = do_call(args, p)
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/cli/conda_argparse.py", line 84, in do_call
    return getattr(module, func_name)(args, parser)
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/cli/main_clean.py", line 288, in execute
    json_result = _execute(args, parser)
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/cli/main_clean.py", line 240, in _execute
    pkgs_dirs, totalsize = find_tarballs()
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/cli/main_clean.py", line 20, in find_tarballs
    from ..core.package_cache_data import PackageCacheData
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/core/package_cache_data.py", line 14, in <module>
    from .path_actions import CacheUrlAction, ExtractPackageAction
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/core/path_actions.py", line 29, in <module>
    from ..gateways.connection.download import download
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/gateways/connection/__init__.py", line 21, in <module>
    from requests import ConnectionError, HTTPError, Session
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/requests/__init__.py", line 95, in <module>
    from urllib3.contrib import pyopenssl
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/OpenSSL/crypto.py", line 1517, in <module>
    class X509StoreFlags(object):
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/OpenSSL/crypto.py", line 1537, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/circleci/project/miniconda/bin/conda", line 13, in <module>
    sys.exit(main())
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/cli/main.py", line 155, in main
    return conda_exception_handler(_main, *args, **kwargs)
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/exceptions.py", line 1374, in conda_exception_handler
    return_value = exception_handler(func, *args, **kwargs)
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/exceptions.py", line 1085, in __call__
    return self.handle_exception(exc_val, exc_tb)
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/exceptions.py", line 1129, in handle_exception
    return self.handle_unexpected_exception(exc_val, exc_tb)
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/exceptions.py", line 1140, in handle_unexpected_exception
    self.print_unexpected_error_report(error_report)
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/exceptions.py", line 1210, in print_unexpected_error_report
    from .cli.main_info import get_env_vars_str, get_main_info_str
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/cli/main_info.py", line 19, in <module>
    from ..core.index import _supplement_index_with_system
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/core/index.py", line 13, in <module>
    from .package_cache_data import PackageCacheData
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/core/package_cache_data.py", line 14, in <module>
    from .path_actions import CacheUrlAction, ExtractPackageAction
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/core/path_actions.py", line 29, in <module>
    from ..gateways.connection.download import download
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/conda/gateways/connection/__init__.py", line 21, in <module>
    from requests import ConnectionError, HTTPError, Session
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/requests/__init__.py", line 95, in <module>
    from urllib3.contrib import pyopenssl
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/OpenSSL/crypto.py", line 1517, in <module>
    class X509StoreFlags(object):
  File "/home/circleci/project/miniconda/lib/python3.7/site-packages/OpenSSL/crypto.py", line 1537, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```

This seems to be caused by an [incompatiblity](https://askubuntu.com/questions/1428181/module-lib-has-no-attribute-x509-v-flag-cb-issuer-check) of the pyopenssl used in the miniconda version we recently switched to. We could now request a newer pyopenssl (2.22 would be needed), but I thought it might as well be time to switch to mambaforge for also speeding up the installation. Let us see whether that works.