### PR TITLE
fix: add missing Arm platforms to skip existing builds

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1400,7 +1400,7 @@ class RepoData:
     #: Columns available in internal dataframe
     columns = _load_columns + ['channel', 'subdir', 'platform']
     #: Platforms loaded
-    platforms = ['linux', 'osx', 'noarch']
+    platforms = ['linux', 'linux-aarch64', 'osx', 'osx-arm64', 'noarch']
     # config object
     config = None
 


### PR DESCRIPTION
When running bulk for linux-aarch64 on CircleCI, all recipes started building, even ones that had not been bumped. The `FILTER: not building recipe X because the same number of builds are in channel(s) and it is not forced.` message was not present in the log. This is because one place in bioconda-utils was missed when adding`linux-aarch64`. 

Bioconda-utils gets a dataframe of packages from the bioconda and conda-forge channels and then compares with the list of recipes requested to be built to see if a build already exists for that subdir, version, build number, and build string. Only `linux-64`, `osx-64`, and `noarch` were being considered. (The platform here gets converted to a subdir string which has the `-64` suffix.)

After this is merged and released, I will re-enable bulk for CircleCI.