### PR TITLE
ci: update upload-artifact version in changevisibility since v3 was removed

### DIFF
--- a/.github/workflows/changevisibility.yml
+++ b/.github/workflows/changevisibility.yml
@@ -20,7 +20,7 @@ jobs:
           QUAY_OAUTH_TOKEN: ${{ secrets.QUAY_BIOCONTAINERS_TOKEN }}
 
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: logs
           path: biocontainers-*.txt


### PR DESCRIPTION
I believe this should fix https://github.com/bioconda/bioconda-recipes/issues/54470 