### PR TITLE
feat: add rust to should_use_compilers lint

### DIFF
--- a/test/lint_cases.yaml
+++ b/test/lint_cases.yaml
@@ -338,6 +338,9 @@ tests:
   - name: compiler_old_3
     expect: should_use_compilers
     add: { requirements: { build: ["llvm  # [osx]"] } }
+  - name: compiler_old_4
+    expect: should_use_compilers
+    add: { requirements: { build: ["rust >=1.56"] } }
   - name: compiler_in_host
     expect: compilers_must_be_in_build
     remove: build/noarch


### PR DESCRIPTION
Rust has been a supported compiler for a little while now, and with the [new guidelines for Rust recipes](https://bioconda.github.io/contributor/guidelines.html#rust), it would be good for the linting to help people