### PR TITLE
feat: Enable Live logs and add option to disable

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -61,7 +61,8 @@ def build(recipe: str, pkg_paths: List[str] = None,
           mulled_conda_image: str = pkg_test.MULLED_CONDA_IMAGE,
           record_build_failure: bool = False,
           dag: Optional[nx.DiGraph] = None,
-          skiplist_leafs: bool = False) -> BuildResult:
+          skiplist_leafs: bool = False,
+          live_logs: bool = False) -> BuildResult:
     """
     Build a single recipe for a single env
 
@@ -137,7 +138,8 @@ def build(recipe: str, pkg_paths: List[str] = None,
             docker_builder.build_recipe(recipe_dir=os.path.abspath(recipe),
                                         build_args=' '.join(args),
                                         env=whitelisted_env,
-                                        noarch=is_noarch)
+                                        noarch=is_noarch,
+                                        live_logs=live_logs)
             # Use presence of expected packages to check for success
             for pkg_path in pkg_paths:
                 if not os.path.exists(pkg_path):
@@ -156,7 +158,7 @@ def build(recipe: str, pkg_paths: List[str] = None,
                     cmd += [config_file.arg, config_file.path]
                 cmd += [os.path.join(recipe, 'meta.yaml')]
                 with utils.Progress():
-                    utils.run(cmd, mask=False)
+                    utils.run(cmd, mask=False, live=live_logs)
 
         logger.info('BUILD SUCCESS %s',
                     ' '.join(os.path.basename(p) for p in pkg_paths))
@@ -295,7 +297,8 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
                   keep_old_work: bool = False,
                   mulled_conda_image: str = pkg_test.MULLED_CONDA_IMAGE,
                   record_build_failures: bool = False,
-                  skiplist_leafs: bool = False):
+                  skiplist_leafs: bool = False,
+                  live_logs: bool = False):
     """
     Build one or many bioconda packages.
 
@@ -421,7 +424,8 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
                     mulled_conda_image=mulled_conda_image,
                     dag=dag,
                     record_build_failure=record_build_failures,
-                    skiplist_leafs=skiplist_leafs)
+                    skiplist_leafs=skiplist_leafs,
+                    live_logs=live_logs)
 
         if not res.success:
             failed.append(recipe)

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -62,7 +62,7 @@ def build(recipe: str, pkg_paths: List[str] = None,
           record_build_failure: bool = False,
           dag: Optional[nx.DiGraph] = None,
           skiplist_leafs: bool = False,
-          live_logs: bool = False) -> BuildResult:
+          live_logs: bool = True) -> BuildResult:
     """
     Build a single recipe for a single env
 
@@ -82,6 +82,7 @@ def build(recipe: str, pkg_paths: List[str] = None,
       record_build_failure: If True, record build failures in a file next to the meta.yaml
       dag: optional nx.DiGraph with dependency information
       skiplist_leafs: If True, blacklist leaf packages that fail to build
+      live_logs: If True, enable live logging during the build process
     """
     if record_build_failure and not dag:
         raise ValueError("record_build_failure requires dag to be set")
@@ -298,7 +299,7 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
                   mulled_conda_image: str = pkg_test.MULLED_CONDA_IMAGE,
                   record_build_failures: bool = False,
                   skiplist_leafs: bool = False,
-                  live_logs: bool = False):
+                  live_logs: bool = True):
     """
     Build one or many bioconda packages.
 
@@ -325,6 +326,8 @@ def build_recipes(recipe_folder: str, config_path: str, recipes: List[str],
       worker_offset: If n_workers is >1, then every worker_offset within a given group of
         sub-DAGs will be processed.
       keep_old_work: Do not remove anything from environment, even after successful build and test.
+      skiplist_leafs: If True, blacklist leaf packages that fail to build
+      live_logs: If True, enable live logging during the build process
     """
     if not recipes:
         logger.info("Nothing to be done.")

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -382,7 +382,6 @@ def do_lint(recipe_folder, config, packages="*", cache=None, list_checks=False,
      those packages matching --packages globs will be built.''')
 @arg('--docker', action='store_true',
      help='Build packages in docker container.')
-@arg('--live-logs', action='store_true', help="Live logging during the build process")
 @arg('--mulled-test', action='store_true', help="Run a mulled-build test on the built package")
 @arg('--mulled-upload-target', help="Provide a quay.io target to push mulled docker images to.")
 @arg('--mulled-conda-image', help='''Conda Docker image to install the package with during
@@ -435,6 +434,7 @@ from environment, even after successful build and test.''')
      Dockerfile template.''')
 @arg("--record-build-failures", action="store_true", help="Record build failures in build_failure.yaml next to the recipe.")
 @arg("--skiplist-leafs", action="store_true", help="Skiplist leaf recipes (i.e. ones that are not depended on by any other recipes) that fail to build.")
+@arg('--live-logs', action='store_true', help="Live logging during the build process")
 @enable_logging()
 def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
           force=False, docker=None, mulled_test=False, build_script_template=None,

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -437,14 +437,15 @@ from environment, even after successful build and test.''')
 @arg("--skiplist-leafs", action="store_true", help="Skiplist leaf recipes (i.e. ones that are not depended on by any other recipes) that fail to build.")
 @enable_logging()
 def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
-          force=False, docker=None, live_logs=False, mulled_test=False, build_script_template=None,
+          force=False, docker=None, mulled_test=False, build_script_template=None,
           pkg_dir=None, anaconda_upload=False, mulled_upload_target=None,
           build_image=False, keep_image=False, lint=False, lint_exclude=None,
           check_channels=None, n_workers=1, worker_offset=0, keep_old_work=False,
           mulled_conda_image=pkg_test.MULLED_CONDA_IMAGE,
           docker_base_image=None,
           record_build_failures=False,
-          skiplist_leafs=False):
+          skiplist_leafs=False,
+          live_logs=False):
     cfg = utils.load_config(config)
     setup = cfg.get('setup', None)
     if setup:

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -434,7 +434,7 @@ from environment, even after successful build and test.''')
      Dockerfile template.''')
 @arg("--record-build-failures", action="store_true", help="Record build failures in build_failure.yaml next to the recipe.")
 @arg("--skiplist-leafs", action="store_true", help="Skiplist leaf recipes (i.e. ones that are not depended on by any other recipes) that fail to build.")
-@arg('--live-logs', action='store_true', help="Live logging during the build process")
+@arg('--disable-live-logs', action='store_true', help="Disable live logging during the build process")
 @enable_logging()
 def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
           force=False, docker=None, mulled_test=False, build_script_template=None,
@@ -445,7 +445,7 @@ def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
           docker_base_image=None,
           record_build_failures=False,
           skiplist_leafs=False,
-          live_logs=False):
+          disable_live_logs=False):
     cfg = utils.load_config(config)
     setup = cfg.get('setup', None)
     if setup:
@@ -506,7 +506,7 @@ def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
                             mulled_conda_image=mulled_conda_image,
                             record_build_failures=record_build_failures,
                             skiplist_leafs=skiplist_leafs,
-                            live_logs=live_logs)
+                            live_logs=(not disable_live_logs))
     exit(0 if success else 1)
 
 

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -382,6 +382,7 @@ def do_lint(recipe_folder, config, packages="*", cache=None, list_checks=False,
      those packages matching --packages globs will be built.''')
 @arg('--docker', action='store_true',
      help='Build packages in docker container.')
+@arg('--live-logs', action='store_true', help="Live logging during the build process")
 @arg('--mulled-test', action='store_true', help="Run a mulled-build test on the built package")
 @arg('--mulled-upload-target', help="Provide a quay.io target to push mulled docker images to.")
 @arg('--mulled-conda-image', help='''Conda Docker image to install the package with during
@@ -436,7 +437,7 @@ from environment, even after successful build and test.''')
 @arg("--skiplist-leafs", action="store_true", help="Skiplist leaf recipes (i.e. ones that are not depended on by any other recipes) that fail to build.")
 @enable_logging()
 def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
-          force=False, docker=None, mulled_test=False, build_script_template=None,
+          force=False, docker=None, live_logs=False, mulled_test=False, build_script_template=None,
           pkg_dir=None, anaconda_upload=False, mulled_upload_target=None,
           build_image=False, keep_image=False, lint=False, lint_exclude=None,
           check_channels=None, n_workers=1, worker_offset=0, keep_old_work=False,
@@ -503,7 +504,8 @@ def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
                             keep_old_work=keep_old_work,
                             mulled_conda_image=mulled_conda_image,
                             record_build_failures=record_build_failures,
-                            skiplist_leafs=skiplist_leafs)
+                            skiplist_leafs=skiplist_leafs,
+                            live_logs=live_logs)
     exit(0 if success else 1)
 
 

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -402,7 +402,7 @@ class RecipeBuilder(object):
             shutil.rmtree(build_dir)
         return p
 
-    def build_recipe(self, recipe_dir, build_args, env, noarch=False, live_logs=False):
+    def build_recipe(self, recipe_dir, build_args, env, noarch=False, live_logs=True):
         """
         Build a single recipe.
 

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -402,7 +402,7 @@ class RecipeBuilder(object):
             shutil.rmtree(build_dir)
         return p
 
-    def build_recipe(self, recipe_dir, build_args, env, noarch=False):
+    def build_recipe(self, recipe_dir, build_args, env, noarch=False, live_logs=False):
         """
         Build a single recipe.
 
@@ -474,7 +474,7 @@ class RecipeBuilder(object):
 
         logger.debug('DOCKER: cmd: %s', cmd)
         with utils.Progress():
-            p = utils.run(cmd, mask=False)
+            p = utils.run(cmd, mask=False, live=live_logs)
         return p
 
     def cleanup(self):


### PR DESCRIPTION
- Enable live logging except when a new `--disable-live-logs` option is enabled.
- This will improve troubleshooting of CI builds while having the option to avoid excessive log messages.