### PR TITLE
fix: Version constraints can start with `!` as well

### DIFF
--- a/bioconda_utils/lint/check_syntax.py
+++ b/bioconda_utils/lint/check_syntax.py
@@ -23,7 +23,7 @@ class version_constraints_missing_whitespace(LintCheck):
         for section in ('build', 'run', 'host'):
             check_paths.append(f'requirements/{section}')
 
-        constraints = re.compile("(.*?)([<=>].*)")
+        constraints = re.compile("(.*?)([!<=>].*)")
         for path in check_paths:
             for n, spec in enumerate(recipe.get(path, [])):
                 has_constraints = constraints.search(spec)
@@ -37,7 +37,7 @@ class version_constraints_missing_whitespace(LintCheck):
         for section in ('build', 'run', 'host'):
             check_paths.append(f'requirements/{section}')
 
-        constraints = re.compile("(.*?)([<=>].*)")
+        constraints = re.compile("(.*?)([!<=>].*)")
         for path in check_paths:
             for spec in self.recipe.get(path, []):
                 has_constraints = constraints.search(spec)

--- a/test/lint_cases.yaml
+++ b/test/lint_cases.yaml
@@ -303,7 +303,7 @@ tests:
       build.sh: |
         $PYTHON setup.py install
   - name: version_constraints_whitespace_ok
-    add: { requirements: { run: ["one >1", "two >=1", "three >1,<2"] } }
+    add: { requirements: { run: ["one >1", "two >=1", "three >1,<2", "four !=3.3"] } }
   - name: version_constraints_whitespace_missing
     expect: version_constraints_missing_whitespace
     add: { requirements: { run: ["one>1"] } }


### PR DESCRIPTION
Resolves #918 