### PR TITLE
chore: bump base image versions

### DIFF
--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -23,7 +23,7 @@ jobs:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
       MAJOR_VERSION: 3
-      MINOR_VERSION: 1
+      MINOR_VERSION: 2
       IMAGE_NAME: base-glibc-busybox-bash
       BUSYBOX_VERSION: '1.36.1'
       DEBIAN_VERSION: '12.5'

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -23,7 +23,7 @@ jobs:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
       MAJOR_VERSION: 3
-      MINOR_VERSION: 1
+      MINOR_VERSION: 2
       IMAGE_NAME: base-glibc-debian-bash
       DEBIAN_VERSION: '12.5'
 

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -21,7 +21,7 @@ jobs:
       options: --privileged
     env:
       MAJOR_VERSION: 3
-      MINOR_VERSION: 1
+      MINOR_VERSION: 2
       IMAGE_NAME: create-env
 
     steps:

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -137,9 +137,9 @@ def build(
     is_noarch = bool(meta.get_value("build/noarch", default=False))
     use_base_image = meta.get_value("extra/container", {}).get("extended-base", False)
     if use_base_image:
-        base_image = "quay.io/bioconda/base-glibc-debian-bash:3.1"
+        base_image = "quay.io/bioconda/base-glibc-debian-bash:3.2"
     else:
-        base_image = "quay.io/bioconda/base-glibc-busybox-bash:3.1"
+        base_image = "quay.io/bioconda/base-glibc-busybox-bash:3.2"
 
     build_failure_record = BuildFailureRecord(recipe)
     build_failure_record_existed_before_build = build_failure_record.exists()

--- a/bioconda_utils/build.py
+++ b/bioconda_utils/build.py
@@ -137,9 +137,9 @@ def build(
     is_noarch = bool(meta.get_value("build/noarch", default=False))
     use_base_image = meta.get_value("extra/container", {}).get("extended-base", False)
     if use_base_image:
-        base_image = "quay.io/bioconda/base-glibc-debian-bash:3.2"
+        base_image = "quay.io/bioconda/base-glibc-debian-bash:3.1"
     else:
-        base_image = "quay.io/bioconda/base-glibc-busybox-bash:3.2"
+        base_image = "quay.io/bioconda/base-glibc-busybox-bash:3.1"
 
     build_failure_record = BuildFailureRecord(recipe)
     build_failure_record_existed_before_build = build_failure_record.exists()

--- a/bioconda_utils/circleci.py
+++ b/bioconda_utils/circleci.py
@@ -4,7 +4,7 @@ CircleCI Web-API Bindings
 
 import abc
 import logging
-from typing import Any
+from typing import Any, TypedDict
 from collections.abc import Mapping
 import uritemplate
 import json
@@ -229,15 +229,22 @@ class CircleAPI(abc.ABC):
         return artifacts
 
 
+class _SlackMessageItem(TypedDict):
+    urls: dict[str, str]
+    success: bool
+
+
 class SlackMessage:
     """Parses a Slack message as sent by CircleCI"""
+
+    parsed: list[_SlackMessageItem]
 
     def __init__(self, _headers: Mapping[str, str], data: bytes) -> None:
         response_text = data.decode("utf-8")
         try:
             data = json.loads(response_text)
         except json.decoder.JSONDecodeError:
-            raise RuntimeError("Unable to decore CircleCI Slack message")
+            raise RuntimeError("Unable to decode CircleCI Slack message")
         self.parsed = []
         for attachment in data["attachments"]:
             text = attachment["text"]

--- a/bioconda_utils/docker_utils.py
+++ b/bioconda_utils/docker_utils.py
@@ -313,15 +313,16 @@ class RecipeBuilder:
         self.cleanup()
 
     def _find_proxy_settings(self) -> dict[str, str]:
-        res = {}
+        res: dict[str, str] = {}
         for var in ("http_proxy", "https_proxy"):
-            values = {
-                os.environ.get(var, None),
-                os.environ.get(var.upper(), None),
-            }.difference([None])
-            if len(values) == 1:
-                res[var] = next(iter(values))
-            elif len(values) > 1:
+            candidates = [
+                val
+                for val in (os.environ.get(var), os.environ.get(var.upper()))
+                if val is not None
+            ]
+            if len(candidates) == 1:
+                res[var] = candidates[0]
+            elif len(candidates) > 1:
                 raise ValueError(f"{var} and {var.upper()} have different values")
         return res
 


### PR DESCRIPTION
Needs a bump because all architectures are built in one go, and tag immutability means ARM images are not pushed if it would mean overriding an existing x86 image. 

CI ty is newer than local ty -> found minor issues, fix