### PR TITLE
docs: showcase more pixi usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,17 @@ bioconda-utils, you can use the respective Pixi tasks defined in
 [`pixi.toml`](pixi.toml). You will need
 [an installation of `pixi`](https://pixi.prefix.dev/latest/installation/).
 Then, you can install the current `bioconda-utils` version in your local folder
-into the `dev` environment, by running the `install` task:
+into the `dev` environment, by
+[running](https://pixi.prefix.dev/latest/reference/cli/pixi/run/) the `install`
+task:
 
 ```bash
 pixi run install
 ```
 
-To then run `bioconda-utils` from anywhere, start a shell with that environment
-activated:
+To then run `bioconda-utils` from anywhere, start a
+[`pixi` shell](https://pixi.prefix.dev/latest/reference/cli/pixi/shell/) with
+that environment activated:
 
 ```bash
 pixi shell -e dev

--- a/README.md
+++ b/README.md
@@ -14,10 +14,21 @@ ensure that your local setup matches that used to build recipes on travis-ci as
 closely as possible.
 
 However, if you would like to test in a standalone manner or help develop
-bioconda-utils, you can use the Just wrappers around the Pixi tasks:
+bioconda-utils, you can use the respective Pixi tasks defined in
+[`pixi.toml`](pixi.toml). You will need
+[an installation of `pixi`](https://pixi.prefix.dev/latest/installation/).
+Then, you can install the current `bioconda-utils` version in your local folder
+into the `dev` environment, by running the `install` task:
 
 ```bash
-just install
+pixi run install
+```
+
+To then run `bioconda-utils` from anywhere, start a shell with that environment
+activated:
+
+```bash
+pixi shell -e dev
 ```
 
 See the help for the `bioconda-utils` command-line interface for details:
@@ -25,3 +36,17 @@ See the help for the `bioconda-utils` command-line interface for details:
 ```bash
 bioconda-utils -h
 ```
+
+Alternatively, you can also globally install `bioconda-utils`, adding it to
+your user's `$PATH`, with the `global-install` task:
+
+```bash
+pixi run global-install
+```
+
+Or use the Just wrappers around the Pixi tasks:
+
+```bash
+just global-install
+```
+

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ format:
 
 # Symlink the CLI into ~/.local/bin for global access.
 # This way the CLI can find its conda deps at runtime.
-install:
+global-install:
     pixi run global-install
 
 # run typechecks and linters, use after a moderate amount of changes


### PR DESCRIPTION
@paperbenni, as this goes along your recent pixi changes, you're probably best suited to review this!

I was just trying out the latest development version to check my linting updates against all of the recipes in `bioconda-recipes` and got thrown by the new `Just` wrapper recommendation. Having another level of wrappers hiding the rather new `pixi` setup, confused me a bit. And I think explaining a bit what's where and how things work, with linkouts to pixi docs, reduces the barrier of contributing a tiny bit. Feel free to edit further for even more clarity...