### PR TITLE
feat: add support for local (file://) channels

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1432,7 +1432,7 @@ class AsyncRequests:
         result = []
         if url.startswith("file://"):
             if os.path.exists(url[7:]):
-                async with aiofiles.open(url[7:], mode='rb') as f:
+                async with aiofiles.open(url[7:], mode="rb") as f:
                     result.append(await f.read())
             else:
                 subdir = url.split("/")[-2]
@@ -1441,7 +1441,7 @@ class AsyncRequests:
                     "packages": dict(),
                     "packages.conda": dict(),
                     "removed": list(),
-                    "repodata_version": 1
+                    "repodata_version": 1,
                 }
                 result.append(json.dumps(d).encode("UTF-8"))
         else:

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1436,11 +1436,13 @@ class AsyncRequests:
                     result.append(await f.read())
             else:
                 subdir = url.split("/")[-2]
-                d = {"info": {"subdir": subdir},
-                     "packages": dict(),
-                     "packages.conda": dict(),
-                     "removed": list(),
-                     "repodata_version": 1}
+                d = {
+                    "info": {"subdir": subdir},
+                    "packages": dict(),
+                    "packages.conda": dict(),
+                    "removed": list(),
+                    "repodata_version": 1
+                }
                 result.append(json.dumps(d).encode("UTF-8"))
         else:
             async with session.get(url, timeout=None) as resp:
@@ -1602,7 +1604,7 @@ class RepoData:
             url_template = self.REPODATA_URL
         local_url_template = self.LOCAL_REPODATA
 
-        if channel.startswith("file://") :  # Allow local channels
+        if channel.startswith("file://"):  # Allow local channels
             url = local_url_template.format(
                 channel=channel, subdir=self.platform2subdir(platform)
             )

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -5,6 +5,7 @@ This module collects small pieces of code used throughout :py:mod:`bioconda_util
 """
 
 import asyncio
+import aiofiles
 import contextlib
 import datetime
 import fnmatch
@@ -1429,27 +1430,40 @@ class AsyncRequests:
     )
     async def _async_fetch_one(session, url, desc, cb=None, data=None, fd=None):
         result = []
-        async with session.get(url, timeout=None) as resp:
-            resp.raise_for_status()
-            size = int(resp.headers.get("Content-Length", 0))
-            with tqdm(
-                total=size,
-                unit="B",
-                unit_scale=True,
-                unit_divisor=1024,
-                desc=desc,
-                miniters=1,
-                disable=logger.getEffectiveLevel() > logging.INFO,
-            ) as progress:
-                while True:
-                    block = await resp.content.read(1024 * 16)
-                    if not block:
-                        break
-                    progress.update(len(block))
-                    if fd:
-                        fd.write(block)
-                    else:
-                        result.append(block)
+        if url.startswith("file://"):
+            if os.path.exists(url[7:]):
+                async with aiofiles.open(url[7:], mode='rb') as f:
+                    result.append(await f.read())
+            else:
+                subdir = url.split("/")[-2]
+                d = {"info": {"subdir": subdir},
+                     "packages": dict(),
+                     "packages.conda": dict(),
+                     "removed": list(),
+                     "repodata_version": 1}
+                result.append(json.dumps(d).encode("UTF-8"))
+        else:
+            async with session.get(url, timeout=None) as resp:
+                resp.raise_for_status()
+                size = int(resp.headers.get("Content-Length", 0))
+                with tqdm(
+                    total=size,
+                    unit="B",
+                    unit_scale=True,
+                    unit_divisor=1024,
+                    desc=desc,
+                    miniters=1,
+                    disable=logger.getEffectiveLevel() > logging.INFO,
+                ) as progress:
+                    while True:
+                        block = await resp.content.read(1024 * 16)
+                        if not block:
+                            break
+                        progress.update(len(block))
+                        if fd:
+                            fd.write(block)
+                        else:
+                            result.append(block)
         if cb:
             return cb(b"".join(result), data)
         else:
@@ -1515,6 +1529,7 @@ class RepoData:
         "https://conda.anaconda.org/{channel}/label/{label}/{subdir}/repodata.json"
     )
     REPODATA_DEFAULTS_URL = "https://repo.anaconda.com/pkgs/main/{subdir}/repodata.json"
+    LOCAL_REPODATA = "{channel}/{subdir}/repodata.json"
 
     _load_columns = ["build", "build_number", "name", "version", "depends"]
 
@@ -1585,10 +1600,16 @@ class RepoData:
             url_template = self.REPODATA_DEFAULTS_URL
         else:
             url_template = self.REPODATA_URL
+        local_url_template = self.LOCAL_REPODATA
 
-        url = url_template.format(
-            channel=channel, subdir=self.platform2subdir(platform)
-        )
+        if channel.startswith("file://") :  # Allow local channels
+            url = local_url_template.format(
+                channel=channel, subdir=self.platform2subdir(platform)
+            )
+        else:
+            url = url_template.format(
+                channel=channel, subdir=self.platform2subdir(platform)
+            )
         return url
 
     def _load_channel_dataframe_cached(self):


### PR DESCRIPTION
I suspect I'm the only one who does this, but perhaps someone else will find this useful.

Sometimes it's useful to have a local channel of packages defined in a config.yml, for example for packages that can't be publicly distributed. If you want to mix that with bioconda-utils you currently get an error when it tries to load the repodata.json, since it always looks for remote files. This change explicitly looks for channels starting with `file://` and handles them with aiofiles, which is already a dependency. I've tested this locally with some private channels and it seems to work nicely.

This is probably nicer than my currently very-ugly-hack of just copying the channel contents into the conda-bld/ directory within my build container and then cleaning things up afterward.