### PR TITLE
chore!: Separate docs-only requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include bioconda_utils/bioconda_utils-requirements.txt
+include bioconda_utils/bioconda_utils-requirements-docs.txt
 include bioconda_utils/bioconda_utils-conda_build_config.yaml
 include bioconda_utils/config.schema.yaml
 include bioconda_utils/templates/*

--- a/bioconda_utils/bioconda_utils-requirements-docs.txt
+++ b/bioconda_utils/bioconda_utils-requirements-docs.txt
@@ -1,0 +1,7 @@
+sphinx>=4.1
+celery
+sphinx-autodoc-typehints
+alabaster=0.7.*
+docutils
+markdown
+graphviz

--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -68,13 +68,3 @@ platformdirs=4.*              #
 
 # build failure output
 tabulate=0.9.*                #
-
-# TODO: Remove these from general requirements into a doc-only-requirements file.
-# docs
-sphinx>=4.1
-celery
-sphinx-autodoc-typehints
-alabaster=0.7.*
-docutils
-markdown
-graphviz

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
             'bioconda_utils',
             [
                 'bioconda_utils/bioconda_utils-requirements.txt',
+                'bioconda_utils/bioconda_utils-requirements-docs.txt',
                 'bioconda_utils/config.schema.yaml',
             ],
         )


### PR DESCRIPTION
As of now, additional requirements for building docs add about 60 packages (+44MB downloaded, 290MB installed) not used by the build env.