### PR TITLE
fix: handle PR list with no items

### DIFF
--- a/bioconda_utils/artifacts.py
+++ b/bioconda_utils/artifacts.py
@@ -38,7 +38,7 @@ def upload_pr_artifacts(config, repo, git_sha, dryrun=False, mulled_upload_targe
 
     commit = repo.get_commit(git_sha)
     prs = commit.get_pulls()
-    if not prs:
+    if not prs or prs.totalCount < 1:
         # no PR found for the commit
         return UploadResult.NO_PR
     pr = prs[0]


### PR DESCRIPTION
This was erroring out on line 44 instead of returning on line 43 because the prs object existed, but had no items.