### PR TITLE
fix: Use mamba in mulled-build

### DIFF
--- a/bioconda_utils/involucro
+++ b/bioconda_utils/involucro
@@ -2,4 +2,5 @@
 
 exec involucro \
     -set POSTINSTALL='create-env --conda=: /usr/local' \
+    -set PREINSTALL='conda() { mamba "${@}" ; }' \
     "${@}"

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -159,6 +159,8 @@ def test_package(
     # galaxy-lib always downloads involucro, unless it's in cwd or its path is explicitly given.
     # We inject a POSTINSTALL to the involucro command with a small wrapper to
     # create activation / entrypoint scripts for the container.
+    # We also inject a PREINSTALL to alias conda to mamba so `mamba install` is
+    # used instead of `conda install` in the container builds.
     involucro_path = os.path.join(os.path.dirname(__file__), 'involucro')
     if not os.path.exists(involucro_path):
         raise RuntimeError('internal involucro wrapper missing')


### PR DESCRIPTION
~~With this little shell injection we can force `mulled-build` to invoke `mamba install` in place of `conda install`.
(It abuses the fact that `--conda-version` invokes a `conda install conda={conda_version}` in which we interject a `conda`->`mamba` aliasing right before the actual `conda install` for the target packages.)
This should only be taken as a possible temporary workaround that works with our current `galaxy-lib` dependency.~~

This now uses the existing `involucro` wrapper to inject a `conda`->`mamba` alias so `mamba install` is used in the container builds.

@dpryan79 suggested we could also add https://github.com/galaxyproject/galaxy/pull/14770 (via https://github.com/johanneskoester/galaxy-lib/tree/feat/use-mamba ) as a patch to https://github.com/bioconda/bioconda-recipes/blob/master/recipes/galaxy-lib/meta.yaml . That would certainly be less hacky than this PR by changing
```diff
-    # We also inject a PREINSTALL to alias conda to mamba so `mamba install` is
-    # used instead of `conda install` in the container builds.
+    cmd += ['--use-mamba']
```
. To be able to use that proposed `--use-mamba` flag with such patch, we should also increase the version of `galaxy-lib` to `19.5.2.post1` or the like and then have `galaxy-lib>=19.5.2.post1` in `bioconda_utils-requirements.txt`.
Or we just use this PR until https://github.com/galaxyproject/galaxy/pull/14770 gets into a release and we update to use `galaxy-tool-util` instead of `galaxy-lib`.