### PR TITLE
feat: add ability to store build failures as yaml next to recipe, add flag to automatically do so upon build failures, consider such files as blacklisting if they include `blacklist: true`.

### DIFF
--- a/bioconda_utils/blacklist.py
+++ b/bioconda_utils/blacklist.py
@@ -30,4 +30,4 @@ class Blacklist:
             return True
 
         build_failure_record = BuildFailureRecord(recipe)
-        return build_failure_record.blacklist
+        return build_failure_record.blacklists_current_recipe()

--- a/bioconda_utils/blacklist.py
+++ b/bioconda_utils/blacklist.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Union
 from bioconda_utils.recipe import Recipe
 
 from bioconda_utils.build_failure import BuildFailureRecord
@@ -20,7 +20,7 @@ class Blacklist:
     def _get_reldir(self, recipe_path: str):
         return os.path.relpath(recipe_path, self.recipe_folder)
 
-    def is_blacklisted(self, recipe: str | Recipe) -> bool:
+    def is_blacklisted(self, recipe: Union[str, Recipe]) -> bool:
         if isinstance(recipe, Recipe):
             recipe_reldir = recipe.reldir
         else:

--- a/bioconda_utils/blacklist.py
+++ b/bioconda_utils/blacklist.py
@@ -27,7 +27,7 @@ class Blacklist:
         else:
             recipe_reldir = self._get_reldir(recipe)
 
-        if recipe_reldir in self.build_failures:
+        if recipe_reldir in self.global_list:
             return True
 
         build_failure_record = BuildFailureRecord(recipe)

--- a/bioconda_utils/blacklist.py
+++ b/bioconda_utils/blacklist.py
@@ -1,0 +1,33 @@
+import os
+from typing import Any, Dict
+from bioconda_utils.recipe import Recipe
+
+from bioconda_utils.build_failure import BuildFailureRecord
+
+
+class Blacklist:
+    def __init__(self, config: Dict[str, Any], recipe_folder: str):
+        self.global_list = set()
+        for p in config.get('blacklists', []):
+            self.global_list.update(
+                [
+                    self._get_reldir(i.strip())
+                    for i in open(p, encoding='utf8')
+                    if not i.startswith('#') and i.strip()
+                ]
+            )
+
+    def _get_reldir(self, recipe_path: str):
+        return os.path.relpath(recipe_path, self.recipe_folder)
+
+    def is_blacklisted(self, recipe: str | Recipe) -> bool:
+        if isinstance(recipe, Recipe):
+            recipe_reldir = recipe.reldir
+        else:
+            recipe_reldir = self._get_reldir(recipe)
+
+        if recipe_reldir in self.build_failures:
+            return True
+
+        build_failure_record = BuildFailureRecord(recipe)
+        return build_failure_record.blacklist

--- a/bioconda_utils/blacklist.py
+++ b/bioconda_utils/blacklist.py
@@ -7,6 +7,7 @@ from bioconda_utils.build_failure import BuildFailureRecord
 
 class Blacklist:
     def __init__(self, config: Dict[str, Any], recipe_folder: str):
+        self.recipe_folder = recipe_folder
         self.global_list = set()
         for p in config.get('blacklists', []):
             self.global_list.update(

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -8,7 +8,7 @@ import os
 import logging
 import itertools
 
-from typing import List
+from typing import List, Optional
 from bioconda_utils.blacklist import Blacklist
 from bioconda_utils.build_failure import BuildFailureRecord
 from bioconda_utils.githandler import GitHandler
@@ -58,7 +58,7 @@ def build(recipe: str, pkg_paths: List[str] = None,
           linter=None,
           mulled_conda_image: str = pkg_test.MULLED_CONDA_IMAGE,
           record_build_failure: bool = False,
-          dag: nx.DiGraph | None = None,
+          dag: Optional[nx.DiGraph] = None,
           blacklist_leafs: bool = False) -> BuildResult:
     """
     Build a single recipe for a single env

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -185,21 +185,14 @@ def store_build_failure(recipe, output, meta, dag, blacklist_leafs):
     pkg_name = meta["package"]["name"]
     is_leaf = dag.out_degree(pkg_name) == 0
 
-    git_handler = GitHandler()
-    # Ger last commit sha of given recipe
-    commit = git_handler.repo.head.commit
-    tree = commit.tree
-    file_blob = tree[os.path.join(recipe, "meta.yaml")]
-    commit_sha = file_blob.binsha.hex()
-
     build_failure_record = BuildFailureRecord(recipe)
-    build_failure_record.commit_sha = commit_sha
+    build_failure_record.set_commit_sha_to_current_recipe()
     # if recipe is a leaf (i.e. not used by others as dependency)
     # we can automatically blacklist it if desired
     build_failure_record.blacklist = blacklist_leafs and is_leaf
     build_failure_record.log = output.decode("utf-8")
 
-    git_handler.commit_and_push_changes([build_failure_record.path], None, f"Add build failure record for recipe {recipe}")
+    build_failure_record.git_handler.commit_and_push_changes([build_failure_record.path], None, f"Add build failure record for recipe {recipe}")
 
 
 def remove_cycles(dag, name2recipes, failed, skip_dependent):

--- a/bioconda_utils/build_failure.py
+++ b/bioconda_utils/build_failure.py
@@ -1,19 +1,22 @@
 import os
+from bioconda_utils.githandler import GitHandler
 
-from ruamel_yaml import YAML
+from ruamel.yaml import YAML, CommentedMap
 import conda.exports
 
 from bioconda_utils.recipe import Recipe
 
 
 class BuildFailureRecord:
+    git_handler = None
+
     def __init__(self, recipe: str | Recipe):
         if isinstance(recipe, Recipe):
-            recipe_path = recipe.path
+            self.recipe_path = recipe.path
         else:
-            recipe_path = recipe
-        self.path = os.path.join(recipe_path, f"build_failure.{conda.exports.subdir}.yaml")
-        
+            self.recipe_path = recipe
+        self.path = os.path.join(self.recipe_path, f"build_failure.{conda.exports.subdir}.yaml")
+
         self.exists = False
 
         if os.path.exists(self.path):
@@ -23,9 +26,33 @@ class BuildFailureRecord:
         else:
             self.inner = dict()
 
+    def set_commit_sha_to_current_recipe(self):
+        self.commit_sha = self.get_recipe_commit_sha()
+
+    def get_recipe_commit_sha(self):
+        if self.git_handler is None:
+            self.git_handler = GitHandler()
+        # Get last commit sha of recipe
+        commit = self.git_handler.repo.head.commit
+        tree = commit.tree
+        file_blob = tree[os.path.join(self.recipe_path, "meta.yaml")]
+        commit_sha = file_blob.binsha.hex()
+        return commit_sha
+
+    def blacklists_current_recipe(self):
+        if self.blacklist:
+            commit_sha = self.get_recipe_commit_sha()
+            if commit_sha == self.commit_sha:
+                return True
+        return False
+
     def write(self):
         with open(self.path, "w") as f:
             yaml=YAML()
+            commented_map = CommentedMap()
+            commented_map.insert(0, "commit_sha", self.commit_sha, comment="The commit at which this recipe failed to build.")
+            commented_map.insert(1, "blacklist", self.blacklist, comment="Set to true to blacklist this recipe so that it will be ignored as long as its latest commit is the one given above.")
+            commented_map.insert(2, "log", self.log)
             yaml.dump(self.inner, f)
         self.exists = True
 
@@ -44,7 +71,7 @@ class BuildFailureRecord:
 
     @property
     def commit_sha(self):
-        return self.inner.get("commit_sha", "")
+        return self.inner.get("commit_sha", None)
 
     @blacklist.setter
     def blacklist(self, value):

--- a/bioconda_utils/build_failure.py
+++ b/bioconda_utils/build_failure.py
@@ -1,0 +1,59 @@
+import os
+
+from ruamel_yaml import YAML
+import conda.exports
+
+from bioconda_utils.recipe import Recipe
+
+
+class BuildFailureRecord:
+    def __init__(self, recipe: str | Recipe):
+        if isinstance(recipe, Recipe):
+            recipe_path = recipe.path
+        else:
+            recipe_path = recipe
+        self.path = os.path.join(recipe_path, f"build_failure.{conda.exports.subdir}.yaml")
+        
+        self.exists = False
+
+        if os.path.exists(self.path):
+            with open(self.path, "r") as f:
+                yaml=YAML()
+                self.inner = yaml.load(f)
+        else:
+            self.inner = dict()
+
+    def write(self):
+        with open(self.path, "w") as f:
+            yaml=YAML()
+            yaml.dump(self.inner, f)
+        self.exists = True
+
+    def delete(self):
+        if self.exists:
+            os.remove(self.path)
+            self.exists = False
+
+    @property
+    def log(self):
+        return self.inner.get("log", "")
+
+    @property
+    def blacklist(self):
+        return self.inner.get("blacklist", False)
+
+    @property
+    def commit_sha(self):
+        return self.inner.get("commit_sha", "")
+
+    @blacklist.setter
+    def blacklist(self, value):
+        self.inner["blacklist"] = value
+
+    @log.setter
+    def log(self, value):
+        self.inner["log"] = value
+    
+    @commit_sha.setter
+    def commit_sha(self, value):
+        self.inner["commit_sha"] = value

--- a/bioconda_utils/build_failure.py
+++ b/bioconda_utils/build_failure.py
@@ -1,4 +1,5 @@
 import os
+from typing import Union
 from bioconda_utils.githandler import GitHandler
 
 from ruamel.yaml import YAML, CommentedMap
@@ -10,7 +11,7 @@ from bioconda_utils.recipe import Recipe
 class BuildFailureRecord:
     git_handler = None
 
-    def __init__(self, recipe: str | Recipe):
+    def __init__(self, recipe: Union[str, Recipe]):
         if isinstance(recipe, Recipe):
             self.recipe_path = recipe.path
         else:

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -426,7 +426,7 @@ def do_lint(recipe_folder, config, packages="*", cache=None, list_checks=False,
 from environment, even after successful build and test.''')
 @arg('--docker-base-image', help='''Name of base image that can be used in
      Dockerfile template.''')
-@arg("--record-build-failues", action="store_true", help="Record build failures in build_failure.yaml next to the recipe.")
+@arg("--record-build-failures", action="store_true", help="Record build failures in build_failure.yaml next to the recipe.")
 @arg("--blacklist-leafs", action="store_true", help="Blacklist leaf recipes (i.e. ones that are not depended on by any other recipes) that fail to build.")
 @enable_logging()
 def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
@@ -436,7 +436,8 @@ def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
           check_channels=None, n_workers=1, worker_offset=0, keep_old_work=False,
           mulled_conda_image=pkg_test.MULLED_CONDA_IMAGE,
           docker_base_image='quay.io/bioconda/bioconda-utils-build-env-cos7:{}'.format(VERSION.replace('+', '_')),
-          record_build_failures=False, blacklist_leafs=False):
+          record_build_failures=False,
+          blacklist_leafs=False):
     cfg = utils.load_config(config)
     setup = cfg.get('setup', None)
     if setup:

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -427,7 +427,7 @@ from environment, even after successful build and test.''')
 @arg('--docker-base-image', help='''Name of base image that can be used in
      Dockerfile template.''')
 @arg("--record-build-failues", action="store_true", help="Record build failures in build_failure.yaml next to the recipe.")
-@arg("--blacklist-leafs", action="store_true", help="Blacklist leaf recipes that fail to build.)
+@arg("--blacklist-leafs", action="store_true", help="Blacklist leaf recipes (i.e. ones that are not depended on by any other recipes) that fail to build.")
 @enable_logging()
 def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
           force=False, docker=None, mulled_test=False, build_script_template=None,

--- a/bioconda_utils/graph.py
+++ b/bioconda_utils/graph.py
@@ -7,15 +7,18 @@ import logging
 from collections import defaultdict
 from fnmatch import fnmatch
 from itertools import chain
+from typing import Any, Dict
 
 import networkx as nx
+
+from bioconda_utils.blacklist import Blacklist
 
 from . import utils
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-def build(recipes, config, blacklist=None, restrict=True):
+def build(recipes, config: Dict[str, Any], blacklist: Blacklist | None=None, restrict: bool=True):
     """
     Returns the DAG of recipe paths and a dictionary that maps package names to
     lists of recipe paths to all defined versions of the package.  defined
@@ -48,20 +51,15 @@ def build(recipes, config, blacklist=None, restrict=True):
     recipes = list(recipes)
     metadata = list(utils.parallel_iter(utils.load_meta_fast, recipes, "Loading Recipes"))
 
-    if blacklist is None:
-        blacklist = set()
-
     # name2recipe is meta.yaml's package:name mapped to the recipe path.
     #
     # A name should map to exactly one recipe. It is possible for multiple
     # names to map to the same recipe, if the package name somehow depends on
     # the environment.
-    #
-    # Note that this may change once we support conda-build 3.
     name2recipe = defaultdict(set)
     for meta, recipe in metadata:
         name = meta["package"]["name"]
-        if name not in blacklist:
+        if blacklist is None or not blacklist.is_blacklisted(recipe):
             name2recipe[name].update([recipe])
 
     def get_deps(meta, sec):

--- a/bioconda_utils/graph.py
+++ b/bioconda_utils/graph.py
@@ -7,7 +7,7 @@ import logging
 from collections import defaultdict
 from fnmatch import fnmatch
 from itertools import chain
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import networkx as nx
 
@@ -18,7 +18,7 @@ from . import utils
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-def build(recipes, config: Dict[str, Any], blacklist: Blacklist | None=None, restrict: bool=True):
+def build(recipes, config: Dict[str, Any], blacklist: Optional[Blacklist]=None, restrict: bool=True):
     """
     Returns the DAG of recipe paths and a dictionary that maps package names to
     lists of recipe paths to all defined versions of the package.  defined

--- a/bioconda_utils/lint/__init__.py
+++ b/bioconda_utils/lint/__init__.py
@@ -104,6 +104,7 @@ from enum import IntEnum
 from typing import Any, Dict, List, NamedTuple, Set, Tuple
 
 import pandas as pd
+from bioconda_utils.blacklist import Blacklist
 import ruamel_yaml as yaml
 import networkx as nx
 
@@ -494,7 +495,7 @@ class Linter:
 
     def get_blacklist(self) -> Set[str]:
         """Loads the blacklist as per linter configuration"""
-        return utils.get_blacklist(self.config, self.recipe_folder)
+        return Blacklist(self.config, self.recipe_folder)
 
     def get_messages(self) -> List[LintMessage]:
         """Returns the lint messages collected during linting"""

--- a/bioconda_utils/lint/check_repo.py
+++ b/bioconda_utils/lint/check_repo.py
@@ -4,6 +4,7 @@ These checks verify consistency with the repository (blacklisting,
 other channels, existing versions).
 """
 
+from bioconda_utils.build_failure import BuildFailureRecord
 from .. import utils
 from . import LintCheck, ERROR, WARNING, INFO
 
@@ -78,10 +79,13 @@ class recipe_is_blacklisted(LintCheck):
         self.blacklists = linter.config.get('blacklists')
 
     def check_recipe(self, recipe):
-        if recipe.name in self.blacklist:
+        if self.blacklist.is_blacklisted(recipe):
             self.message(section='package/name', data=True)
 
     def fix(self, _message, _data):
+        failure_record = BuildFailureRecord(self.recipe)
+        if failure_record.exists and failure_record.blacklist:
+            failure_record.delete()
         for blacklist in self.blacklists:
             with open(blacklist, 'r') as fdes:
                 data = fdes.readlines()


### PR DESCRIPTION
This will enable a more automated bulk update process, where we auto-blacklist failing recipes that are not libraries.
We can then organize fixing those blacklisted recipes in a follow-up hackathon. For that purpose, I plan a bot command that automatically generates and updates an issue that lists all blacklisted recipes sorted by their download count in descending order (for prioritization). People can then choose one and post a link to the PR in which they try to fix it.