### PR TITLE
fix: swaps from github API to expanding the assets

### DIFF
--- a/bioconda_utils/hosters.py
+++ b/bioconda_utils/hosters.py
@@ -357,14 +357,25 @@ class GithubRelease(GithubBase):
     """Matches release artifacts uploaded to Github"""
     link_pattern = r"/{account}/{project}/releases/download/{tag}/{fname}{ext}?"
     expanded_assets_pattern = r"https://github.com/{account}/{project}/releases/expanded_assets/{version}"
+    alt_releases_formats = ["https://api.github.com/repos/{account}/{project}/releases"]
 
     async def get_versions(self, req, orig_version):
         # first, try the older version when HTML worked
         matches = await super().get_versions(req, orig_version)
         if len(matches) > 0:
             return matches
-
-        # old version found nothing, pull the webpage and expand the assets
+        
+        # now try the expanded webpage parsing, this may break if the HTML page changes in the future
+        matches = await self.get_expanded_versions(req, orig_version)
+        if len(matches) > 0:
+            return matches
+        
+        # now try the github API parsing, this will hit the API rate limit
+        matches = await self.get_api_versions(req, orig_version)
+        return matches
+    
+    async def get_expanded_versions(self, req, orig_version):
+        # this version will parse the releases page and expand sub-pages that are collapsed in the initial download
         # this section is basically copied from HTMLHoster, but we need the raw contents of the webpage to look for expanded assets
         exclude = set(self.exclude)
         vals = {key: val
@@ -403,6 +414,58 @@ class GithubRelease(GithubBase):
                     break
 
         return result
+
+    async def get_api_versions(self, req, orig_version):
+        # this version searches using the API for releases
+        # TODO: we basically immediately hit the rate limit with this version, we eventually need some long-term persistent memory
+        #   that can track the etags or last-modified so we do not hit this limit except in the initial spin-up
+        #   more information on etags: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#conditional-requests
+        self.releases_urls = [
+            template.format_map(self.vals)
+            for template in self.alt_releases_formats
+        ]
+
+        # this is basically copied from a mixture of the base version and the JSON version
+        # need to compile the link regex
+        exclude = set(self.exclude)
+        vals = {key: val
+                for key, val in self.vals.items()
+                if key not in exclude}
+        link_pattern = replace_named_capture_group(self.link_pattern_compiled, vals)
+        link_re = re.compile(link_pattern)
+
+        # now iterate over the alternate release URLs
+        matches = []
+        for url in self.releases_urls:
+            text = await req.get_text_from_url(url)
+            data = json.loads(text)
+
+            # structured as an array of tagged releases
+            for tag_dict in data:
+                # each release has an asset dict
+                for asset_dict in tag_dict.get('assets', []):
+                    # there is a direct download link for each asset, which should make the typical pattern for an HTML user
+                    download_url = asset_dict['browser_download_url']
+                    re_match = link_re.search(download_url)
+            
+                    if re_match:
+                        # this one matches the pattern
+                        # link - just copy the download_url in full
+                        # version - pull out of the regex match
+                        data = re_match.groupdict()
+                        matches.append({
+                            'link' : download_url,
+                            'version' : data['version']
+                        })
+
+        # now strip down to the version(s) that are more recent than what currently is in bioconda
+        num = None
+        for num, match in enumerate(matches):
+            if match["version"] == self.vals["version"]:
+                break
+        if num is None:
+            return matches
+        return matches[:num + 1]
 
 class GithubTag(GithubBase):
     """Matches GitHub repository archives created automatically from tags"""

--- a/bioconda_utils/hosters.py
+++ b/bioconda_utils/hosters.py
@@ -371,7 +371,7 @@ class GithubRelease(GithubBase):
                 for key, val in self.vals.items()
                 if key not in exclude}
         
-        # this is the pattern for the expanded assets
+        # this is the pattern for the expanded assets, which auto-expand when viewed via web
         expanded_assets_pattern = replace_named_capture_group(self.expanded_assets_pattern_compiled, vals)
         expanded_assets_re = re.compile(expanded_assets_pattern)
 


### PR DESCRIPTION
This is basically a patch to fix a new issue (described here: https://github.com/bioconda/bioconda-recipes/issues/42176) that was introduced by myself here: https://github.com/bioconda/bioconda-utils/pull/896.

The primary cause is that the GitHub API is rate limited (which I was not aware of), so autobump basically blows through the limits quickly and then subsequent calls automatically fail.  Of course, this means that the tools we were hoping to see get autobumped are not.

This patch basically removes the original patch (which uses a single GitHub API call) and replaces it with an approach that basically "expands" the release webpage to find the assets.  See https://github.com/bioconda/bioconda-utils/issues/895 for more details on how the URLs are masked and the expansion pattern.

Couple other notes:
* I added an `IncludeFragmentParser` that is basically identical to the `HrefParser` except it is looking for tags with this pattern: `<include-fragment src="http://url/of/interest" ...>`
* The general expansion logic is:
  * Pull the full release page
  * Search for `<include-fragment ...>` tags
  * Iteratively pull these looking for the main link URL of interest 
  * Break the above iteration early if the current version is identified
* This should no longer use the GitHub API, I'm unaware of other rate limiters for these URLs (🤞that none are hidden...)

Pinging @dpryan79 and @johanneskoester as you both reviewed the last related PR.  Sorry that the previous PR injected a rate limit issue! 

EDIT: I forgot, I have tested these on both `hiphase` and `pbfusion` recipes, the diff of the results are here and match our current expectations:
```
(bioconda)$ git diff
diff --git a/recipes/hiphase/meta.yaml b/recipes/hiphase/meta.yaml
index 38b939bf9f..b5d2503597 100644
--- a/recipes/hiphase/meta.yaml
+++ b/recipes/hiphase/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "hiphase" %}
-{% set version = "0.10.0" %}
-{% set hiphase_sha256 = "e22d3530a395bd218bd4634537f5b3c31a82cd8155849291c69d81c48f0c58fe" %}
+{% set version = "0.10.2" %}
+{% set hiphase_sha256 = "2a20fc437ab5c0f2437246e8a36e7590c68f5ae5caa0cecb8e85a371f5357c6c" %}
 
 package:
   name: {{ name }}
diff --git a/recipes/pbfusion/meta.yaml b/recipes/pbfusion/meta.yaml
index 781ada3413..ca69e87d0f 100644
--- a/recipes/pbfusion/meta.yaml
+++ b/recipes/pbfusion/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pbfusion" %}
-{% set version = "0.2.2" %}
-{% set pbfusion_sha256 = "3390adbeb8550265fcf4fad89dad80740cc368e96d10f3b23bb19ef001ffd081" %}
+{% set version = "0.3.0" %}
+{% set pbfusion_sha256 = "ef9767af7e82bd1e664711e7521d7a8370a41f101cccf1db4a58895d9f88934c" %}
 
 package:
   name: {{ name }}
```