### PR TITLE
fix: specify involucro path when uploading

### DIFF
--- a/bioconda_utils/upload.py
+++ b/bioconda_utils/upload.py
@@ -76,6 +76,13 @@ def mulled_upload(image: str, quay_target: str) -> sp.CompletedProcess:
       quary_target: name of image on quay
     """
     cmd = ['mulled-build', 'push', image, '-n', quay_target]
+
+    # galaxy-lib always downloads involucro, unless it's in cwd or its path is
+    # explicitly given.
+    involucro_path = os.path.join(os.path.dirname(__file__), 'involucro')
+    if not os.path.exists(involucro_path):
+        raise RuntimeError('internal involucro wrapper missing')
+    cmd += ['--involucro-path', involucro_path]
     mask = []
     if os.environ.get('QUAY_OAUTH_TOKEN', False):
         token = os.environ['QUAY_OAUTH_TOKEN']

--- a/bioconda_utils/upload.py
+++ b/bioconda_utils/upload.py
@@ -83,12 +83,18 @@ def mulled_upload(image: str, quay_target: str) -> sp.CompletedProcess:
     if not os.path.exists(involucro_path):
         raise RuntimeError('internal involucro wrapper missing')
     cmd += ['--involucro-path', involucro_path]
+
+    env = os.environ.copy()
+
+    # Env var expected by mulled-build
+    env["DEST_BASE_IMAGE"] = base_image
+
     mask = []
     if os.environ.get('QUAY_OAUTH_TOKEN', False):
         token = os.environ['QUAY_OAUTH_TOKEN']
         cmd.extend(['--oauth-token', token])
         mask = [token]
-    return utils.run(cmd, mask=mask)
+    return utils.run(cmd, mask=mask, env=env)
 
 
 def skopeo_upload(image_file: str, target: str,

--- a/bioconda_utils/upload.py
+++ b/bioconda_utils/upload.py
@@ -86,9 +86,6 @@ def mulled_upload(image: str, quay_target: str) -> sp.CompletedProcess:
 
     env = os.environ.copy()
 
-    # Env var expected by mulled-build
-    env["DEST_BASE_IMAGE"] = base_image
-
     mask = []
     if os.environ.get('QUAY_OAUTH_TOKEN', False):
         token = os.environ['QUAY_OAUTH_TOKEN']


### PR DESCRIPTION
Port the fixes in f48280167a31cc87192e0a9ce729de935d702990, which were in `pkg_test.py`, to `upload.py` as well.

ping @bgruening this is what was causing that strangely different behavior in `mulled-build`'s `build-and-test` and `push` over in https://github.com/bioconda/bioconda-recipes/pull/43995.

After reviewing this and tracking down all the various moving parts, it's *really* unclear how the various docker images are specified throughout all our machinery. Explicit and implicit env vars set at various times, sometimes overridden by default args, sometimes not, sometimes hard-coded deep in bioconda-utils. Needs a refactor, where everything gets specified just once in bioconda-common and used everywhere. That's for another day though...