### PR TITLE
fix: Remove htslib build pinning

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -21,9 +21,6 @@ pin_run_as_build:
     max_pin: x.x
     min_pin: x.x
 
-htslib:
-  - "1.17"
-
 bamtools:
   - "2.5.1"
 


### PR DESCRIPTION
By patching repodata htslib dependencies, we no longer need to pin htslib. See bioconda/bioconda-recipes#42895.