### PR TITLE
ci: update autobump machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ version: 2
 jobs:
   autobump:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2204:2024.05.1
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ version: 2
 jobs:
   autobump:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:current
     steps:
       - add_ssh_keys:
           fingerprints:


### PR DESCRIPTION
CircleCI is removing the image: https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

This is the one we are using for linux-aarch64 builds.