### PR TITLE
feat: Bulk build failure wiki

### DIFF
--- a/bioconda_utils/build_failure.py
+++ b/bioconda_utils/build_failure.py
@@ -232,10 +232,11 @@ def collect_build_failure_dataframe(recipe_folder, config, channel, link_fmt="tx
             recs = list(get_build_failure_records(recipe))
 
             failures = ", ".join(utils.format_link(rec.path, link_fmt, prefix=link_prefix, label=rec.platform) for rec in recs)
+            categories = ", ".join(rec.category for rec in recs)
             skiplisted = any(rec.skiplist for rec in recs)
             prs = utils.format_link(f"https://github.com/bioconda/bioconda-recipes/pulls?q=is%3Apr+is%3Aopen+{package}", link_fmt, label="show")
-            yield (recipe, downloads, descendants, skiplisted, failures, prs)
+            yield (recipe, downloads, descendants, skiplisted, categories, failures, prs)
 
-    data = pd.DataFrame(get_data(), columns=["recipe", "downloads", "depending", "skiplisted", "build failures", "pull requests"])
+    data = pd.DataFrame(get_data(), columns=["recipe", "downloads", "depending", "skiplisted", "category", "build failures", "pull requests"])
     data.sort_values(by=["depending", "downloads"], ascending=False, inplace=True)
     return data

--- a/bioconda_utils/build_failure.py
+++ b/bioconda_utils/build_failure.py
@@ -14,7 +14,7 @@ import conda.base.constants
 import pandas as pd
 import networkx as nx
 
-from .githandler import BiocondaRepo, install_gpg_key
+from .githandler import BiocondaRepo
 
 from bioconda_utils.recipe import Recipe
 from bioconda_utils import graph, utils

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -1075,7 +1075,11 @@ def annotate_build_failures(recipes, skiplist=False, reason=None, category=None,
 @arg('--channel', help="Channel with packages to check", default="bioconda")
 @arg('--output-format', help="Output format", choices=['txt', 'markdown'], default="txt")
 @arg('--link-prefix', help="Prefix for links to build failures", default='')
-def list_build_failures(recipe_folder, config, channel=None, output_format=None, link_prefix=None):
+@arg('--git-range', nargs='+',
+     help='''Git range (e.g. commits or something like
+     "master HEAD" to check commits in HEAD vs master, or just "HEAD" to
+     include uncommitted changes).''')
+def list_build_failures(recipe_folder, config, channel=None, output_format=None, link_prefix=None, git_range=None):
     """List recipes with build failure records"""
 
     df = collect_build_failure_dataframe(
@@ -1084,6 +1088,7 @@ def list_build_failures(recipe_folder, config, channel=None, output_format=None,
         channel,
         link_fmt=output_format,
         link_prefix=link_prefix,
+        git_range=git_range
     )
     if output_format == "markdown":
         fmt_writer = pandas.DataFrame.to_markdown

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1645,4 +1645,6 @@ def yaml_remove_invalid_chars(text: str, valid_chars_re=re.compile(r"[^ \t\n\w\d
 def get_package_downloads(channel, package):
     """Use anaconda API to obtain download counts."""
     data = requests.get(f"https://api.anaconda.org/package/{channel}/{package}").json()
-    return sum(rec["ndownloads"] for rec in data["files"])
+    if "files" in data:
+        return sum(rec["ndownloads"] for rec in data["files"])
+    return 0


### PR DESCRIPTION
In order to have a `bulk` branch-specific Build Failures wiki page, need to allow for a git range to be specified for which recipes will be included. This uses the same method of determining whether a recipe is included as the build command. (i.e., it's not diffing the build failure files between branches.)

Also added handling for recipes that exist but have no corresponding package in the channel. That avoids errors from new Bioconductor recipes during a bulk update.