### PR TITLE
fix: Do not emit cython_needs_compiler if compiler("cxx") is set

### DIFF
--- a/bioconda_utils/lint/check_build_help.py
+++ b/bioconda_utils/lint/check_build_help.py
@@ -134,7 +134,7 @@ class cython_needs_compiler(LintCheck):
     """
     severity = WARNING
     def check_deps(self, deps):
-        if 'cython' in deps and 'compiler_c' not in deps:
+        if 'cython' in deps and 'compiler_c' not in deps and 'compiler_cxx' not in deps:
             self.message()
 
 

--- a/test/lint_cases.yaml
+++ b/test/lint_cases.yaml
@@ -403,6 +403,10 @@ tests:
     add:
       requirements: { host: [cython], build: ['{{compiler("c")}}'] }
       build: { noarch: False }
+  - name: cython_cxx_compiler_ok
+    add:
+      requirements: { host: [cython], build: ['{{compiler("cxx")}}'] }
+      build: { noarch: False }
   - name: missing_run_exports
     remove: build/run_exports
     expect: missing_run_exports


### PR DESCRIPTION
The current lint is only happy with `compiler("c")`, but `compiler("cxx")` works just as well if the project is a C++ project. I noticed this in <https://github.com/bioconda/bioconda-recipes/pull/43724>.