### PR TITLE
fix: use package name instead of folder for build failure list dag check

### DIFF
--- a/bioconda_utils/build_failure.py
+++ b/bioconda_utils/build_failure.py
@@ -206,10 +206,11 @@ def collect_build_failure_dataframe(recipe_folder, config, channel, link_fmt="tx
                     continue
 
             package = components[-1] if not is_version_subdir else components[-2]
+            meta = utils.load_meta_fast(recipe)[0]
+            package_name = meta["package"]["name"]
+            descendants = len(nx.descendants(dag, package_name))
 
-            descendants = len(nx.descendants(dag, package))
-
-            downloads = utils.get_package_downloads(channel, package)
+            downloads = utils.get_package_downloads(channel, package_name)
             recs = list(get_build_failure_records(recipe))
 
             failures = ", ".join(utils.format_link(rec.path, link_fmt, prefix=link_prefix, label=rec.platform) for rec in recs)


### PR DESCRIPTION
GitHub Action Update build Failure list (https://github.com/bioconda/bioconda-recipes/actions/workflows/build-failures.yml) is failing to find "r-boutroslabplottinggeneral" in the DAG because the recipe folder was being used instead of the name from meta.yaml.