### PR TITLE
fix: Change logic for checking if there are missing commits in a branch vs…

### DIFF
--- a/bioconda_utils/githandler.py
+++ b/bioconda_utils/githandler.py
@@ -147,7 +147,7 @@ class GitHandlerBase():
         return remotes[0]
 
     async def branch_is_current(self, branch, path: str, master="master") -> bool:
-        """Checks if **branch** has the most recent commit modifying **path**
+        """Checks if **branch** is missing any commits to **path**
         as compared to **master**"""
         #proc = await asyncio.create_subprocess_exec(
         #    'git', 'log', '-1', '--oneline', '--decorate',
@@ -156,7 +156,7 @@ class GitHandlerBase():
             'git', 'log', f'{branch.name}..{master}', '--', path,
             stdout=asyncio.subprocess.PIPE)
         stdout, _ = await proc.communicate()
-        return branch.name in stdout.decode('ascii')
+        return len(stdout) == 0
 
     def delete_local_branch(self, branch) -> None:
         """Deletes **branch** locally"""

--- a/bioconda_utils/githandler.py
+++ b/bioconda_utils/githandler.py
@@ -149,9 +149,11 @@ class GitHandlerBase():
     async def branch_is_current(self, branch, path: str, master="master") -> bool:
         """Checks if **branch** has the most recent commit modifying **path**
         as compared to **master**"""
+        #proc = await asyncio.create_subprocess_exec(
+        #    'git', 'log', '-1', '--oneline', '--decorate',
+        #    f'{master}...{branch.name}', '--', path,
         proc = await asyncio.create_subprocess_exec(
-            'git', 'log', '-1', '--oneline', '--decorate',
-            f'{master}...{branch.name}', '--', path,
+            'git', 'log', f'{branch.name}..{master}', '--', path,
             stdout=asyncio.subprocess.PIPE)
         stdout, _ = await proc.communicate()
         return branch.name in stdout.decode('ascii')


### PR DESCRIPTION
… master

This should prevent the bot from closing PRs prematurely, since it's now checking whether all commits to a recipe in master are synced with a PR. If not, the branch is deleted and recreated.