### PR TITLE
fix: fix `git diff` argument error

### DIFF
--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate bioconda
-          if git diff --name-only origin/master...HEAD | grep -vE ^docs; then
+          if git diff --name-only origin/master HEAD | grep -vE ^docs; then
               py.test --durations=0 test/ -v --log-level=DEBUG -k "not docker" --tb=native
           else
               echo "Skipping pytest - only docs modified"


### PR DESCRIPTION
To fix the error like:

```
fatal: ambiguous argument 'origin/master...HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Skipping pytest - only docs modified
```