### PR TITLE
feat: choose worker recipes by depth level

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -228,7 +228,7 @@ def remove_cycles(dag, name2recipes, failed, skip_dependent):
     return dag.subgraph(name for name in dag if name not in nodes_in_cycles)
 
 
-def get_subdags(dag, n_workers, worker_offset, subdag_depth = 0):
+def get_subdags(dag, n_workers, worker_offset, subdag_depth):
     if n_workers > 1 and worker_offset >= n_workers:
         raise ValueError(
             "n-workers is less than the worker-offset given! "

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -435,6 +435,7 @@ from environment, even after successful build and test.''')
 @arg("--record-build-failures", action="store_true", help="Record build failures in build_failure.yaml next to the recipe.")
 @arg("--skiplist-leafs", action="store_true", help="Skiplist leaf recipes (i.e. ones that are not depended on by any other recipes) that fail to build.")
 @arg('--disable-live-logs', action='store_true', help="Disable live logging during the build process")
+@arg('--subdag-depth', type=int, help="Number of levels of root nodes to skip. (Optional, and only if using n_workers)")
 @enable_logging()
 def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
           force=False, docker=None, mulled_test=False, build_script_template=None,
@@ -445,7 +446,8 @@ def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
           docker_base_image=None,
           record_build_failures=False,
           skiplist_leafs=False,
-          disable_live_logs=False):
+          disable_live_logs=False,
+          subdag_depth=None):
     cfg = utils.load_config(config)
     setup = cfg.get('setup', None)
     if setup:
@@ -506,7 +508,8 @@ def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
                             mulled_conda_image=mulled_conda_image,
                             record_build_failures=record_build_failures,
                             skiplist_leafs=skiplist_leafs,
-                            live_logs=(not disable_live_logs))
+                            live_logs=(not disable_live_logs),
+                            subdag_depth=subdag_depth)
     exit(0 if success else 1)
 
 


### PR DESCRIPTION
In an attempt to try a more efficient process for doing bulk builds, I added an option `--subdag-depth` (int, default: None) that will only assign recipes with a certain dependency depth to the bulk workers. Only nodes of a certain depth will be built (i.e., 0: only root nodes, 1: only nodes with parents that are root nodes, etc.). The idea is to allow someone to build all recipes that have no dependencies in the DAG, then remove those from the DAG and build the new "root" recipes. The existing behavior will still work if `--subdag-depth` is not included.

Currently, manual intervention is needed to do the Bioconductor bulk update because the recipes are assigned unevenly to the workers and some child nodes are dependent on recipes being built on a different worker. This new approach also requires manual intervention to increment `--subdag-depth` after the previous depth level is done building, but hopefully will result in fewer failures from the chain of dependencies and less time spent with one worker building while the rest sit idle.

Example of the behavior without (left) and with (right) `--subdag-depth`:
![image](https://github.com/bioconda/bioconda-utils/assets/108547992/0128cc85-a16c-49a6-a595-18d75f0aa988)

Tested on https://github.com/bioconda/bioconda-recipes/tree/bulk-performance-testing branch (action: https://github.com/bioconda/bioconda-recipes/actions/workflows/Bulk.yml).