### PR TITLE
feat: add osx-arm64 to platform checks

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -277,9 +277,12 @@ def do_not_consider_for_additional_platform(recipe_folder: str, recipe: str, pla
       Return True if current native platform are not included in recipe's additional platforms (no need to build).
     """
     recipe_obj = _recipe.Recipe.from_file(recipe_folder, recipe)
-    # On linux-aarch64 env, only build recipe with linux-aarch64 extra_additional_platforms
+    # On linux-aarch64 or osx-arm64 env, only build recipe with matching extra_additional_platforms
     if platform == "linux-aarch64":
         if "linux-aarch64" not in recipe_obj.extra_additional_platforms:
+            return True
+    if platform == "osx-arm64":
+        if "osx-arm64" not in recipe_obj.extra_additional_platforms:
             return True
     return False
 

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1520,6 +1520,8 @@ class RepoData:
             return "linux-aarch64"
         if sys.platform.startswith("linux"):
             return "linux"
+        if sys.platform.startswith("darwin") and arch == "arm64":
+            return "osx-arm64"
         if sys.platform.startswith("darwin"):
             return "osx"
         raise ValueError("Running on unsupported platform")
@@ -1532,11 +1534,13 @@ class RepoData:
             return 'linux-aarch64'
         elif platform == 'osx':
             return 'osx-64'
+        elif platform == 'osx-arm64':
+            return 'osx-arm64'
         elif platform == 'noarch':
             return 'noarch'
         else:
             raise ValueError(
-                'Unsupported platform: bioconda only supports linux, linux-aarch64, osx and noarch.')
+                'Unsupported platform: bioconda only supports linux, linux-aarch64, osx, osx-arm64 and noarch.')
 
 
     def get_versions(self, name):

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -264,6 +264,29 @@ def test_recipe_extra_additional_platforms(recipe):
     recipe.meta_yaml += [
         'extra:',
         '  additional-platforms:',
+        '    - linux-aarch64',
+        '    - osx-arm64'
+    ]
+    recipe.render()
+    assert recipe.extra_additional_platforms == ["linux-aarch64", "osx-arm64"]
+
+@with_recipes
+def test_recipe_extra_additional_platform_osx(recipe):
+    assert recipe.extra_additional_platforms == []
+    recipe.meta_yaml += [
+        'extra:',
+        '  additional-platforms:',
+        '    - osx-arm64'
+    ]
+    recipe.render()
+    assert recipe.extra_additional_platforms == ["osx-arm64"]
+
+@with_recipes
+def test_recipe_extra_additional_platform_linux(recipe):
+    assert recipe.extra_additional_platforms == []
+    recipe.meta_yaml += [
+        'extra:',
+        '  additional-platforms:',
         '    - linux-aarch64'
     ]
     recipe.render()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -962,7 +962,7 @@ def test_native_platform_skipping():
         two:
           meta.yaml: |
             package:
-              name: one
+              name: two
               version: "0.1"
             extra:
               additional-platforms:
@@ -970,7 +970,7 @@ def test_native_platform_skipping():
         three:
           meta.yaml: |
             package:
-              name: one
+              name: three
               version: "0.1"
             extra:
               additional-platforms:
@@ -978,7 +978,7 @@ def test_native_platform_skipping():
         four:
           meta.yaml: |
             package:
-              name: one
+              name: four
               version: "0.1"
             extra:
               additional-platforms:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -939,10 +939,14 @@ def test_native_platform_skipping():
         # Don't skip linux-x86 for any recipes
         ["one", "linux", False],
         ["two", "linux", False],
-        # Skip recipe without linux aarch64 enable on linux-aarch64 platform
+        # Skip recipe without linux aarch64 enabled on linux-aarch64 platform
         ["one", "linux-aarch64", True],
-        # Don't skip recipe with linux aarch64 enable on linux-aarch64 platform
+        # Don't skip recipe with linux aarch64 enabled on linux-aarch64 platform
         ["two", "linux-aarch64", False],
+        # Skip recipe without osx-arm64 enabled on osx-arm64 platform
+        ["one", "osx-arm64", True],
+        # Don't skip recipe with osx-arm64 enabled on osx-arm64 platform
+        ["two", "osx-arm64", False],
     ]
     r = Recipes(
         """
@@ -959,6 +963,7 @@ def test_native_platform_skipping():
             extra:
               additional-platforms:
                 - linux-aarch64
+                - osx-arm64
         """, from_string=True)
     r.write_recipes()
     # Make sure RepoData singleton init

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -939,14 +939,18 @@ def test_native_platform_skipping():
         # Don't skip linux-x86 for any recipes
         ["one", "linux", False],
         ["two", "linux", False],
-        # Skip recipe without linux aarch64 enabled on linux-aarch64 platform
+        ["three", "linux", False],
+        ["four", "linux", False],
+        # Skip recipes without linux aarch64 enable on linux-aarch64 platform
         ["one", "linux-aarch64", True],
-        # Don't skip recipe with linux aarch64 enabled on linux-aarch64 platform
+        ["three", "linux-aarch64", True],
+        # Don't skip recipes with linux aarch64 enable on linux-aarch64 platform
         ["two", "linux-aarch64", False],
-        # Skip recipe without osx-arm64 enabled on osx-arm64 platform
+        ["four", "linux-aarch64", False],
         ["one", "osx-arm64", True],
-        # Don't skip recipe with osx-arm64 enabled on osx-arm64 platform
-        ["two", "osx-arm64", False],
+        ["two", "osx-arm64", True],
+        ["three", "osx-arm64", False],
+        ["four", "osx-arm64", False],
     ]
     r = Recipes(
         """
@@ -956,6 +960,22 @@ def test_native_platform_skipping():
               name: one
               version: "0.1"
         two:
+          meta.yaml: |
+            package:
+              name: one
+              version: "0.1"
+            extra:
+              additional-platforms:
+                - linux-aarch64
+        three:
+          meta.yaml: |
+            package:
+              name: one
+              version: "0.1"
+            extra:
+              additional-platforms:
+                - osx-arm64
+        four:
           meta.yaml: |
             package:
               name: one


### PR DESCRIPTION
add osx-arm64 to platforms and only build if additional platform is configured