### PR TITLE
fix: allow tilde in conda version constraints

### DIFF
--- a/bioconda_utils/lint/check_syntax.py
+++ b/bioconda_utils/lint/check_syntax.py
@@ -23,7 +23,7 @@ class version_constraints_missing_whitespace(LintCheck):
         for section in ('build', 'run', 'host'):
             check_paths.append(f'requirements/{section}')
 
-        constraints = re.compile("(.*?)([!<=>].*)")
+        constraints = re.compile("(.*?)([!~<=>].*)")
         for path in check_paths:
             for n, spec in enumerate(recipe.get(path, [])):
                 has_constraints = constraints.search(spec)
@@ -37,7 +37,7 @@ class version_constraints_missing_whitespace(LintCheck):
         for section in ('build', 'run', 'host'):
             check_paths.append(f'requirements/{section}')
 
-        constraints = re.compile("(.*?)([!<=>].*)")
+        constraints = re.compile("(.*?)([!~<=>].*)")
         for path in check_paths:
             for spec in self.recipe.get(path, []):
                 has_constraints = constraints.search(spec)


### PR DESCRIPTION


See conda package match specifications:

https://docs.conda.io/projects/conda-build/en/25.1.x/resources/package-spec.html#package-match-specifications

This syntax has also been around for a bit, I can already see it in the `24.1.x` docs.