### PR TITLE
fix: Update htslib pinning to 1.18 (released 2023-07-25)

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -22,7 +22,7 @@ pin_run_as_build:
     min_pin: x.x
 
 htslib:
-  - "1.17"
+  - "1.18"
 
 bamtools:
   - "2.5.1"


### PR DESCRIPTION
Samtools/bcftools/htslib 1.18 were released over a month ago.

To make samtools (bioconda/bioconda-recipes#42168) and bcftools (bioconda/bioconda-recipes#42167) 1.18 packages built against htslib 1.18, this pinning must be updated first.