### PR TITLE
chore: Drop osx intel

### DIFF
--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -69,7 +69,7 @@ jobs:
           fi
   test-macosx:
     name: OSX ARM tests
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/GithubActionTests.yml
+++ b/.github/workflows/GithubActionTests.yml
@@ -82,8 +82,8 @@ jobs:
               echo "Skipping pytest - only docs modified"
           fi
   test-macosx:
-    name: OSX tests
-    runs-on: macos-15-intel
+    name: OSX ARM tests
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 Since `bioconda-utils` is tightly coupled to `bioconda-recipes`, it is
 strongly recommended that `bioconda-utils` be set up and used according to the
 instructions at https://bioconda.github.io/contributor/index.html. This will
-ensure that your local setup matches that used to build recipes on travis-ci as
-closely as possible.
+ensure that your local setup matches that used for CI builds as closely as
+possible.
 
 However, if you would like to test in a standalone manner or help develop
 bioconda-utils, you can install requirements via conda into your root conda

--- a/bioconda_utils/bioconda_utils-conda_build_config.yaml
+++ b/bioconda_utils/bioconda_utils-conda_build_config.yaml
@@ -15,10 +15,8 @@ c_stdlib:
 c_stdlib_version:
   - 2.17                       # [linux]
   - 11.0                       # [osx and arm64]
-  - 10.13                      # [osx and x86_64]
 MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 11.0                       # [osx and arm64]
-  - 10.13                      # [osx and x86_64]
 
 bamtools:
   - "2.5.3"

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -1488,8 +1488,8 @@ class RepoData:
 
     Each **channel** hosted at anaconda cloud comprises a number of
     **subdirs** in which the individual package files reside. The
-    **subdirs** can be one of **noarch**, **osx-64** and **linux-64**
-    for Bioconda. (Technically ``(noarch|(linux|osx|win)-(64|32))``
+    **subdirs** can be one of **noarch**, **osx-arm64**, **linux-64** and **linux-aarch64**
+    for Bioconda. (Technically ``(noarch|(linux|osx)-(64|32|arm64|aarch64))``
     appears to be the schema).
 
     For **channel/subdir** (aka **channel/platform**) combination, a
@@ -1543,7 +1543,7 @@ class RepoData:
     #: Columns available in internal dataframe
     columns = _load_columns + ["channel", "subdir", "platform"]
     #: Platforms loaded
-    platforms = ["linux", "linux-aarch64", "osx", "osx-arm64", "noarch"]
+    platforms = ["linux", "linux-aarch64", "osx-arm64", "noarch"]
     # config object
     config = None
 
@@ -1694,15 +1694,13 @@ class RepoData:
             return "linux-64"
         elif platform == "linux-aarch64":
             return "linux-aarch64"
-        elif platform == "osx":
-            return "osx-64"
         elif platform == "osx-arm64":
             return "osx-arm64"
         elif platform == "noarch":
             return "noarch"
         else:
             raise ValueError(
-                "Unsupported platform: bioconda only supports linux, linux-aarch64, osx, osx-arm64 and noarch."
+                "Unsupported platform: bioconda only supports linux, linux-aarch64, osx-arm64 and noarch."
             )
 
     def get_versions(self, name):

--- a/images/bioconda-recipes-issue-responder/issue-responder
+++ b/images/bioconda-recipes-issue-responder/issue-responder
@@ -141,10 +141,6 @@ async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> No
     if nPackages > 0:
         comment = "Package(s) built on Azure are ready for inspection:\n\n"
         comment += "Arch | Package | Zip File\n-----|---------|---------\n"
-        install_noarch = ""
-        install_linux = ""
-        install_osx = ""
-
         # Table of packages and repodata.json
         for URL, artifact in artifacts:
             if not (package_match := re.match(r"^((.+)\/(.+)\/(.+)\/(.+\.tar\.bz2))$", artifact)):
@@ -153,17 +149,17 @@ async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> No
             urlBase = URL[:-3]  # trim off zip from format=
             urlBase += "file&subPath=%2F{}".format("%2F".join([basedir, subdir]))
             conda_install_url = urlBase
-            # N.B., the zip file URL is nearly identical to the URL for the individual member files. It's unclear if there's an API for getting the correct URL to the files themselves
-            #pkgUrl = "%2F".join([urlBase, packageName])
-            #repoUrl = "%2F".join([urlBase, "current_repodata.json"])
-            #resp = await session.get(repoUrl)
 
             if subdir == "noarch":
                 comment += "noarch |"
             elif subdir == "linux-64":
                 comment += "linux-64 |"
+            elif subdir == "linux-aarch64":
+                comment += "linux-aarch64 |"
+            elif subdir == "osx-arm64":
+                comment += "osx-arm64 |"
             else:
-                comment += "osx-64 |"
+                comment += f"{subdir} |"
             comment += f" {packageName} | [{archdir}]({URL})\n"
 
         # Conda install examples

--- a/test/test_bioconductor_skeleton.py
+++ b/test/test_bioconductor_skeleton.py
@@ -93,7 +93,9 @@ def test_meta_contents(tmpdir, bioc_fetch):
     # The rendered meta has {{ compiler('c') }} filled in, so we need to check
     # for one of those filled-in values.
     names = [i.split()[0] for i in edger_meta["requirements"]["build"]]
-    assert "libstdcxx-ng" in names or "clang_osx-64" in names or "clang_osx-arm64" in names
+    assert (
+        "libstdcxx-ng" in names or "clang_osx-64" in names or "clang_osx-arm64" in names
+    )
 
     # bioconductor, bioarchive, and cargoport
     assert len(edger_meta["source"]["url"]) == 3

--- a/test/test_bioconductor_skeleton.py
+++ b/test/test_bioconductor_skeleton.py
@@ -93,7 +93,7 @@ def test_meta_contents(tmpdir, bioc_fetch):
     # The rendered meta has {{ compiler('c') }} filled in, so we need to check
     # for one of those filled-in values.
     names = [i.split()[0] for i in edger_meta["requirements"]["build"]]
-    assert "libstdcxx-ng" in names or "clang_osx-64" in names
+    assert "libstdcxx-ng" in names or "clang_osx-64" in names or "clang_osx-arm64" in names
 
     # bioconductor, bioarchive, and cargoport
     assert len(edger_meta["source"]["url"]) == 3

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -754,7 +754,7 @@ def test_rendering_sandboxing():
     # }
 
     # If GITHUB_TOKEN is already set in the bash environment, then we get
-    # a message on stdout+stderr (this is the case on travis-ci).
+    # a message on stdout+stderr.
     #
     # However if GITHUB_TOKEN is not already set in the bash env (e.g., when
     # testing locally), then we get a SystemError.
@@ -788,7 +788,6 @@ def test_sandboxed():
     env = {
         "PATH": "/foo/bar",
         "CONDA_ARBITRARY_VAR": "conda-val-here",
-        "TRAVIS_ARBITRARY_VAR": "travis-val-here",
         "GITHUB_TOKEN": "asdf",
         "BUILDKITE_TOKEN": "asdf",
     }
@@ -796,7 +795,6 @@ def test_sandboxed():
         print(os.environ)
         assert os.environ["PATH"] == "/foo/bar"
         assert "CONDA_ARBITRARY_VAR" not in os.environ
-        assert "TRAVIS_ARBITRARY_VAR" not in os.environ
         assert "GITHUB_TOKEN" not in os.environ
         assert "BUILDKITE_TOKEN" not in os.environ
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -748,7 +748,6 @@ def test_rendering_sandboxing():
     # env = {
     #     # None of these should be passed to the recipe
     #     "CONDA_ARBITRARY_VAR": "conda-val-here",
-    #     "TRAVIS_ARBITRARY_VAR": "travis-val-here",
     #     "GITHUB_TOKEN": "asdf",
     #     "BUILDKITE_TOKEN": "asdf",
     # }


### PR DESCRIPTION
The Next MacOS version is dropping X86 support, even Rosetta is EOL. This removes all MacOS X86 references, and quite conveniently saves us a lot of CI time.

Also removes some dead Travis CI references