### PR TITLE
fix: handle recipes with an empty extra section

### DIFF
--- a/bioconda_utils/recipe.py
+++ b/bioconda_utils/recipe.py
@@ -403,7 +403,7 @@ class Recipe():
     @property
     def extra_additional_platforms(self) -> list:
         """The extra additional-platforms list"""
-        if 'extra' in self.meta and 'additional-platforms' in self.meta['extra']:
+        if 'extra' in self.meta and self.meta['extra'] and 'additional-platforms' in self.meta['extra']:
             return list(self.meta["extra"]["additional-platforms"])
         return []
 


### PR DESCRIPTION
The recipe `ligand-validation` was added with an empty `extra:` section in meta.yaml. This will handle that situation without throwing an error during the nightly ARM builds.