### PR TITLE
fix: test_package for .tar.bz2 and .conda

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -11,6 +11,7 @@ conda=24.3.*
 conda-libmamba-solver=24.1.*
 conda-build=24.3.*
 conda-index=0.4.*
+conda-package-streaming=0.9.*
 mamba=1.5.*
 boa=0.17.*
 

--- a/bioconda_utils/pkg_test.py
+++ b/bioconda_utils/pkg_test.py
@@ -14,6 +14,7 @@ from . import utils
 
 from conda_build.metadata import MetaData
 from conda_index.index import update_index
+from conda_package_streaming.package_streaming import stream_conda_info
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +24,9 @@ MULLED_CONDA_IMAGE = "quay.io/bioconda/create-env:latest"
 def get_tests(path):
     "Extract tests from a built package"
     tmp = tempfile.mkdtemp()
-    t = tarfile.open(path)
-    t.extractall(tmp)
+    for tar, member in stream_conda_info(path):
+        if member.name.startswith("info/recipe/"):
+            tar.extract(member, tmp)
     input_dir = os.path.join(tmp, 'info', 'recipe')
 
     tests = [

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -408,19 +408,18 @@ def sandboxed_env(env):
     the existing `os.environ` or the provided **env** that match
     ENV_VAR_WHITELIST globs.
     """
+    os_environ = os.environ
+    orig = os_environ.copy()
     env = dict(env)
-    orig = os.environ.copy()
-
-    _env = {k: v for k, v in orig.items() if allowed_env_var(k)}
-    _env.update({k: str(v) for k, v in env.items() if allowed_env_var(k)})
-
-    os.environ = _env
 
     try:
+        os_environ.clear()
+        os_environ.update({k: v for k, v in orig.items() if allowed_env_var(k)})
+        os_environ.update({k: str(v) for k, v in env.items() if allowed_env_var(k)})
         yield
     finally:
-        os.environ.clear()
-        os.environ.update(orig)
+        os_environ.clear()
+        os_environ.update(orig)
 
 
 def load_all_meta(recipe, config=None, finalize=True):


### PR DESCRIPTION
We used some custom code to extract test information from `.tar.bz2` packages which would need adjustments to handle `.conda` packages -- but nowadays we can just use `conda-package-streaming` for this instead, as done here.