### PR TITLE
refactor: standardize yaml parsing to ruamel

### DIFF
--- a/bioconda_utils/bioconda_utils-requirements.txt
+++ b/bioconda_utils/bioconda_utils-requirements.txt
@@ -17,7 +17,6 @@ colorlog=6.*
 tqdm=4.67.*
 yaspin=3.*
 ruamel.yaml=0.18.*
-pyaml=26.2.*
 networkx=3.6.*
 pandas=3.0.*
 libblas=*=*openblas

--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -10,16 +10,15 @@ import re
 import shutil
 import tarfile
 import tempfile
-from collections import OrderedDict
 from datetime import UTC, datetime
+from io import StringIO
 from pathlib import Path
 from textwrap import dedent
 from typing import Any
 
 import networkx as nx
-import pyaml
 import requests
-import yaml
+from ruamel.yaml import YAML
 
 from . import utils
 
@@ -189,7 +188,7 @@ def bioconductor_versions():
     """
     url = "https://bioconductor.org/config.yaml"
     response = requests.get(url, timeout=20)
-    bioc_config = yaml.safe_load(response.text)
+    bioc_config = YAML(typ="safe").load(response.text)
     versions = list(bioc_config["r_ver_for_bioc_ver"].keys())
     # Handle semantic version sorting like 3.10 and 3.9
     versions = sorted(
@@ -502,7 +501,7 @@ class BioCProjectPage:
         self.is_data_package = False
         self.package_lower = package.lower()
         self.version = pkg_version or ""
-        self.extra: OrderedDict[Any, Any] | None = None
+        self.extra: dict[Any, Any] | None = None
         self.patches = None
         self.needsX = False
 
@@ -999,16 +998,11 @@ class BioCProjectPage:
         """
         Build the meta.yaml string based on discovered values.
 
-        Here we use a nested OrderedDict so that all meta.yaml files created by
-        this script have the same consistent format. Otherwise we're at the
-        mercy of Python dict sorting.
+        All meta.yaml files created by this script have consistent structure.
+        We use ruamel.yaml directly for formatting.
 
-        We use pyaml (rather than yaml) because it has better handling of
-        OrderedDicts.
-
-        However pyaml does not support comments, but if there are gcc and llvm
-        dependencies then they need to be added with preprocessing selectors
-        for ``# [linux]`` and ``# [osx]``.
+        If there are gcc and llvm dependencies then they need to be added with
+        preprocessing selectors for ``# [linux]`` and ``# [osx]``.
 
         We do this with a unique placeholder (not a jinja or $-based
         string.Template) so as to avoid conflicting with the conda jinja
@@ -1085,72 +1079,34 @@ class BioCProjectPage:
                 )
             )
 
-        d: OrderedDict[str, Any] = OrderedDict(
-            (
-                (
-                    "package",
-                    OrderedDict(
-                        (
-                            ("name", "bioconductor-{{ name|lower }}"),
-                            ("version", "{{ version }}"),
-                        )
-                    ),
-                ),
-                (
-                    "source",
-                    OrderedDict(
-                        (
-                            ("url", url),
-                            ("md5", self.md5),
-                        )
-                    ),
-                ),
-                (
-                    "build",
-                    OrderedDict(
-                        (
-                            ("number", self.build_number),
-                            ("rpaths", ["lib/R/lib/", "lib/"]),
-                            (
-                                "run_exports",
-                                f'{{{{ pin_subpackage("bioconductor-{self.package_lower}", max_pin="x.x") }}}}',
-                            ),
-                        )
-                    ),
-                ),
-                (
-                    "requirements",
-                    OrderedDict(
-                        (
-                            # If you don't make copies, pyaml sees these as the same
-                            # object and tries to make a shortcut, causing an error in
-                            # decoding unicode. Possible pyaml bug? Anyway, this fixes
-                            # it.
-                            ("host", DEPENDENCIES[:] + additional_host_deps),
-                            ("run", DEPENDENCIES[:] + additional_run_deps),
-                        )
-                    ),
-                ),
-                (
-                    "test",
-                    OrderedDict((("commands", ['''$R -e "library('{{ name }}')"''']),)),
-                ),
-                (
-                    "about",
-                    OrderedDict(
-                        (
-                            ("home", sub_placeholders(self.url)),
-                            ("license", self.license),
-                            ("summary", self.pacified_text(section="Title")),
-                            (
-                                "description",
-                                self.pacified_text(section="Description"),
-                            ),
-                        )
-                    ),
-                ),
-            )
-        )
+        d: dict[str, Any] = {
+            "package": {
+                "name": "bioconductor-{{ name|lower }}",
+                "version": "{{ version }}",
+            },
+            "source": {
+                "url": url,
+                "md5": self.md5,
+            },
+            "build": {
+                "number": self.build_number,
+                "rpaths": ["lib/R/lib/", "lib/"],
+                "run_exports": f'{{{{ pin_subpackage("bioconductor-{self.package_lower}", max_pin="x.x") }}}}',
+            },
+            "requirements": {
+                "host": DEPENDENCIES[:] + additional_host_deps,
+                "run": DEPENDENCIES[:] + additional_run_deps,
+            },
+            "test": {
+                "commands": ['''$R -e "library('{{ name }}')"'''],
+            },
+            "about": {
+                "home": sub_placeholders(self.url),
+                "license": self.license,
+                "summary": self.pacified_text(section="Title"),
+                "description": self.pacified_text(section="Description"),
+            },
+        }
 
         if self.license_file_location():
             d["about"]["license_file"] = self.license_file_location()
@@ -1168,11 +1124,11 @@ class BioCProjectPage:
         if self.needsX:
             # Anything that causes rgl to get imported needs X around
             if not self.extra:
-                self.extra = OrderedDict()
-            self.extra["container"] = OrderedDict([("extended-base", True)])
+                self.extra = {}
+            self.extra["container"] = {"extended-base": True}
 
             if "build" not in d["requirements"]:
-                # This is filled in manually later since pyaml.dumps will mess of the formatting otherwise
+                # This is filled in manually later
                 d["requirements"]["build"] = ["PLACEHOLDER"]
 
             d["test"]["commands"] = [
@@ -1194,12 +1150,17 @@ class BioCProjectPage:
             d["requirements"]["build"].append(k + "_" + "PLACEHOLDER")
 
         # sort requirements sections to match standard order
-        d["requirements"] = OrderedDict(sorted(d["requirements"].items()))
+        d["requirements"] = dict(sorted(d["requirements"].items()))
 
-        rendered = pyaml.dumps(d, width=1e6, sort_keys=False)
+        yaml = YAML()
+        yaml.indent(mapping=2, sequence=4, offset=2)
+        yaml.width = 1000000
+        buf = StringIO()
+        yaml.dump(d, buf)
+        rendered = buf.getvalue()
 
         # Add Suggests: and SystemRequirements:
-        renderedsplit = rendered.split("\n")
+        renderedsplit = rendered.strip().split("\n")
         idx = renderedsplit.index("requirements:")
         if self.packages[self.package].get("SystemRequirements", None):
             renderedsplit.insert(
@@ -1493,9 +1454,9 @@ def write_recipe(
 
         if "extra" in current_meta:
             exclude = {"final", "copy_test_source_files"}
-            proj.extra = OrderedDict(
-                (x, y) for x, y in current_meta["extra"].items() if x not in exclude
-            )
+            proj.extra = {
+                x: y for x, y in current_meta["extra"].items() if x not in exclude
+            }
 
     with open(os.path.join(recipe_dir, "meta.yaml"), "w") as fout:
         fout.write(Path(proj.meta_yaml).read_text())

--- a/bioconda_utils/githandler.py
+++ b/bioconda_utils/githandler.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import BinaryIO, Protocol
 
 import git
-import yaml
+from ruamel.yaml import YAML
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -511,7 +511,7 @@ class BiocondaRepoMixin(GitHandlerBase):
         if branch is None:
             raise GitHandlerFailure(f"Unable to resolve branch {ref}")
         config_data = self.read_from_branch(branch, self.config_file)
-        config = yaml.safe_load(config_data)
+        config = YAML(typ="safe").load(config_data)
         blacklists = config["blacklists"]
         blacklisted = set()
         for blacklist in blacklists:

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -46,13 +46,14 @@ import platformdirs
 import psutil
 import requests
 import tqdm as _tqdm
-import yaml
 from boltons.funcutils import FunctionBuilder
 from colorlog import ColoredFormatter
 from conda_build import api
 from github import Github
 from jinja2 import Environment, PackageLoader
 from jsonschema import validate
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 from urllib3 import Retry
 from yaspin import Spinner, yaspin
 from yaspin.spinners import Spinners
@@ -587,9 +588,11 @@ def load_meta_fast(recipe: str, env=None):
     try:
         pth = os.path.join(recipe, "meta.yaml")
         template = jinja_silent_undef.from_string(Path(pth).read_text(encoding="utf-8"))
-        meta = yaml.safe_load(template.render(env))
+        yaml_loader = YAML(typ="safe")
+        yaml_loader.allow_duplicate_keys = True
+        meta = yaml_loader.load(template.render(env))
         return (meta, recipe)
-    except (OSError, jinja2.TemplateError, yaml.YAMLError) as exc:
+    except (OSError, jinja2.TemplateError, YAMLError) as exc:
         raise ValueError(f"Problem inspecting {recipe}") from exc
 
 
@@ -1190,7 +1193,7 @@ def validate_config(config: dict[str, Any]) -> None:
         as_file(files("bioconda_utils") / "config.schema.yaml") as schema_path,
         open(schema_path, encoding="utf-8") as fh,
     ):
-        schema = yaml.safe_load(fh)
+        schema = YAML(typ="safe").load(fh)
 
     validate(config, schema)
 
@@ -1234,7 +1237,7 @@ def normalize_config(config: dict[str, Any]) -> Config:
 def load_config(path: Path) -> Config:
     """Load and normalize a YAML configuration file."""
     with path.open(encoding="utf-8") as fh:
-        config = yaml.safe_load(fh)
+        config = YAML(typ="safe").load(fh)
     config = normalize_config(config)
     config["blacklists"] = [str(path.parent / item) for item in config["blacklists"]]
     RepoData.register_config(config)

--- a/pixi.lock
+++ b/pixi.lock
@@ -226,7 +226,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyaml-26.2.1-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.5-pyhcf101f3_0.conda
@@ -364,7 +363,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyaml-26.2.1-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.5-pyhcf101f3_0.conda
@@ -762,7 +760,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyaml-26.2.1-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.5-pyhcf101f3_0.conda
@@ -903,7 +900,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyaml-26.2.1-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.5-pyhcf101f3_0.conda
@@ -4149,17 +4145,6 @@ packages:
   run_exports: {}
   size: 25877
   timestamp: 1764896838868
-- conda: https://conda.anaconda.org/conda-forge/noarch/pyaml-26.2.1-pyhcf101f3_1.conda
-  sha256: df776946b5ba6b274abee8882451ba28e4c20dadab377373a93206751cf605b2
-  md5: c884653e29de632aa9b5d731e4fad01c
-  depends:
-  - python >=3.10
-  - pyyaml
-  - python
-  license: WTFPL
-  run_exports: {}
-  size: 31646
-  timestamp: 1770906370091
 - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
   sha256: 9e7fe12f727acd2787fb5816b2049cef4604b7a00ad3e408c5e709c298ce8bf1
   md5: f0599959a2447c1e544e216bddf393fa

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,7 +27,6 @@ tqdm = "4.67.*"  # Progress monitor
 yaspin = "3.*"
 # Recipe YAML parsing
 "ruamel.yaml" = "0.18.*"
-pyaml = "26.2.*"  # Faster YAML parser (deprecate?)
 networkx = "3.6.*"  # (networkx>3.3 needs python>=3.10)
 pandas = "3.0.*"
 # Avoid large mkl package (pulled in by pandas)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -3,8 +3,8 @@ import tempfile
 from pathlib import Path
 from textwrap import dedent
 
-import yaml
 from conda_index.index import update_index
+from ruamel.yaml import YAML
 
 
 def ensure_missing(package):
@@ -91,12 +91,13 @@ class Recipes:
                    dirs. These are full paths to subdirs in `basedir`.
         """
 
+        yaml = YAML(typ="safe")
         if from_string:
             self.data = dedent(data)
-            self.recipes = yaml.safe_load(data)
+            self.recipes = yaml.load(self.data)
         else:
             self.data = os.path.join(os.path.dirname(__file__), data)
-            self.recipes = yaml.safe_load(Path(self.data).read_text())
+            self.recipes = yaml.load(Path(self.data).read_text())
         self.pkgs: dict[str, list[str]] = {}
 
     def write_recipes(self):

--- a/test/test_hosters.py
+++ b/test/test_hosters.py
@@ -3,12 +3,12 @@ import json
 import os.path as op
 
 import pytest
-import yaml
+from ruamel.yaml import YAML
 
 from bioconda_utils.hosters import Hoster
 
 with open(op.join(op.dirname(__file__), "hoster_cases.yaml")) as data:
-    TEST_CASES = yaml.safe_load(data)
+    TEST_CASES = YAML(typ="safe").load(data)
 
 TEST_CASE_LIST = [
     (hoster, num, case)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1940,3 +1940,26 @@ def test_load_config_registers_config_after_resolving_paths(monkeypatch, tmp_pat
     assert config["channels"] == ["conda-forge", "bioconda"]
     assert config["primary_platforms"] == [PackageSubdir.LINUX_64, PackageSubdir.OSX_64]
     assert registered == [config]
+
+
+def test_load_meta_fast_allows_duplicate_keys(tmp_path):
+    recipe_dir = tmp_path / "recipe"
+    recipe_dir.mkdir()
+    meta_path = recipe_dir / "meta.yaml"
+    meta_path.write_text(
+        "package:\n"
+        "  name: test-pkg\n"
+        "  version: '1.0'\n"
+        "source:\n"
+        "  url: http://example.com/linux.tar.gz  # [linux]\n"
+        "  url: http://example.com/osx.tar.gz    # [osx]\n"
+        "build:\n"
+        "  number: 0\n"
+        "  skip: true  # [osx]\n"
+        "  skip: true  # [win]\n",
+        encoding="utf-8",
+    )
+    meta, loaded_recipe = utils.load_meta_fast(str(recipe_dir))
+    assert meta["package"]["name"] == "test-pkg"
+    assert meta["build"]["number"] == 0
+    assert loaded_recipe == str(recipe_dir)


### PR DESCRIPTION
What
- use ruaml for all the yaml parsing
Why
- 3 different yaml libraries implementing different yaml standards were in use before. this makes things more maintainable and consistent