### PR TITLE
fix: recover --docker-base-image feature

### DIFF
--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -465,7 +465,7 @@ def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
             logger.warning(f"Using tag {image_tag} for docker image, since there is no image for a not yet release version ({VERSION}).")
         else:
             image_tag = VERSION
-        docker_base_image = f"quay.io/bioconda/bioconda-utils-build-env-cos7:{image_tag}"
+        docker_base_image = docker_base_image or f"quay.io/bioconda/bioconda-utils-build-env-cos7:{image_tag}"
         logger.info(f"Using docker image {docker_base_image} for building.")
 
         docker_builder = docker_utils.RecipeBuilder(


### PR DESCRIPTION
In the https://github.com/bioconda/bioconda-utils/pull/866 we introduced the `--docker-base-image` to help user to specify customized build docker image (such as Linux aarch64 build).

But we noticed that it doesn’t work after the https://github.com/bioconda/bioconda-utils/pull/894 , because a local var introduced and the `docker-base-image` arguments is ignored.

This PR try to recover it, if user specify the `--docker-base-image`, it will be used directly otherwise use the local var.

Test:
```
[root@kunpeng bioconda-recipes]# bioconda-utils build --docker --packages bamstats --docker-base-image ghcr.io/yikun/bioconda-utils-build-env-cos7-aarch64

11:50:12 BIOCONDA INFO Considering total of 1 recipes (bamstats).
11:50:12 BIOCONDA INFO Processing 1 recipes (bamstats).
11:50:12 BIOCONDA WARNING Using tag 2.3.4 for docker image, since there is no image for a not yet release version (2.3.4+0.g9a85115.dirty).
11:50:12 BIOCONDA INFO Using docker image ghcr.io/yikun/bioconda-utils-build-env-cos7-aarch64 for building.
// ... ...
```