### PR TITLE
ci: make CI check shell scripts

### DIFF
--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -25,12 +25,17 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda create -n bioconda --quiet --yes --file test-requirements.txt --file bioconda_utils/bioconda_utils-requirements.txt
           conda activate bioconda
-          conda install -y -c conda-forge ty
+          conda install -y -c conda-forge ty shellcheck just
       - name: ty check
         run: |
           eval "$(conda shell.bash hook)"
           conda activate bioconda
           ty check .
+      - name: shellcheck
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate bioconda
+          just shellcheck
   test-linux:
     name: Linux tests
     runs-on: ubuntu-latest

--- a/images/base-glibc-busybox-bash/install-pkgs
+++ b/images/base-glibc-busybox-bash/install-pkgs
@@ -1,4 +1,6 @@
 #! /bin/sh
+# local is available in Debian's dash (patched) and BusyBox ash
+# shellcheck disable=SC3043
 set -xeu
 
 arch=$(uname -m)
@@ -291,14 +293,19 @@ get_deps() {
             libaudit1 libpam-modules libpam-runtime libpam0g |
             grep -vFx "$(printf %s\\n "${@}")"
     )"
-    [ -f "${root_fs}/.pkg.lst" ] &&
+    if [ -f "${root_fs}/.pkg.lst" ]; then
+        # ignore_pkgs is intentionally word-split to iterate multiple packages; $(cat -s) output also word-split
+        # shellcheck disable=SC2086,SC2046
         ignore_pkgs=$(printf %s\\n ${ignore_pkgs} $(cat -s "${root_fs}/.pkg.lst"))
+    fi
 
     local new_pkgs="${*}"
     local old_pkgs=''
     while ! [ "${new_pkgs}" = "${old_pkgs}" ]; do
         old_pkgs="${new_pkgs}"
         new_pkgs="$(
+            # ${old_pkgs} is intentionally word-split to pass multiple packages as separate arguments
+            # shellcheck disable=SC2086
             apt-cache depends \
                 --no-recommends --no-suggests --no-conflicts \
                 --no-breaks --no-replaces --no-enhances \
@@ -306,11 +313,13 @@ get_deps() {
                 sed -n 's/.*Depends: //p' | cat -s
         )"
         new_pkgs="$(
-            printf %s\\n ${old_pkgs} ${new_pkgs} |
-                sort -u |
-                grep -vFx "$(printf %s\\n ${ignore_pkgs})"
+            # ${old_pkgs}, ${new_pkgs}, and ${ignore_pkgs} are intentionally word-split for package iteration
+            # shellcheck disable=SC2086
+            printf %s\\n ${old_pkgs} ${new_pkgs} | sort -u | grep -vFx "$(printf %s\\n ${ignore_pkgs})"
         )"
     done
+    # ${new_pkgs} is intentionally word-split to emit one package per line
+    # shellcheck disable=SC2086
     printf %s\\n ${new_pkgs}
 }
 

--- a/images/create-env/create-env
+++ b/images/create-env/create-env
@@ -132,6 +132,8 @@ eval "$(conda shell.posix activate base)"
 set -u
 
 printf 'creating environment at %s ...\n' "${prefix}" 1>&2
+# ${conda_impl} and ${create_command} are intentionally word-split (e.g. "conda" or "mamba env")
+# shellcheck disable=SC2086
 CONDA_YES=1 \
     ${conda_impl} \
     ${create_command} \
@@ -153,11 +155,9 @@ if [ -n "${env_activate_file}${env_execute_file}" ]; then
     fi
     if [ -n "${env_execute_file-}" ]; then
         printf 'writing execution script to %s ...\n' "${env_execute_file}" 1>&2
-        printf '%s\n' \
-            '#! /bin/bash' \
-            "${activate_script}" \
-            'exec "${@}"' \
-            >"${env_execute_file}"
+        # ${@} must be literal in the generated script, not expanded at write time
+        # shellcheck disable=SC2016
+        printf '%s\n' '#! /bin/bash' "${activate_script}" 'exec "${@}"' >"${env_execute_file}"
         chmod +x "${env_execute_file}"
     fi
 fi
@@ -204,9 +204,11 @@ if [ -n "${strip_files_globs}" ]; then
                 -n 64 \
                 -- \
                 stat -L -c '%d,%i:%n' -- |
-            sed \
-                ${skip_inode_expressions} \
-                -e 's/^[^:]*://' |
+            {
+                # ${skip_inode_expressions} is intentionally word-split to pass multiple sed arguments
+                # shellcheck disable=SC2086
+                sed ${skip_inode_expressions} -e 's/^[^:]*://'
+            } |
             tr \\n \\0 |
             xargs \
                 -0 \

--- a/images/create-env/install-conda
+++ b/images/create-env/install-conda
@@ -20,6 +20,8 @@ miniconda_boostrap_prefix="$(pwd)/miniconda"
         -p "${miniconda_boostrap_prefix}"
 
     # Install the base Conda installation.
+    # conda.sh is created by the Miniconda installer above and doesn't exist at analysis time
+    # shellcheck disable=SC1091
     . "${miniconda_boostrap_prefix}/etc/profile.d/conda.sh"
 
     # Install conda, mamba and some additional tools:
@@ -38,6 +40,8 @@ miniconda_boostrap_prefix="$(pwd)/miniconda"
     conda remove --yes --all \
         --prefix="${conda_install_prefix}"
 
+    # ${tools} may be empty or space-separated list; word splitting is intentional
+    # shellcheck disable=SC2086
     conda create --yes \
         --prefix="${conda_install_prefix}" \
         --channel=conda-forge \
@@ -47,8 +51,7 @@ miniconda_boostrap_prefix="$(pwd)/miniconda"
         tini \
         \
         libgcc-ng \
-        ${tools} \
-        ;
+        ${tools}
 
     mv \
         ./print-env-activate \

--- a/justfile
+++ b/justfile
@@ -12,10 +12,16 @@ deps:
     conda install --file bioconda_utils/bioconda_utils-requirements.txt -c conda-forge -c bioconda
     conda install -c conda-forge ty ruff shfmt shellcheck
 
-check:
+ruff:
     ruff check .
+
+ty:
     ty check .
+
+shellcheck:
     shellcheck {{shell_scripts}}
+
+check: ruff ty shellcheck
 
 # install a local build of the CLI for testing
 install:


### PR DESCRIPTION
Make CI run shellcheck to lint the shell scripts. 
There is a lot of shell script in this repo, which goes mostly unchecked. This adds a few exemptions where the linter messes up and adds it to the CI quality control