### PR TITLE
fix: don't decode

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -1032,7 +1032,7 @@ class BioCProjectPage(object):
         for k, v in self._cb3_build_reqs.items():
             d['requirements']['build'].append(k + '_' + "PLACEHOLDER")
 
-        rendered = pyaml.dumps(d, width=1e6).decode('utf-8')
+        rendered = pyaml.dumps(d, width=1e6)  #.decode('utf-8')  # decoding seems no longer needed
 
         # Add Suggests: and SystemRequirements:
         renderedsplit = rendered.split('\n')


### PR DESCRIPTION
Looks like we don't need the `.decode('utf8')` anymore; this line was originally added in 2017 so it was probably using py27 or something at the time.