### PR TITLE
fix: unexpected arg 'label'

### DIFF
--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -556,7 +556,6 @@ def handle_merged_pr(
             anaconda_upload=not dryrun,
             mulled_upload_target=quay_upload_target if not dryrun else None,
             mulled_test=True,
-            label=label,
         )
     else:
         success = res != UploadResult.FAILURE


### PR DESCRIPTION
There is an error in `bioconda_utils/cli.py`:

Currently, `handle_merged_pr` calls `build` with setting arg `label`, see https://github.com/bioconda/bioconda-utils/blob/41b24166f8e24b2155d4bb2dcfff94c10f46dfb7/bioconda_utils/cli.py#L551C5-L560C10:
```
if res == UploadResult.NO_ARTIFACTS and fallback == 'build':
        success = build(
            recipe_folder,
            config,
            git_range=git_range,
            anaconda_upload=not dryrun,
            mulled_upload_target=quay_upload_target if not dryrun else None,
            mulled_test=True,
            label=label,
        )
```
But `build` is defined as following:
```
def build(recipe_folder, config, packages="*", git_range=None, testonly=False,
          force=False, docker=None, mulled_test=False, build_script_template=None,
          pkg_dir=None, anaconda_upload=False, mulled_upload_target=None,
          build_image=False, keep_image=False, lint=False, lint_exclude=None,
          check_channels=None, n_workers=1, worker_offset=0, keep_old_work=False,
          mulled_conda_image=pkg_test.MULLED_CONDA_IMAGE,
          docker_base_image=None,
          record_build_failures=False,
          skiplist_leafs=False,
          disable_live_logs=False,
          exclude=None,
          subdag_depth=None):
```
There is no arg `label` in `build`, this will fail when `res == UploadResult.NO_ARTIFACTS and fallback == 'build'`.

I think maybe it never entered this branch before, so never an error encountered.
