### PR TITLE
feat: fetch artifacts from GitHub Actions

### DIFF
--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -80,6 +80,37 @@ jobs:
               echo "Skipping pytest - only docs modified"
           fi
 
+  test-macosx-arm64:
+    name: OSX-Arm64 tests
+    runs-on: macOS-14 # M1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: set path
+        run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
+
+      - name: Install bioconda-utils
+        run: |
+          export BIOCONDA_DISABLE_BUILD_PREP=1
+          wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
+          bash install-and-set-up-conda.sh
+          eval "$(conda shell.bash hook)"
+          mamba create -n bioconda -y --file test-requirements.txt --file bioconda_utils/bioconda_utils-requirements.txt
+          conda activate bioconda
+          python setup.py install
+
+      - name: Run tests
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate bioconda
+          if git diff --name-only origin/master...HEAD | grep -vE ^docs; then
+              py.test --durations=0 test/ -v --log-level=DEBUG -k "not docker" --tb=native
+          else
+              echo "Skipping pytest - only docs modified"
+          fi
+
   autobump-test:
     name: autobump test
     runs-on: ubuntu-latest

--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -80,37 +80,6 @@ jobs:
               echo "Skipping pytest - only docs modified"
           fi
 
-  test-macosx-arm64:
-    name: OSX-Arm64 tests
-    runs-on: macOS-14 # M1
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: set path
-        run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
-
-      - name: Install bioconda-utils
-        run: |
-          export BIOCONDA_DISABLE_BUILD_PREP=1
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
-          bash install-and-set-up-conda.sh
-          eval "$(conda shell.bash hook)"
-          mamba create -n bioconda -y --file test-requirements.txt --file bioconda_utils/bioconda_utils-requirements.txt
-          conda activate bioconda
-          python setup.py install
-
-      - name: Run tests
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate bioconda
-          if git diff --name-only origin/master...HEAD | grep -vE ^docs; then
-              py.test --durations=0 test/ -v --log-level=DEBUG -k "not docker" --tb=native
-          else
-              echo "Skipping pytest - only docs modified"
-          fi
-
   autobump-test:
     name: autobump test
     runs-on: ubuntu-latest

--- a/bioconda_utils/artifacts.py
+++ b/bioconda_utils/artifacts.py
@@ -219,13 +219,16 @@ def get_circleci_artifacts(check_run, platform):
                             yield artifact_url
 
 def parse_gha_build_id(url: str) -> str:
+    # Get workflow run id from URL
     return re.search("runs/(\d+)/", url).group(1)
 
 def get_gha_artifacts(check_run, platform, repo):
     gha_workflow_id = parse_gha_build_id(check_run.details_url)
     if (gha_workflow_id) :
+        # The workflow run is different from the check run
         run = repo.get_workflow_run(int(gha_workflow_id))
         artifacts = run.get_artifacts()
         for artifact in artifacts:
+            # This URL is valid for 1 min and requires a token
             artifact_url = artifact.archive_download_url
             yield artifact_url

--- a/bioconda_utils/artifacts.py
+++ b/bioconda_utils/artifacts.py
@@ -106,12 +106,13 @@ def upload_pr_artifacts(config, repo, git_sha, dryrun=False, mulled_upload_targe
 )
 def download_artifact(url, to_path, artifact_source):
     logger.info(f"Downloading artifact {url}.")
+    headers = {}
     if artifact_source == "github-actions":
         token = os.environ.get("GITHUB_TOKEN")
         if not token:
             logger.critical("GITHUB_TOKEN required to download GitHub Actions artifacts")
             exit(1)
-    headers = {"Authorization": f"token {token}"}
+        headers = {"Authorization": f"token {token}"}
     resp = requests.get(url, stream=True, allow_redirects=True, headers=headers)
     resp.raise_for_status()
     with open(to_path, "wb") as f:

--- a/bioconda_utils/artifacts.py
+++ b/bioconda_utils/artifacts.py
@@ -34,7 +34,7 @@ def upload_pr_artifacts(config, repo, git_sha, dryrun=False, mulled_upload_targe
         # no PR found for the commit
         return True
     pr = prs[0]
-    artifacts = set(fetch_artifacts(pr, artifact_source))
+    artifacts = set(fetch_artifacts(pr, artifact_source, repo))
     if not artifacts:
         # no artifacts found, fail and rebuild packages
         logger.info("No artifacts found.")
@@ -45,13 +45,19 @@ def upload_pr_artifacts(config, repo, git_sha, dryrun=False, mulled_upload_targe
                 # download the artifact
                 if artifact_source == "azure":
                     artifact_path = os.path.join(tmpdir, os.path.basename(artifact))
-                    download_artifact(artifact, artifact_path)
+                    download_artifact(artifact, artifact_path, artifact_source)
                     zipfile.ZipFile(artifact_path).extractall(tmpdir)
                 elif artifact_source == "circleci":
                     artifact_dir = os.path.join(tmpdir, *(artifact.split("/")[-4:-1]))
                     artifact_path = os.path.join(tmpdir, artifact_dir, os.path.basename(artifact))
-                    Path(artifact_dir).mkdir(parents=True, exist_ok=True) 
-                    download_artifact(artifact, artifact_path)
+                    Path(artifact_dir).mkdir(parents=True, exist_ok=True)
+                    download_artifact(artifact, artifact_path, artifact_source)
+                elif artifact_source == "github-actions":
+                    artifact_dir = os.path.join(tmpdir, "artifacts")
+                    artifact_path = os.path.join(artifact_dir, os.path.basename(artifact))
+                    Path(artifact_dir).mkdir(parents=True, exist_ok=True)
+                    download_artifact(artifact, artifact_path, artifact_source)
+                    zipfile.ZipFile(artifact_path).extractall(artifact_dir)
 
                 # get all the contained packages and images and upload them
                 platform_patterns = [repodata.platform2subdir(repodata.native_platform())]
@@ -98,9 +104,15 @@ def upload_pr_artifacts(config, repo, git_sha, dryrun=False, mulled_upload_targe
     backoff.expo,
     requests.exceptions.RequestException
 )
-def download_artifact(url, to_path):
+def download_artifact(url, to_path, artifact_source):
     logger.info(f"Downloading artifact {url}.")
-    resp = requests.get(url, stream=True, allow_redirects=True)
+    if artifact_source == "github-actions":
+        token = os.environ.get("GITHUB_TOKEN")
+        if not token:
+            logger.critical("GITHUB_TOKEN required to download GitHub Actions artifacts")
+            exit(1)
+    headers = {"Authorization": f"token {token}"}
+    resp = requests.get(url, stream=True, allow_redirects=True, headers=headers)
     resp.raise_for_status()
     with open(to_path, "wb") as f:
         for chunk in resp.iter_content(chunk_size=1024):
@@ -108,7 +120,7 @@ def download_artifact(url, to_path):
                 f.write(chunk)
 
 
-def fetch_artifacts(pr, artifact_source):
+def fetch_artifacts(pr, artifact_source, repo):
     """
     Fetch artifacts from a PR.
 
@@ -142,6 +154,13 @@ def fetch_artifacts(pr, artifact_source):
         ):
             # Circle CI builds
             artifact_url = get_circleci_artifacts(check_run, platform)
+            yield from artifact_url
+        elif (
+            artifact_source == "github-actions" and
+            check_run.app.slug == "github-actions"
+        ):
+            # GitHubActions builds
+            artifact_url = get_gha_artifacts(check_run, platform, repo)
             yield from artifact_url
 
 
@@ -185,3 +204,15 @@ def get_circleci_artifacts(check_run, platform):
                             continue
                         else:
                             yield artifact_url
+
+def parse_gha_build_id(url: str) -> str:
+    return re.search("runs/(\d+)/", url).group(1)
+
+def get_gha_artifacts(check_run, platform, repo):
+    gha_workflow_id = parse_gha_build_id(check_run.details_url)
+    if (gha_workflow_id) :
+        run = repo.get_workflow_run(int(gha_workflow_id))
+        artifacts = run.get_artifacts()
+        for artifact in artifacts:
+            artifact_url = artifact.archive_download_url
+            yield artifact_url

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -524,7 +524,7 @@ def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
 @arg('--dryrun', action='store_true', help='''Do not actually upload anything.''')
 @arg('--fallback', choices=['build', 'ignore'], default='build', help="What to do if no artifacts are found in the PR.")
 @arg('--quay-upload-target', help="Provide a quay.io target to push docker images to.")
-@arg('--artifact-source', choices=['azure', 'circleci'], default='azure', help="Application hosting build artifacts (e.g., Azure or Circle CI).")
+@arg('--artifact-source', choices=['azure', 'circleci','github-actions'], default='azure', help="Application hosting build artifacts (e.g., Azure, Circle CI, or GitHub Actions).")
 @enable_logging()
 def handle_merged_pr(
     recipe_folder,


### PR DESCRIPTION
GitHub requires a token for artifact downloads from their API. (A logged-in user is required for the normal download link shown on the Actions page. This needs to be kept in mind when we update the download comment from the bot.)

I could not find any way to get the workflow run ID or artifacts from the check run object except parsing the URL.