### PR TITLE
ci: specify macos version to control architecture

### DIFF
--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -51,7 +51,7 @@ jobs:
           fi
   test-macosx:
     name: OSX tests
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
GitHub Actions changes are being rolled out to change `macos-latest` to use `macos-14` which has ARM architecture. Specify `macos-13` to continue to test on x86-64.
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources