### PR TITLE
fix: adds alternate lookup if base lookup fails

### DIFF
--- a/test/test_bioconductor_skeleton.py
+++ b/test/test_bioconductor_skeleton.py
@@ -97,7 +97,7 @@ def test_meta_contents(tmpdir, bioc_fetch):
 
 def test_find_best_bioc_version():
 
-    assert bioconductor_skeleton.find_best_bioc_version('DESeq2', '1.36.0') == '3.15'
+    assert bioconductor_skeleton.find_best_bioc_version('DESeq2', '1.40.1') == '3.17'
 
     # Non-existent version:
     with pytest.raises(bioconductor_skeleton.PackageNotFoundError):


### PR DESCRIPTION
This is a first pass attempt at fixing #895.

Main changes are updating the GithubRelease hoster to look for alternate paths via the GitHub API.  The API sends a JSON response (example: https://api.github.com/repos/PacificBiosciences/HiPhase/releases) that contains each release along with a list of assets.  The assets are searched for files that match the provides pattern.  Currently, this first pass puts this as a backup to the main one (which I think is always failing now).  I also did not update the tests, I think someone may have a better idea of how to do that.  Happy to help push this further, but wanted to get the ball rolling.