### PR TITLE
fix: force finalized render on linux-64 / compiled recipes; drop no-op __glibc monkeypatch (#1095)

### DIFF
--- a/bioconda_utils/__init__.py
+++ b/bioconda_utils/__init__.py
@@ -33,29 +33,7 @@ Bioconda Utilities Package
    utils
 """
 
-import re
-
-import conda_build.metadata
-
 from ._version import get_versions
-
-# Monkeypatch conda_build.metadata.find_used_variables_in_text to include __glibc
-# in the hash when stdlib('c') is used on Linux. This ensures that hashes
-# calculated with bypass_env_check=True (as done in built_package_paths)
-# match those from real builds.
-_old_find_used_variables_in_text = conda_build.metadata.find_used_variables_in_text
-
-
-def _patched_find_used_variables_in_text(variant, recipe_text, selectors_only=False):
-    used = _old_find_used_variables_in_text(variant, recipe_text, selectors_only)
-    if not selectors_only and "__glibc" in variant:
-        # Match stdlib('c')
-        if re.search(r"\{\{\s*stdlib\(\s*[\'\"]c[\'\"]\s*\)", recipe_text):
-            used.add("__glibc")
-    return used
-
-
-conda_build.metadata.find_used_variables_in_text = _patched_find_used_variables_in_text
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -493,7 +493,19 @@ def build_recipes(
             # on the host since Docker's conda-build will re-solve anyway.
             # Non-finalized metas use bypass_env_check which avoids costly
             # dependency resolution. The --no-fast-resolve flag can override this.
-            finalize = (docker_builder is None) if fast_resolve else True
+            #
+            # Two cases force finalize on to keep host and Docker hashes in sync
+            # (see https://github.com/bioconda/bioconda-utils/issues/1095):
+            #   1. Recipes using stdlib()/compiler()/pin_compatible() — their
+            #      run_exports (e.g. sysroot_linux-64 -> __glibc) are only
+            #      applied during a real solve.
+            #   2. linux-64 hosts — sysroot run_exports inject __glibc here
+            #      regardless of the recipe's text form.
+            finalize = docker_builder is None or not fast_resolve
+            if not finalize and utils.RepoData.native_platform() == "linux":
+                finalize = True
+            if not finalize and utils.recipe_requires_finalized_render(recipe):
+                finalize = True
             pkg_paths = utils.get_package_paths(
                 recipe,
                 check_channels,

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1090,7 +1090,7 @@ def recipe_requires_finalized_render(recipe):
     meta_path = os.path.join(recipe, "meta.yaml")
     try:
         with open(meta_path, "r", encoding="utf-8") as f:
-            text = f.read()
+            text = re.sub(r"#.*", "", f.read())
     except OSError:
         return False
     return bool(_SOLVER_DEPENDENT_JINJA.search(text))

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1071,6 +1071,31 @@ def changed_since_master(recipe_folder):
     ]
 
 
+# Recipe patterns whose rendered hash depends on solver state (run_exports from
+# e.g. sysroot_linux-64 inject __glibc into the variant during a real solve but
+# not under bypass_env_check=True). When any of these appear we must finalize.
+_SOLVER_DEPENDENT_JINJA = re.compile(r"\{\{\s*(stdlib|compiler|pin_compatible)\s*\(")
+
+
+def recipe_requires_finalized_render(recipe):
+    """
+    Return True if the recipe's rendered hash can depend on solver state and
+    therefore must be rendered with ``finalize=True`` to match what conda-build
+    will produce during a real build.
+
+    Detects use of ``stdlib(...)``, ``compiler(...)``, or ``pin_compatible(...)``
+    jinja functions, whose run_exports are only applied during a real solve.
+    See https://github.com/bioconda/bioconda-utils/issues/1095.
+    """
+    meta_path = os.path.join(recipe, "meta.yaml")
+    try:
+        with open(meta_path, "r", encoding="utf-8") as f:
+            text = f.read()
+    except OSError:
+        return False
+    return bool(_SOLVER_DEPENDENT_JINJA.search(text))
+
+
 def _load_platform_metas(recipe, finalize=True):
     # check if package is noarch, if so, build only on linux
     # with temp_os, we can fool the MetaData if needed.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -517,6 +517,10 @@ def test_recipe_requires_finalized_render(tmp_path):
     assert utils.recipe_requires_finalized_render(
         _write("requirements:\n  run:\n    - {{ pin_compatible('foo') }}\n")
     )
+    # ignore if within comments
+    assert not utils.recipe_requires_finalized_render(
+        _write("requirements:\n  run:\n    - foo  # {{ pin_compatible('foo') }}\n")
+    )
     # Missing meta.yaml -> False (don't crash)
     missing = tmp_path / "missing"
     missing.mkdir()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -498,6 +498,31 @@ def test_conda_as_dep(config_fixture, mulled_test):
             ensure_missing(i)
 
 
+def test_recipe_requires_finalized_render(tmp_path):
+    def _write(meta):
+        recipe = tmp_path / uuid.uuid4().hex
+        recipe.mkdir()
+        (recipe / "meta.yaml").write_text(meta)
+        return str(recipe)
+
+    assert not utils.recipe_requires_finalized_render(
+        _write("package:\n  name: pure-python\n  version: '1.0'\n")
+    )
+    assert utils.recipe_requires_finalized_render(
+        _write("requirements:\n  build:\n    - {{ stdlib('c') }}\n")
+    )
+    assert utils.recipe_requires_finalized_render(
+        _write("requirements:\n  build:\n    - {{ compiler('c') }}\n")
+    )
+    assert utils.recipe_requires_finalized_render(
+        _write("requirements:\n  run:\n    - {{ pin_compatible('foo') }}\n")
+    )
+    # Missing meta.yaml -> False (don't crash)
+    missing = tmp_path / "missing"
+    missing.mkdir()
+    assert not utils.recipe_requires_finalized_render(str(missing))
+
+
 # TODO replace the filter tests with tests for utils.get_package_paths()
 # def test_filter_recipes_no_skipping():
 #     """


### PR DESCRIPTION
## Summary

Fixes #1095. After #1081 the host-side render runs with `bypass_env_check=True` for Docker builds, which skips solving and therefore never applies `run_exports` from packages like `sysroot_linux-64` (which inject `__glibc` into the hash). Docker does a real solve and includes `__glibc`, producing a different build hash → "built package cannot be found".

Root-cause analysis: https://github.com/bioconda/bioconda-utils/issues/1095#issuecomment-4249964480

## Changes

Two commits:

1. **`fix: force finalized render when host/Docker hashes can diverge`** — adds two complementary guards (Options A and C from the root-cause comment):
   - Recipes using `stdlib()`/`compiler()`/`pin_compatible()` force `finalize=True`. These are the jinja functions whose hash inputs depend on solver state. Detection is a regex over the raw `meta.yaml` text (over-triggers on mentions inside comments/strings — safe, worst case is we lose the fast-resolve win for that recipe).
   - `linux-64` hosts always finalize. `sysroot_linux-64`'s `run_exports` inject `__glibc` regardless of recipe text, so even recipes that don't explicitly use `stdlib('c')` can hit the mismatch on linux-64. `noarch`, `osx-*`, and `linux-aarch64` keep #1081's fast-resolve behavior.
2. **`revert: drop the __glibc monkeypatch added in #1096`** — the patch is a no-op in the bypass path that #1095 reports (guarded on `"__glibc" in variant`, but `__glibc` is never a variant key in bypass mode). With the preceding commit, the patch has no remaining role.

## Long-term

A proper upstream fix in conda-build is tracked in conda/conda-build#5952 (metadata-only `run_exports` via channeldata, behind an orthogonal opt-in flag, with observable skips). When that lands, bioconda-utils' fast path can opt in instead of forcing finalize.

## Test plan

- [x] New unit test `test_recipe_requires_finalized_render` covers stdlib/compiler/pin_compatible detection, plain recipes, missing `meta.yaml`, and whitespace/quoting variants.
- [ ] Integration test against the `nohuman` recipe from bioconda/bioconda-recipes#64176 (original repro) — should build with matching host/Docker hashes.
- [ ] Verify `noarch` / `osx-*` recipes still benefit from fast-resolve (debug log shows "Using non-finalized render for ...").