### PR TITLE
fix: networkx NodeView and random.shuffle incompatible

### DIFF
--- a/bioconda_utils/autobump.py
+++ b/bioconda_utils/autobump.py
@@ -142,7 +142,7 @@ class RecipeGraphSource(RecipeSource):
         # Keep set of recipes "in flight"
         sent: Set[Recipe] = set()
         while dag:
-            remaining_recipes = dag.nodes()
+            remaining_recipes = list(dag.nodes())
             if self.shuffle:
                 random.shuffle(remaining_recipes)
             for recipe in remaining_recipes:


### PR DESCRIPTION
This should resolve https://github.com/bioconda/bioconda-recipes/issues/52577 and https://github.com/bioconda/bioconda-recipes/pull/961