### PR TITLE
feat: Use conda/conda-build instead of mamba/conda-mambabuild

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -147,7 +147,7 @@ def build(recipe: str, pkg_paths: List[str] = None,
                         "cannot be found", pkg_path)
                     return BuildResult(False, None)
         else:
-            conda_build_cmd = [utils.bin_for('conda'), 'mambabuild']
+            conda_build_cmd = [utils.bin_for('conda-build')]
             # - Temporarily reset os.environ to avoid leaking env vars
             # - Also pass filtered env to run()
             # - Point conda-build to meta.yaml, to avoid building subdirs

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -108,12 +108,12 @@ conda config --add channels file://{self.container_staging} 2> >(
 # The actual building...
 # we explicitly point to the meta.yaml, in order to keep
 # conda-build from building all subdirectories
-conda mambabuild -c file://{self.container_staging} {self.conda_build_args} {self.container_recipe}/meta.yaml 2>&1
+conda-build -c file://{self.container_staging} {self.conda_build_args} {self.container_recipe}/meta.yaml 2>&1
 
 # copy all built packages to the staging area
 cp /opt/conda/conda-bld/*/*.tar.bz2 {self.container_staging}/{arch}
 #While technically better, this is slower and more prone to breaking
-#cp `conda mambabuild {self.conda_build_args} {self.container_recipe}/meta.yaml --output | grep tar.bz2` {self.container_staging}/{arch}
+#cp `conda-build {self.conda_build_args} {self.container_recipe}/meta.yaml --output | grep tar.bz2` {self.container_staging}/{arch}
 conda index {self.container_staging}
 # Ensure permissions are correct on the host.
 HOST_USER={self.user_info[uid]}

--- a/bioconda_utils/involucro
+++ b/bioconda_utils/involucro
@@ -2,5 +2,4 @@
 
 exec involucro \
     -set POSTINSTALL='create-env --conda=: /usr/local' \
-    -set PREINSTALL='conda() { mamba "${@}" ; }' \
     "${@}"

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -162,8 +162,6 @@ def test_package(
     # galaxy-lib always downloads involucro, unless it's in cwd or its path is explicitly given.
     # We inject a POSTINSTALL to the involucro command with a small wrapper to
     # create activation / entrypoint scripts for the container.
-    # We also inject a PREINSTALL to alias conda to mamba so `mamba install` is
-    # used instead of `conda install` in the container builds.
     involucro_path = os.path.join(os.path.dirname(__file__), 'involucro')
     if not os.path.exists(involucro_path):
         raise RuntimeError('internal involucro wrapper missing')

--- a/bioconda_utils/recipe.py
+++ b/bioconda_utils/recipe.py
@@ -24,7 +24,6 @@ from typing import Any, Dict, List, Sequence, Tuple, Optional, Pattern
 
 import conda_build.api
 from conda_build.metadata import MetaData
-from boa.cli.mambabuild import prepare as insert_mambabuild
 
 import jinja2
 
@@ -769,8 +768,6 @@ class Recipe():
             def new_exit(args=None):
                 raise SystemExit(args)
             sys.exit = new_exit
-
-        insert_mambabuild()
 
         try:
             with open("/dev/null", "w") as devnull:

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -57,7 +57,6 @@ conda.gateways.logging.initialize_logging = lambda: None
 from conda_build import api
 from conda.exports import VersionOrder
 from conda.exports import subdir as conda_subdir
-from boa.cli.mambabuild import prepare as insert_mambabuild
 
 from jsonschema import validate
 from colorlog import ColoredFormatter
@@ -436,8 +435,6 @@ def load_all_meta(recipe, config=None, finalize=True):
         via conda and also download of those packages (to inspect possible
         run_exports). For fast-running tasks like linting, set to False.
     """
-    insert_mambabuild()
-
     if config is None:
         config = load_conda_build_config()
     # `bypass_env_check=True` prevents evaluating (=environment solving) the

--- a/test/test_pkg_test.py
+++ b/test/test_pkg_test.py
@@ -10,7 +10,6 @@ from bioconda_utils import utils
 from bioconda_utils import build
 
 from conda import __version__ as conda_version
-from mamba import __version__ as mamba_version
 
 # TODO:
 # need tests for channel order and extra channels (see


### PR DESCRIPTION
conda>=23.10 uses conda-libmamba-solver by default which means we don't need the solver injection via boa/conda-mambabuild anymore since it is handled upstream.