### PR TITLE
chore: update circleci config version to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 # bioconda-common/common.sh (via the installation script), rather than the
 # latest commit on the branch where this is running.
 
-version: 2
+version: 2.1
 
 jobs:
   autobump:
@@ -82,7 +82,6 @@ jobs:
           path: /tmp/artifacts
 
 workflows:
-  version: 2
   bioconda-utils-autobump:
     triggers:
       - schedule:


### PR DESCRIPTION
CircleCI is updating config compilation: https://discuss.circleci.com/t/breaking-changes-config-compilation-updates-september-21-2026/54719

I checked this on their GUI config editor and there were no compilation errors after changing the version to 2.1.

Also, looks like the `version` for `workflows` is not required for 2.1: https://circleci.com/docs/reference/configuration-reference/#workflow-version

(bioconda-recipes has been using v2.1 for a while now)