### PR TITLE
feat: add support to run build for recipes with linux-aarch64 additional-platforms

### DIFF
--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -52,6 +54,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH

--- a/bioconda_utils/recipe.py
+++ b/bioconda_utils/recipe.py
@@ -407,6 +407,13 @@ class Recipe():
         return []
 
     @property
+    def extra_additional_platforms(self) -> list:
+        """The extra additional-platforms list"""
+        if 'extra' in self.meta and 'additional-platforms' in self.meta['extra']:
+            return list(self.meta["extra"]["additional-platforms"])
+        return []
+
+    @property
     def name(self) -> str:
         """The name of the toplevel package built by this recipe"""
         return self.meta["package"]["name"]

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -56,33 +56,6 @@ two:
       license: BSD
       home: https://elsewhere
       summary: the_summary
-three:
-  folder: three
-  meta.yaml:
-    #{% set version="0.1" %}
-    package:
-      name: three
-      version: #{{version}}
-    source:
-      - url: https://somewhere # [osx]
-        sha256: 123            # [osx[
-      - url: https://somewhere # [linux]
-        sha256: 456            # [linux]
-    build:
-      number: 0
-    outputs:
-      - name: libthree
-      - name: three-tools
-    test:
-      commands:
-        - do nothing
-    about:
-      license: BSD
-      home: https://elsewhere
-      summary: the_summary
-    extra:
-      additional-platforms:
-        - linux-aarch64
 """
 RECIPES = yaml.load(RECIPE_DATA)
 
@@ -287,12 +260,14 @@ def test_recipe_package_names(recipe):
 
 @with_recipes
 def test_recipe_extra_additional_platforms(recipe):
-    expected = {
-        'one': [],
-        'two': [],
-        'three': ["linux-aarch64"]
-    }[recipe.name]
-    assert recipe.extra_additional_platforms == expected
+    assert recipe.extra_additional_platforms == []
+    recipe.meta_yaml += [
+        'extra:',
+        '  additional-platforms:',
+        '    - linux-aarch64'
+    ]
+    recipe.render()
+    assert recipe.extra_additional_platforms == ["linux-aarch64"]
 
 
 @with_recipes

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -56,6 +56,33 @@ two:
       license: BSD
       home: https://elsewhere
       summary: the_summary
+three:
+  folder: three
+  meta.yaml:
+    #{% set version="0.1" %}
+    package:
+      name: three
+      version: #{{version}}
+    source:
+      - url: https://somewhere # [osx]
+        sha256: 123            # [osx[
+      - url: https://somewhere # [linux]
+        sha256: 456            # [linux]
+    build:
+      number: 0
+    outputs:
+      - name: libthree
+      - name: three-tools
+    test:
+      commands:
+        - do nothing
+    about:
+      license: BSD
+      home: https://elsewhere
+      summary: the_summary
+    extra:
+      additional-platforms:
+        - linux-aarch64
 """
 RECIPES = yaml.load(RECIPE_DATA)
 
@@ -256,6 +283,16 @@ def test_recipe_package_names(recipe):
         'two': ['two', 'libtwo', 'two-tools'],
     }[recipe.name]
     assert recipe.package_names == expected
+
+
+@with_recipes
+def test_recipe_extra_additional_platforms(recipe):
+    expected = {
+        'one': [],
+        'two': [],
+        'three': ["linux-aarch64"]
+    }[recipe.name]
+    assert recipe.extra_additional_platforms == expected
 
 
 @with_recipes

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,7 +6,6 @@ import yaml
 import tempfile
 import requests
 import uuid
-import unittest.mock
 import contextlib
 import tarfile
 import logging
@@ -890,8 +889,7 @@ def test_load_meta_skipping():
     assert utils.load_all_meta(recipe) == []
 
 
-@unittest.mock.patch('bioconda_utils.utils.RepoData.native_platform')
-def test_native_platform_skipping(func_mock):
+def test_native_platform_skipping():
     expections = [
         # Don't skip linux-x86 for any recipes
         ["one", "linux", False],
@@ -920,10 +918,11 @@ def test_native_platform_skipping(func_mock):
     r.write_recipes()
     # Make sure RepoData singleton init
     utils.RepoData.register_config(config_fixture)
-    for recipe_name, native_platform, result in expections:
+    for recipe_name, platform, result in expections:
         recipe_folder = os.path.dirname(r.recipe_dirs[recipe_name])
-        func_mock.return_value = native_platform
-        assert build.check_native_platform_skippable(recipe_folder, r.recipe_dirs[recipe_name]) == result
+        assert build.do_not_consider_for_additional_platform(recipe_folder,
+                                                             r.recipe_dirs[recipe_name],
+                                                             platform) == result
 
 
 def test_variants():


### PR DESCRIPTION
This patches add support in bioconda-utils to run on linux-arm if the following is added to the recipe:
```yaml
extra:
  additional-platforms:
    - linux-aarch64
```

- Add a `check_native_platform_skippable` to checkout should we skip the recipes in current nativei platform
- Add `extra_additional_platforms` property to recipe object
- Add UT to test above function
```
py.test --durations=0 test/test_utils.py::test_native_platform_skipping
py.test --durations=0 test/test_recipe.py::test_recipe_extra_additional_platforms
```
- E2E test
```
bioconda-utils build recipes config.yml --git-range origin/master HEAD
bioconda-utils build recipes config.yml --git-range origin/master HEAD --force
```
- Fix test trigger by adding `fetch-depth`

related: https://github.com/bioconda/bioconda-recipes/pull/40550