### PR TITLE
fix: include pypi.org/packages in PyPi hoster_pattern

### DIFF
--- a/bioconda_utils/hosters.py
+++ b/bioconda_utils/hosters.py
@@ -683,6 +683,7 @@ class PyPi(JSONHoster):
     hoster_pattern = (r"(?P<hoster>"
                       r"files.pythonhosted.org/packages|"
                       r"pypi.python.org/packages|"
+                      r"pypi.org/packages|"
                       r"pypi.io/packages)")
     url_pattern = r"{hoster}/.*/{source}"
 


### PR DESCRIPTION
Adding `pypi.org/packages` to the hoster_pattern for PyPi (which is a redirection to `files.pythonhosted.org/packages`), which I believe is the URL that e.g. grayskull uses.