### PR TITLE
feat: live logs for mulled build

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -183,7 +183,8 @@ def build(recipe: str, pkg_paths: List[str] = None,
         for pkg_path in pkg_paths:
             try:
                 pkg_test.test_package(pkg_path, base_image=base_image,
-                                      conda_image=mulled_conda_image)
+                                      conda_image=mulled_conda_image,
+                                      live_logs=live_logs)
             except sp.CalledProcessError:
                 logger.error('TEST FAILED: %s', recipe)
                 return BuildResult(False, None)

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -92,6 +92,7 @@ def test_package(
     mulled_args="",
     base_image=None,
     conda_image=MULLED_CONDA_IMAGE,
+    live_logs = True,
 ):
     """
     Tests a built package in a minimal docker container.
@@ -119,6 +120,9 @@ def test_package(
     conda_image : None | str
         Conda Docker image to install the package with during the mulled based
         tests.
+
+    live_logs : True | bool
+        If True, enable live logging during the build process
     """
 
     assert path.endswith('.tar.bz2'), "Unrecognized path {0}".format(path)
@@ -173,6 +177,6 @@ def test_package(
     env["CONDA_IMAGE"] = conda_image
     with tempfile.TemporaryDirectory() as d:
         with utils.Progress():
-            p = utils.run(cmd, env=env, cwd=d, mask=False)
+            p = utils.run(cmd, env=env, cwd=d, mask=False, live=live_logs)
 
     return p


### PR DESCRIPTION
Enable live logs for mulled-test.

The `--disable-live-logs` option was added in  https://github.com/bioconda/bioconda-utils/pull/930 but was only for the build. This will enable live logs for the mulled test.


Draft because it still needs testing.