### PR TITLE
chore: Bump bamtools to 2.5.2

### DIFF
--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -23,7 +23,7 @@ pin_run_as_build:
     min_pin: x.x
 
 bamtools:
-  - "2.5.1"
+  - "2.5.2"
 
 # NOTE: Workaround https://github.com/conda/conda-build/issues/3974 we slightly alter the values
 #       from conda-forge-pinnings here (inserting '.*' or ' ' which should be ignored later on).


### PR DESCRIPTION
2.5.2 is the only version at the moment that provides linux-aarch64 package: https://anaconda.org/bioconda/bamtools/files

I faced the following error
```
WARNING: failed to get package records, retrying.  exception was: Unsatisfiable dependencies for platform linux-aarch64: {MatchSpec("bamtools=2.5.1")}
Encountered problems while solving:
  - nothing provides requested bamtools 2.5.1.*
```
while adding linux-aarch64 to `scalpel`
  (https://github.com/bioconda/bioconda-recipes/pull/47964)

Full logs with the error:
- https://circleci.com/api/v1.1/project/github/bioconda/bioconda-recipes/186948/output/107/0?file=true&allocation-id=664c88870a2ca54ac5eb924f-0-build%2FABCDEFGH

Successful build after adding custom conda_build_config.yaml for scalpel:
- https://app.circleci.com/pipelines/github/bioconda/bioconda-recipes/116194/workflows/00d6dc8f-1d05-48a5-b15f-1ae3bff71433/jobs/186951