### PR TITLE
fix: fix image artifact regex to match GitHub Actions filename

### DIFF
--- a/bioconda_utils/artifacts.py
+++ b/bioconda_utils/artifacts.py
@@ -18,7 +18,7 @@ from bioconda_utils.upload import anaconda_upload, skopeo_upload
 logger = logging.getLogger(__name__)
 
 
-IMAGE_RE = re.compile(r"(.+)(?::|%3A)(.+)\.tar\.gz$")
+IMAGE_RE = re.compile(r"(.+)(?::|%3A|---)(.+)\.tar\.gz$")
 
 
 class UploadResult(Enum):


### PR DESCRIPTION
GitHub Actions doesn't allow artifact files to contain `:`, so it is replaced with `---`. Update this artifact finding code to match that pattern.