### PR TITLE
feat: add liblzma-devel to host deps for compiled bioc pkgs

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -39,7 +39,7 @@ git=2.*                       # well - git
 regex=2024.*                  #
 
 # asyncio
-aiohttp=3.9.*                 # HTTP lib
+aiohttp>=3.10.11              # HTTP lib; pinning to reflect dependabot alert
 aiohttp-jinja2                # jinja2 renderer for aiohttp.web
 aiohttp-session               #
 aiohttp-security              #

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -944,9 +944,10 @@ class BioCProjectPage(object):
             additional_host_deps.append('liblapack')
 
             # During the BioC 3.20 builds, which also corresponded to updates
-            # in pinnings, there were quite a few issues where zlib was
-            # missing.
+            # in pinnings, there were quite a few issues where zlib and liblzma
+            # were missing.
             additional_host_deps.append('zlib')
+            additional_host_deps.append('liblzma-devel')
 
         additional_run_deps = []
         if self.is_data_package:


### PR DESCRIPTION
During BioC 3.20 builds, many pkgs were missing zlib and liblzma.

This PR also updates aiohttp to address dependabot alerts.