### PR TITLE
feat: Add Python 3.11 to the build matrix

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -37,6 +37,7 @@ libxml2:
   - "2.11.*"
 
 python:
+  - 3.11.*  *_cpython
   - 3.10.*  *_cpython
   - 3.9.*  *_cpython
   - 3.8.*  *_cpython
@@ -46,12 +47,14 @@ python_impl:
   - cpython
   - cpython
   - cpython
+  - cpython
 
 # Warning! This needs to both match the length of python and python_impl but ALSO match what conda-forge is using/has used!
 numpy:
-  - 1.21.*
-  - 1.21.*
-  - 1.21.*
+  - 1.23.*
+  - 1.22.*
+  - 1.22.*
+  - 1.22.*
 
 channel_sources:
   - conda-forge,bioconda,defaults

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -23,7 +23,7 @@ jsonschema=3.2.*     # JSON schema verification
 pyopenssl>=22.1      # Stay compatible with cryptography
 
 # pinnings
-conda-forge-pinning=2023.05.06.13.08.41
+conda-forge-pinning=2024.03.06.07.52.39
 
 # tools
 anaconda-client=1.6.*  # anaconda_upload


### PR DESCRIPTION
I have no idea what all is involved in updating this and perhaps doing initial package builds on the **bulk** branch, but this PR provides a starting point for this long-overdue update. Python 3.12 was released almost two months ago, so it is embarrassing that bioconda is still not building packages for the previous year's release, Python 3.11.

This is tracked as bioconda/bioconda-recipes#37805. That links to conversation on #878 which indicates that bioconda has been waiting for conda-forge to include 3.11. It appears that [conda-forge's migration was completed in September](https://conda-forge.org/docs/user/announcements.html#python-3-12-migration-and-python-3-11-by-default).