### PR TITLE
feat: download aarch64 artifacts from CircleCI

### DIFF
--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -517,6 +517,7 @@ def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
 @arg('--dryrun', action='store_true', help='''Do not actually upload anything.''')
 @arg('--fallback', choices=['build', 'ignore'], default='build', help="What to do if no artifacts are found in the PR.")
 @arg('--quay-upload-target', help="Provide a quay.io target to push docker images to.")
+@arg('--artifact-source', choices=['azure', 'circleci'], default='azure', help="Application hosting build artifacts (e.g., Azure or Circle CI).")
 @enable_logging()
 def handle_merged_pr(
     recipe_folder,
@@ -525,12 +526,13 @@ def handle_merged_pr(
     git_range=None,
     dryrun=False,
     fallback='build',
-    quay_upload_target=None
+    quay_upload_target=None,
+    artifact_source='azure'
 ):
     label = os.getenv('BIOCONDA_LABEL', None) or None
 
     success = upload_pr_artifacts(
-        config, repo, git_range[1], dryrun=dryrun, mulled_upload_target=quay_upload_target, label=label
+        config, repo, git_range[1], dryrun=dryrun, mulled_upload_target=quay_upload_target, label=label, artifact_source=artifact_source
     )
     if not success and fallback == 'build':
         success = build(

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -11,6 +11,7 @@ import fnmatch
 import glob
 import logging
 import os
+import platform
 import re
 import subprocess as sp
 import sys
@@ -1514,6 +1515,9 @@ class RepoData:
 
     @staticmethod
     def native_platform():
+        arch = platform.machine()
+        if sys.platform.startswith("linux") and arch == "aarch64":
+            return "linux-aarch64"
         if sys.platform.startswith("linux"):
             return "linux"
         if sys.platform.startswith("darwin"):
@@ -1524,14 +1528,15 @@ class RepoData:
     def platform2subdir(platform):
         if platform == 'linux':
             return 'linux-64'
+        elif platform == 'linux-aarch64':
+            return 'linux-aarch64'
         elif platform == 'osx':
             return 'osx-64'
         elif platform == 'noarch':
             return 'noarch'
         else:
             raise ValueError(
-                'Unsupported platform: bioconda only supports linux, osx and noarch.')
-
+                'Unsupported platform: bioconda only supports linux, linux-aarch64, osx and noarch.')
 
 
     def get_versions(self, name):


### PR DESCRIPTION
- Support for downloading artifacts from CircleCI instead of Azure.
- Added option `--artifact-source` with `choices=['azure', 'circleci']` to `handle_merged_pr`
- Check architecture when returning platform
- See PR for the ARM builds https://github.com/bioconda/bioconda-recipes/pull/40550 