### PR TITLE
fix: Use newer mulled conda image

### DIFF
--- a/bioconda_utils/involucro
+++ b/bioconda_utils/involucro
@@ -2,5 +2,5 @@
 
 exec involucro \
     -set POSTINSTALL='create-env --conda=: /usr/local' \
-    -set PREINSTALL='conda() { mamba "${@}" ; }; mamba update -y mamba' \
+    -set PREINSTALL='conda() { mamba "${@}" ; }' \
     "${@}"

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -18,7 +18,7 @@ from conda_build.metadata import MetaData
 logger = logging.getLogger(__name__)
 
 # TODO: Make this configurable in bioconda_utils.build and bioconda_utils.cli.
-MULLED_CONDA_IMAGE = "quay.io/bioconda/create-env:2.1.0"
+MULLED_CONDA_IMAGE = "quay.io/bioconda/create-env:latest"
 
 
 def get_tests(path):


### PR DESCRIPTION
Use `quay.io/bioconda/create-env:latest` and ensure that we have updated `conda`/`mamba` packages installed.
This fixes the current state where we use `quay.io/bioconda/create-env:2.1.0` which was build 1 1/2 years ago and thus has a quite outdated `mamba` installed.