### PR TITLE
ci: Fetch the full Git history to be able to diff it against HEAD

### DIFF
--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -42,7 +42,8 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate bioconda
-          if git diff --name-only origin/master...HEAD | grep -vE ^docs; then
+          git fetch origin master:refs/remotes/origin/master
+          if git diff --name-only HEAD..origin/master | grep -vE ^docs; then
               py.test --durations=0 test/ -v --log-level=DEBUG --tb=native -m '${{ matrix.py_test_marker }}'
           else
               echo "Skipping pytest - only docs modified"
@@ -70,7 +71,8 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate bioconda
-          if git diff --name-only origin/master...HEAD | grep -vE ^docs; then
+          git fetch origin master:refs/remotes/origin/master
+          if git diff --name-only HEAD..origin/master | grep -vE ^docs; then
               py.test --durations=0 test/ -v --log-level=DEBUG -k "not docker" --tb=native
           else
               echo "Skipping pytest - only docs modified"

--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -42,8 +44,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate bioconda
-          git fetch origin master:refs/remotes/origin/master
-          if git diff --name-only HEAD..origin/master | grep -vE ^docs; then
+          if git diff --name-only origin/master...HEAD | grep -vE ^docs; then
               py.test --durations=0 test/ -v --log-level=DEBUG --tb=native -m '${{ matrix.py_test_marker }}'
           else
               echo "Skipping pytest - only docs modified"
@@ -53,6 +54,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -71,8 +74,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate bioconda
-          git fetch origin master:refs/remotes/origin/master
-          if git diff --name-only HEAD..origin/master | grep -vE ^docs; then
+          if git diff --name-only origin/master...HEAD | grep -vE ^docs; then
               py.test --durations=0 test/ -v --log-level=DEBUG -k "not docker" --tb=native
           else
               echo "Skipping pytest - only docs modified"


### PR DESCRIPTION
The `Run tests` jobs were broken with https://github.com/bioconda/bioconda-utils/commit/1ae4126c5ba961667bc321c451957a50be305461 The problem is that the project uses `fetch-depth: 1` (the default) and thus has no branch history.

Refs:
- https://github.com/actions/checkout/issues/296
- https://github.com/actions/checkout/pull/301

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>