### PR TITLE
feat: update deployment target for osx-arm64

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -9,8 +9,9 @@
 # clear hard-coded default value for CONDA_BUILD_SYSROOT
 CONDA_BUILD_SYSROOT:
   - ""
-MACOSX_DEPLOYMENT_TARGET:
-  - "10.9"
+MACOSX_DEPLOYMENT_TARGET:      # [osx]
+  - 11.0                       # [osx and arm64]
+  - 10.9                       # [osx and x86_64]
 
 pin_run_as_build:
   htslib:


### PR DESCRIPTION
11.0 is the oldest SDK that has arm64 support.