### PR TITLE
fix: retry on flaky CDN PayloadError

### DIFF
--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1427,7 +1427,7 @@ class AsyncRequests:
     @staticmethod
     @backoff.on_exception(
         backoff.fibo,
-        aiohttp.ClientResponseError,
+        (aiohttp.ClientResponseError, aiohttp.ClientPayloadError),
         max_tries=20,
         giveup=lambda ex: (
             isinstance(ex, aiohttp.ClientResponseError)


### PR DESCRIPTION
fixes failures like https://github.com/bioconda/bioconda-utils/actions/runs/27829995799/job/82364035914?pr=1118

This is likely caused by a flaky CDN or GitHub Actions, retrying should eliminate that error class