### PR TITLE
fix: add local channel for docker builds

### DIFF
--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -105,7 +105,7 @@ conda config --add channels file://{self.container_staging} 2> >(
 # The actual building...
 # we explicitly point to the meta.yaml, in order to keep
 # conda-build from building all subdirectories
-conda mambabuild {self.conda_build_args} {self.container_recipe}/meta.yaml 2>&1
+conda mambabuild -c file://{self.container_staging} {self.conda_build_args} {self.container_recipe}/meta.yaml 2>&1
 
 # copy all built packages to the staging area
 cp /opt/conda/conda-bld/*/*.tar.bz2 {self.container_staging}/{arch}


### PR DESCRIPTION
The local folder channel was not included in the command, causing newly built packages on the `bulk` branch to not be usable to their descendants on the same worker because of strict channel priority.