### PR TITLE
feat: Update base-glibc-*-bash images to 3.1

### DIFF
--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -122,9 +122,9 @@ def build(recipe: str, pkg_paths: List[str] = None,
     is_noarch = bool(meta.get_value('build/noarch', default=False))
     use_base_image = meta.get_value('extra/container', {}).get('extended-base', False)
     if use_base_image:
-        base_image = 'quay.io/bioconda/base-glibc-debian-bash:3.0'
+        base_image = 'quay.io/bioconda/base-glibc-debian-bash:3.1'
     else:
-        base_image = 'quay.io/bioconda/base-glibc-busybox-bash:3.0'
+        base_image = 'quay.io/bioconda/base-glibc-busybox-bash:3.1'
 
     build_failure_record = BuildFailureRecord(recipe)
     build_failure_record_existed_before_build = build_failure_record.exists()


### PR DESCRIPTION
New images use Debian 12.5 base and are built with Buildah >=1.35.0 for better compatibility w.r.t. gh-958 .

refs:
- https://github.com/bioconda/bioconda-containers/pull/82

fixes gh-958