### PR TITLE
feat: make GITHUB_TOKEN optional for fetch

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1606,8 +1606,15 @@ class RepoData:
 def get_github_client():
     """Get a Github client with a robust retry policy.
     """
+    if "GITHUB_TOKEN" in os.environ.keys():
+        return Github(
+            os.environ["GITHUB_TOKEN"],
+            retry=Retry(
+                total=10, status_forcelist=(500, 502, 504), backoff_factor=0.3
+            ),
+        )
+    logger.warn("GITHUB_TOKEN not found, restrictions may be enforced by GitHub API")
     return Github(
-        os.environ["GITHUB_TOKEN"],
         retry=Retry(
             total=10, status_forcelist=(500, 502, 504), backoff_factor=0.3
         ),


### PR DESCRIPTION
Check if the GITHUB_TOKEN environment variable exists for getting the PR during artifact fetching. Since it's a read-only request, it works without a token. The risk is that GitHub API has a 60 request/hr limit for unauthenticated users associated with the originating IP address. https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api

We talked about adding a flag to specify not using the token, but I thought it would be cleaner to just log a warning and proceed. (Also open to adjusting the retry for the tokenless option, but usually a rate limit would be 429 return code and this retry policy is only for 500, 502, 504.)