### PR TITLE
docs: Do not use <details> as much

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,10 +20,15 @@ If you have used Bioconda in the past, note that the recommended configuration
 has changed over the years. Just run the above commands to ensure your
 settings follow the current recommendation.
 
+In most cases, this is all you need to do to start using Bioconda.
+
+See also: `What do do when you do not want to modify your Conda configuration
+file <usage-without-condarc>`_.
+
 .. details:: What did these commands do?
 
-    In general, running `conda config` modifies your condarc file which can be
-    found at `~/.condarc` by default.
+    In general, running ``conda config`` modifies your condarc file which can be
+    found at ``~/.condarc`` by default.
 
     The first three commands add channels, from lowest to highest priority.
     **The order is important** to avoid problems with solving dependencies::
@@ -52,29 +57,34 @@ settings follow the current recommendation.
     section of the conda-forge docs
     <https://conda-forge.org/docs/user/tipsandtricks.html>`_ for more info.
 
-.. details:: What if I don't want to modify my condarc?
 
-    Sometimes you might want to specify the channel priority directly in the
-    ``conda`` command-line call when installing a package or creating an
-    environment, and not edit the condarc file with the suggested ``conda
-    config`` commands above.
+.. _usage-without-condarc:
 
-    In that case, you would need to add the following arguments to ``conda`` calls::
+Usage without modifying the Conda configuration
+-----------------------------------------------
 
-        --channel conda-forge --channel bioconda --strict-channel-priority
+Sometimes you might want to specify the channel priority directly in the
+``conda`` command-line call when installing a package or creating an
+environment, and not edit the ``~/.condarc`` file with the suggested ``conda
+config`` commands above.
 
-    For example, if you were creating an environment with bwa and samtools in
-    it, you would use:
+In that case, you would need to add the following arguments to ``conda`` calls::
 
-        conda create -n myenv samtools bwa \
-          --channel conda-forge \
-          --channel bioconda \
-          --channel defaults \
-          --strict-channel-priority
+    --channel conda-forge --channel bioconda --strict-channel-priority
 
-    Note that conda interprets channels on the command line in order
-    of *decreasing* priority (in contrast to ``conda config``, where they are
-    listed in increasing priority).
+For example, if you were creating an environment with bwa and samtools in
+it, you would use:
+
+    conda create -n myenv samtools bwa \
+      --channel conda-forge \
+      --channel bioconda \
+      --channel defaults \
+      --strict-channel-priority
+
+Note that conda interprets channels on the command line in order
+of *decreasing* priority (in contrast to ``conda config``, where they are
+listed in increasing priority).
+
 
 .. _`Install conda`: https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,6 @@ biomedical research using the `conda <https://conda.io>`_ package manager.
 Usage
 =====
 
-
 First, `install conda`_. Then perform a one-time set up of Bioconda with the
 following commands::
 
@@ -16,6 +15,10 @@ following commands::
     conda config --add channels bioconda
     conda config --add channels conda-forge
     conda config --set channel_priority strict
+
+If you have used Bioconda in the past, note that the recommended configuration
+has changed over the years. Just run the above commands to ensure your
+settings follow the current recommendation.
 
 .. details:: What did these commands do?
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,10 +20,13 @@ If you have used Bioconda in the past, note that the recommended configuration
 has changed over the years. Just run the above commands to ensure your
 settings follow the current recommendation.
 
-In most cases, this is all you need to do to start using Bioconda.
+.. _`Install conda`: https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html
 
-See also: `What do do when you do not want to modify your Conda configuration
-file <usage-without-condarc>`_.
+Now you can use ``conda`` to install and use any of the `packages available in
+Bioconda <conda-package_index.html>`_.
+
+See also: :ref:`What do do when you do not want to modify your Conda configuration
+file <usage-without-condarc>`.
 
 .. details:: What did these commands do?
 
@@ -85,27 +88,24 @@ Note that conda interprets channels on the command line in order
 of *decreasing* priority (in contrast to ``conda config``, where they are
 listed in increasing priority).
 
+Speeding up package installation
+--------------------------------
 
-.. _`Install conda`: https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html
+Sometimes conda can spend a lot of time trying to solve dependencies for an
+environment. See :ref:`speedup` in the FAQs for some options to improve this.
 
-Now you can use ``conda`` to install and use any of the `packages available in
-bioconda <conda-package_index.html>`_.
+Getting Docker containers of packages
+-------------------------------------
 
-.. details:: How do I speed up package installation?
+Every conda package in Bioconda has a corresponding Docker `BioContainer`_
+automatically created and uploaded to `Quay.io`_. A list of these and other
+containers can be found at the `BioContainers Registry
+<https://biocontainers.pro/#/registry>`_. For example::
 
-    Sometimes conda can spend a lot of time trying to solve dependencies for an
-    environment. See :ref:`speedup` in the FAQs for some options to improve this.
+    docker pull quay.io/biocontainers/samtools:1.15.1--h1170115_0
 
-.. details:: How do I get Docker containers of packages?
+If you have Docker installed, you do not need any additional configuration.
 
-    Every conda package in Bioconda has a corresponding Docker `BioContainer`_
-    automatically created and uploaded to `Quay.io`_. A list of these and other
-    containers can be found at the `BioContainers Registry
-    <https://biocontainers.pro/#/registry>`_. For example::
-
-        docker pull quay.io/biocontainers/samtools:1.15.1--h1170115_0
-
-    If you have docker installed, you do not need any additional configuration.
 
 Overview
 ========


### PR DESCRIPTION
On multiple occasions, I had the need to explain to fellow bioinformaticians how to use Bioconda properly (and in particular, why just using `-c bioconda` won’t work in general). There is a nice explanation about the channel setup in the documentation, but it is currently hidden behind a `<details>` tag. Linking to an expanded `<details>` tag is not possible AFAIK, so every time I had to write something like "please go to ... and then click on the triangle next to *What if I don't want to modify my condarc?*". It would be much nicer if the text were in a proper section.

My suggestion in this PR expands three of the four details texts into their own sections.

While I was editing the text, I also added a sentence about old Bioconda configurations.

I tried to run Sphinx locally to get this rendered properly, but it crashed for me after generating HTML pages for all Bioconda packages, so I hope the GitHub RST preview is enough.