### PR TITLE
chore: requirements updates needed for osx-arm64

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -41,7 +41,7 @@ aiohttp-session
 aiohttp-security
 aiofiles=0.8.*     # async open
 aioftp=0.12.*      # FTP lib
-backoff=1.6.*      # retrying of failed API calls
+backoff=2.2.*      # retrying of failed API calls
 cachetools=3.0.*   # request caching (NEEDED?)
 
 # client API wrappers
@@ -51,7 +51,7 @@ gidgethub=3.0.*           # githubhandler
 pyjwt>=2.4.0              # githubhandler (JWT signing), needs >=2.4.0, CVE-2022-29217
 
 # unknown
-beautifulsoup4=4.8.*
+beautifulsoup4=4.2.*
 galaxy-lib>=18.9.1
 jinja2>=2.10.1,<3
 markupsafe<2.1           # markupsafe 2.1 breaks jinja2
@@ -66,7 +66,7 @@ markdown
 graphviz
 
 # The bioconductor skeleton needs this
-requests=2.22.*
+requests=2.29.*
 
 # merge handling
 pygithub

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -51,7 +51,7 @@ gidgethub=3.0.*           # githubhandler
 pyjwt>=2.4.0              # githubhandler (JWT signing), needs >=2.4.0, CVE-2022-29217
 
 # unknown
-beautifulsoup4=4.2.*
+beautifulsoup4=4.12.*
 galaxy-lib>=18.9.1
 jinja2>=2.10.1,<3
 markupsafe<2.1           # markupsafe 2.1 breaks jinja2


### PR DESCRIPTION
beautifulsoup4 and requests need a version that is noarch. The older version of backoff was causing an error with asyncio on Mac.