### PR TITLE
feat: allow and require {{ stdlib("c") }} in recipes

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -825,6 +825,8 @@ class BioCProjectPage(object):
             self._cb3_build_reqs['cxx'] = "{{ compiler('cxx') }}"
         if need_f:
             self._cb3_build_reqs['fortran'] = "{{ compiler('fortran') }}"
+        if len(self._cb3_build_reqs):
+            self._cb3_build_reqs['stdlib'] = "{{ stdlib('c') }}"
         if need_autotools:
             self._cb3_build_reqs['automake'] = 'automake'
         if need_make:
@@ -939,7 +941,7 @@ class BioCProjectPage(object):
         # Handle libblas and liblapack, which all compiled packages
         # are assumed to need
         additional_host_deps = []
-        if self.linkingto != [] or len(set(['c', 'cxx', 'fortran']).intersection(self._cb3_build_reqs.keys())) > 0:
+        if self.linkingto != [] or len(set(['c', 'cxx', 'fortran', 'stdlib']).intersection(self._cb3_build_reqs.keys())) > 0:
             additional_host_deps.append('libblas')
             additional_host_deps.append('liblapack')
 

--- a/bioconda_utils/lint/check_build_help.py
+++ b/bioconda_utils/lint/check_build_help.py
@@ -62,6 +62,24 @@ class compilers_must_be_in_build(LintCheck):
                     if "run" in location or "host" in location:
                         self.message(section=location)
 
+class compiler_needs_stdlib_c(LintCheck):
+    """The recipe requests a compiler in the build section, but does not have stdlib.
+
+    Please add the ``{{ stdlib('c') }}`` line to the
+    ``requirements: build:`` section.
+    """
+
+    def check_deps(self, deps):
+        compiler = False
+        stdlib = False
+        for dep, locations in deps.items():
+            if dep.startswith("compiler_") and any(["build" in location for location in locations]):
+                compiler = True
+            if dep == "stdlib_c" and any(["build" in location for location in locations]):
+                stdlib = True
+        if compiler and not stdlib:
+            self.message(section="requirements/build")
+
 
 class uses_setuptools(LintCheck):
     """The recipe uses setuptools in run depends

--- a/bioconda_utils/recipe.py
+++ b/bioconda_utils/recipe.py
@@ -138,6 +138,7 @@ class Recipe():
     JINJA_VARS = {
         "cran_mirror": "https://cloud.r-project.org",
         "compiler": lambda x: f"compiler_{x}",
+        "stdlib": lambda x: f"stdlib_{x}",
         "pin_compatible": lambda x, max_pin=None, min_pin=None: f"{x}",
         "cdt": lambda x: x
     }

--- a/test/lint_cases.yaml
+++ b/test/lint_cases.yaml
@@ -230,7 +230,7 @@ tests:
   - name: should_not_be_noarch_compiler
     add:
       build: { noarch: python }
-      requirements: { build: [compiler_gcc] }
+      requirements: { build: [compiler_gcc, stdlib_c] }
     expect: should_not_be_noarch_compiler
   - name: should_not_be_noarch_skip
     add:
@@ -257,7 +257,7 @@ tests:
           sha256: 123 # [linux]
         - url: https://elsewhere # [osx]
           sha256: 123 # [osx]
-      requirements: { build: ['{{compiler("c")}}'] }
+      requirements: { build: ['{{compiler("c")}}', '{{stdlib("c")}}'] }
   - name: noarch_java_with_python_wrapper
     add:
       build: { noarch: generic }
@@ -328,7 +328,7 @@ tests:
     add: { requirements: { build: ["numpy x.x"], run: ["numpy x.x"] } }
   - name: compiler_ok
     remove: build/noarch
-    add: { requirements: { build: ['{{compiler("c")}}'] } }
+    add: { requirements: { build: ['{{compiler("c")}}', '{{stdlib("c")}}'] } }
   - name: compiler_old_1
     expect: should_use_compilers
     add: { requirements: { build: ["gcc  # [linux]"] } }
@@ -341,6 +341,10 @@ tests:
   - name: compiler_old_4
     expect: should_use_compilers
     add: { requirements: { build: ["rust >=1.56"] } }
+  - name: compiler_needs_stdlib_c
+    expect: compiler_needs_stdlib_c
+    remove: build/noarch
+    add: { requirements: { build: ['{{compiler("c")}}'] } }
   - name: compiler_in_host
     expect: compilers_must_be_in_build
     remove: build/noarch
@@ -397,18 +401,18 @@ tests:
   - name: cython_in_run
     expect: cython_must_be_in_host
     add:
-      requirements: { run: [cython], build: ['{{compiler("c")}}'] }
+      requirements: { run: [cython], build: ['{{compiler("c")}}', '{{stdlib("c")}}'] }
       build: { noarch: False }
   - name: cython_in_host_no_compiler
     expect: cython_needs_compiler
     add: { requirements: { host: [cython] } }
   - name: cython_in_host
     add:
-      requirements: { host: [cython], build: ['{{compiler("c")}}'] }
+      requirements: { host: [cython], build: ['{{compiler("c")}}', '{{stdlib("c")}}'] }
       build: { noarch: False }
   - name: cython_cxx_compiler_ok
     add:
-      requirements: { host: [cython], build: ['{{compiler("cxx")}}'] }
+      requirements: { host: [cython], build: ['{{compiler("cxx")}}', '{{stdlib("c")}}'] }
       build: { noarch: False }
   - name: missing_run_exports
     remove: build/run_exports


### PR DESCRIPTION
- add stdlib function to `JINJA_VARS` to prevent the `version_constraints_missing_whitespace` lint error
- add new lint to require stdlib function if compilers are used
- update tests for the new lint (and to avoid tripping it when testing other lints)
- Add `{{ stdlib("c") }}` to bioconductor-skeleton

See https://github.com/bioconda/bioconda-recipes/issues/51185