### PR TITLE
ci: update to macos-15-intel

### DIFF
--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -52,7 +52,7 @@ jobs:
           fi
   test-macosx:
     name: OSX tests
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
macos-13 is deprecated and being removed.