### PR TITLE
docs: support anchors in <details>

### DIFF
--- a/docs/source/_ext/details_ext.py
+++ b/docs/source/_ext/details_ext.py
@@ -23,19 +23,24 @@ The resulting HTML has the structure:
     </div>
 </details>
 
-That is, you can style the part that expanded with CSS like:
+That is, you can style the part that expanded with CSS like::
 
-.. code-block:: css
+    details div { }
 
-    details div {
-    }
+And the label (when collapsed) with::
 
-And the label (when collapsed) with:
+    details summary { }
 
-.. code-block:: css
+You can also add anchors, which when visited (and when paired with the proper
+javascript) will unfold the details such that the anchors can be used as
+permalinks, like this:
 
-    details summary {
-    }
+.. details: Label here
+    :anchor: label-here
+
+    Arbitrary content
+
+Then you can link back to it with `see here <#label-here>`_.
 """
 
 

--- a/docs/source/_ext/details_ext.py
+++ b/docs/source/_ext/details_ext.py
@@ -53,11 +53,13 @@ class summary(nodes.TextElement, nodes.General):
 
 class DetailsDirective(rst.Directive):
     has_content = True
-    required_arguments = 1
+    required_arguments = 0
+    optional_arguments = 1
     final_argument_whitespace = True
     option_spec = {
         "class": rst.directives.class_option,
         "name": rst.directives.unchanged,
+        "anchor": rst.directives.unchanged,
     }
 
     def run(self):
@@ -65,15 +67,27 @@ class DetailsDirective(rst.Directive):
 
         # Pass along the first argument of the directive to the node
         details_node["heading"] = self.arguments[0]
+        details_node["anchor"] = self.options.get("anchor", None)
         self.state.nested_parse(self.content, self.content_offset, details_node)
         return [details_node]
 
 
 def visit_details(self, node):
     heading = node["heading"]
-    self.body.append(
-        f'<details><summary>{heading}</summary><div class="details">'
-    )
+    anchor = node["anchor"]
+    if anchor:
+        self.body.append(
+            f"<details><summary>{heading}</summary>"
+            f'<div id={anchor} class="details">'
+            f"<p><i>{heading}</i>"
+            f'<a class="headerlink" title="Permalink" href="#{anchor}">¶</a></p>'
+        )
+    else:
+        self.body.append(
+            f"<details><summary>{heading}</summary>"
+            f'<div class="details">'
+            f"<p><i>{heading}</i></p>"
+        )
 
 
 def depart_details(self, node):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,8 +37,15 @@ If you have used Bioconda in the past, note that the recommended configuration
 has changed over the years. You should run the above commands to ensure your
 settings follow the current recommendations.
 
+.. details:: How have the recommendations changed?
+    :anchor: recommendation-changes
+
+    In June 2022, the additional command ``conda config --set
+    channel_priority_strict`` was added; see the `explanation of commands below
+    <#explain-commands>`_ for details.
+
 .. details:: What did these commands do?
-   :anchor:
+    :anchor: explain-commands
 
     In general, running ``conda config`` modifies your condarc file which can be
     found at ``~/.condarc`` by default.
@@ -73,17 +80,18 @@ settings follow the current recommendations.
 .. details:: What if I don't want to modify my condarc?
    :anchor: do-not-modify-condarc
 
-    Sometimes you might want to specify the channel priority directly in the
-    ``conda`` command-line call when installing a package or creating an
-    environment, and not edit the condarc file with the suggested ``conda
-    config`` commands above.
+    Sometimes you want to specify the channel priority directly in the
+    ``conda`` command-line call, and do not want to change the condarc file
+    with the suggested ``conda config`` commands above.
 
-    In that case, you would need to add the following arguments to ``conda`` calls::
+    To match the above recommendations, you need to append the following
+    arguments to any ``conda`` calls::
 
         --channel conda-forge --channel bioconda --strict-channel-priority
 
-    For example, if you were creating an environment with bwa and samtools in
-    it, you would use:
+    For example, to create an environment containing bwa and
+    samtools without running the ``conda config`` commands above, then you
+    would use::
 
         conda create -n myenv samtools bwa \
           --channel conda-forge \
@@ -94,6 +102,9 @@ settings follow the current recommendations.
     Note that conda interprets channels on the command line in order
     of *decreasing* priority (in contrast to ``conda config``, where they are
     listed in increasing priority).
+
+    See the `explanation of commands <#explain-commands>`_ for details on what
+    these arguments do.
 
 .. _`Install conda`: https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html
 
@@ -122,7 +133,7 @@ Overview
 
 .. role:: circlednumber
 
-The Bioconda channel is the primary output for users, but it takes a team of
+While Bioconda channel is the primary output for users, it takes a team of
 contributors and additional infrastructure to make it all happen. The entire
 system consists of the components illustrated in the diagram below.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,11 +33,15 @@ will modify your :file:`~/.condarc` file::
     conda config --add channels conda-forge
     conda config --set channel_priority strict
 
+If you have used Bioconda in the past, note that the recommended configuration
+has changed over the years. You should run the above commands to ensure your
+settings follow the current recommendations.
+
 .. details:: What did these commands do?
    :anchor:
 
-    In general, running `conda config` modifies your condarc file which can be
-    found at `~/.condarc` by default.
+    In general, running ``conda config`` modifies your condarc file which can be
+    found at ``~/.condarc`` by default.
 
     The first three commands add channels, from lowest to highest priority.
     **The order is important** to avoid problems with solving dependencies::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,3 +1,18 @@
+.. Notes to documentation editors:
+
+   To build the documentation locally, first create an environment using
+   bioconda_utils/bioconda_utils-requirements.txt.
+
+   Then activate the env and run:
+
+     make -C docs/ BIOCONDA_FILTER_RECIPES=2 SPHINXOPTS="-E" html
+
+   This will only build 2 of the recipes pages, dramatically speeding up the
+   build process.
+
+   For more information on the ".. details::" directive, see
+   _ext/details_ext.py.
+
 .. image:: images/bioconda.png
 
 **Bioconda** lets you install thousands of software packages related to

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,9 +23,10 @@ biomedical research using the `conda <https://conda.io>`_ package manager.
 Usage
 =====
 
+First, `install conda`_.
 
-First, `install conda`_. Then perform a one-time set up of Bioconda with the
-following commands::
+Then perform a one-time set up of Bioconda with the following commands. This
+will modify your :file:`~/.condarc` file::
 
     conda config --add channels defaults
     conda config --add channels bioconda
@@ -33,6 +34,7 @@ following commands::
     conda config --set channel_priority strict
 
 .. details:: What did these commands do?
+   :anchor:
 
     In general, running `conda config` modifies your condarc file which can be
     found at `~/.condarc` by default.
@@ -65,6 +67,7 @@ following commands::
     <https://conda-forge.org/docs/user/tipsandtricks.html>`_ for more info.
 
 .. details:: What if I don't want to modify my condarc?
+   :anchor: do-not-modify-condarc
 
     Sometimes you might want to specify the channel priority directly in the
     ``conda`` command-line call when installing a package or creating an
@@ -99,6 +102,7 @@ bioconda <conda-package_index.html>`_.
     environment. See :ref:`speedup` in the FAQs for some options to improve this.
 
 .. details:: How do I get Docker containers of packages?
+   :anchor: how-do-i-get-containers
 
     Every conda package in Bioconda has a corresponding Docker `BioContainer`_
     automatically created and uploaded to `Quay.io`_. A list of these and other

--- a/docs/source/static/style.css
+++ b/docs/source/static/style.css
@@ -163,3 +163,8 @@ details div.details {
 #overview details {
     margin-top: -15px;
 }
+
+details a.headerlink {
+    color: #ccc;
+    visibility: visible;
+}

--- a/docs/source/templates/layout.html
+++ b/docs/source/templates/layout.html
@@ -19,6 +19,23 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="{{pathto('_static/ms-icon-144x144.png', 1)}}">
 
+    <script>
+        const openDetailsIfAnchorHidden = evt => {
+          const targetDiv = document.querySelector(evt.target.getAttribute("href"));
+
+          // Detect if the target is hidden, in which case do nothing
+          const props = window.getComputedStyle(targetDiv);
+          if (props.display === 'none' || props.visibility === 'hidden') return;
+
+          // otherwise, find the closest <details> element and open it
+          targetDiv.closest("details").open = true;
+        }
+
+        [...document.querySelectorAll("[href^='#']")].forEach( 
+           el => el.addEventListener("click", openDetailsIfAnchorHidden )
+        );
+    </script>
+
     <link rel="manifest" href="/manifest.json">
     <meta name="theme-color" content="#ffffff">
 {{ super() }}


### PR DESCRIPTION
This builds on ideas in @marcelm's #831 by keeping the front page streamlined while still supporting anchors that can be used as permalinks.

First, the `details_ext.py` Sphinx extension was updated to support adding an optional `:anchor:` argument. Using this option causes an anchor to be created at the top of the `<details>` element, which repeats the summary text followed by a `¶` with the permalink.

Then there's additional JS in the `docs/source/templates/layout.html` that, upon visiting an anchor, looks for the closest `<details>` to the target and makes it visible.

So once built, the link https://bioconda.github.io/index.html#do-not-modify-condarc will link to, and open if folded, the details section about how `-c bioconda` is not sufficient (the original inspiration for #831).



