### PR TITLE
ci: update image workflow to use ubuntu-24.04, remove deprecated set-output

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: Build image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - uses: GoogleCloudPlatform/release-please-action@v4
         id: release
         with:
           release-type: python
@@ -31,7 +31,7 @@ jobs:
         run: |
           #tag=${{ github.event.release && github.event.release.tag_name || github.sha }}
           tag=${{ needs.release_please.outputs.tag_name }}
-          printf %s "::set-output name=tag::${tag#v}"
+          printf %s "tag=${tag#v}" >> $GITHUB_OUTPUT
 
       - name: Install qemu dependency
         run: |


### PR DESCRIPTION
ubuntu-20.04 is no longer supported

set-output is deprecated: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 