### PR TITLE
fix: platform detection

### DIFF
--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -1509,6 +1509,7 @@ def autobump(
     help="Platforms to annotate",
     nargs="+",
     type=str,
+    choices=sorted(conda.base.constants.PLATFORM_DIRECTORIES),
 )
 @arg(
     "--existing-only",

--- a/bioconda_utils/cli.py
+++ b/bioconda_utils/cli.py
@@ -1509,7 +1509,6 @@ def autobump(
     help="Platforms to annotate",
     nargs="+",
     type=str,
-    default=["linux-64", "osx-64"],
 )
 @arg(
     "--existing-only",
@@ -1526,7 +1525,11 @@ def annotate_build_failures(
 ):
     valid_platform_names = set(conda.base.constants.PLATFORM_DIRECTORIES)
     if platforms is None:
-        platforms = ["linux-64", "osx-64"]
+        platforms = [
+            utils.RepoData.platform2subdir(p)
+            for p in utils.RepoData.platforms
+            if p != "noarch"
+        ]
     for recipe in recipes:
         if existing_only:
             platforms = [

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1103,14 +1103,7 @@ def recipe_requires_finalized_render(recipe):
 
 
 def _load_platform_metas(recipe, finalize=True):
-    # check if package is noarch, if so, build only on linux
-    # with temp_os, we can fool the MetaData if needed.
-    platform = os.environ.get("OSTYPE", sys.platform)
-    if platform.startswith("darwin"):
-        platform = "osx"
-    elif platform == "linux-gnu":
-        platform = "linux"
-
+    platform = RepoData.native_platform()
     config = load_conda_build_config(platform=platform)
     return platform, load_all_meta(recipe, config=config, finalize=finalize)
 
@@ -1133,7 +1126,7 @@ def check_recipe_skippable(recipe, check_channels):
     if os.environ.get("CI", None) == "true":
         first_meta = metas[0]
         if first_meta.get_value("build/noarch"):
-            if platform != "linux":
+            if not platform.startswith("linux"):
                 logger.info(
                     "FILTER: only building %s on linux because it defines noarch.",
                     recipe,


### PR DESCRIPTION
When `_load_platform_metas()` returns `"linux"` on ARM64 hardware, `config.platform` is set to `"linux"`, which causes conda-build to resolve x86_64 variants. 
This fixes that by doing proper platform detection