### PR TITLE
refactor: deduplicate http

### DIFF
--- a/bioconda_utils/__init__.py
+++ b/bioconda_utils/__init__.py
@@ -25,6 +25,7 @@ Bioconda Utilities Package
    gitter
    graph
    hosters
+   http
    pkg_test
    recipe
    autobump

--- a/bioconda_utils/aiopipe.py
+++ b/bioconda_utils/aiopipe.py
@@ -25,9 +25,9 @@ from urllib.parse import urlparse
 import aiofiles
 import aioftp
 import aiohttp
-import backoff
 from typing_extensions import Self
 
+from . import http
 from .utils import threads_to_use, tqdm
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -244,7 +244,7 @@ class AsyncRequests:
     """Provides helpers for async access to URLs"""
 
     #: Used as user agent in http requests and as requester in github API requests
-    USER_AGENT = "bioconda/bioconda-utils"
+    USER_AGENT = http.USER_AGENT
 
     def __init__(self, cache_fn: str | None = None) -> None:
         #: aiohttp session (only exists while running)
@@ -254,9 +254,7 @@ class AsyncRequests:
         self.cache: dict[str, dict[str, Any]] | None = None
 
     async def __aenter__(self) -> Self:
-        session = aiohttp.ClientSession(
-            headers={"User-Agent": self.USER_AGENT}, trust_env=True
-        )
+        session = http.make_session(user_agent=self.USER_AGENT)
         await session.__aenter__()
         self.session = session
         if self.cache_fn:
@@ -281,20 +279,12 @@ class AsyncRequests:
             cache_data = pickle.dumps(self.cache)
             await asyncio.to_thread(Path(self.cache_fn).write_bytes, cache_data)
 
-    @backoff.on_exception(
-        backoff.fibo,
-        aiohttp.ClientResponseError,
-        max_tries=20,
-        giveup=lambda ex: (
-            isinstance(ex, aiohttp.ClientResponseError)
-            and ex.status not in [429, 502, 503, 504]
-        ),
-    )
+    @http.retry_on_transient
     async def get_text_from_url(self, url: str) -> str:
         """Fetch content at **url** and return as text
 
-        - On non-permanent errors (429, 502, 503, 504), the GET is retried 10 times with
-          increasing wait times according to fibonacci series.
+        - On non-permanent errors (429, 502, 503, 504), the GET is attempted up to
+          20 times with increasing waits according to the Fibonacci series.
         - Permanent errors raise a ClientResponseError
         """
         if self.cache and url in self.cache["url_text"]:
@@ -330,78 +320,42 @@ class AsyncRequests:
 
         return res
 
-    @backoff.on_exception(
-        backoff.fibo,
-        aiohttp.ClientResponseError,
-        max_tries=20,
-        giveup=lambda ex: (
-            isinstance(ex, aiohttp.ClientResponseError)
-            and ex.status not in [429, 502, 503, 504]
-        ),
-    )
+    @http.retry_on_transient
     async def get_checksum_from_http(self, url: str, desc: str) -> str:
         """Compute sha256 checksum of content at http **url**
 
-        Shows TQDM progress monitor with label **desc**.
+        Shows progress monitor with label **desc**.
         """
         checksum = sha256()
         assert self.session is not None
         async with self.session.get(url) as resp:
             resp.raise_for_status()
-            size = int(resp.headers.get("Content-Length", 0))
-            with tqdm(
-                total=size,
-                unit="B",
-                unit_scale=True,
-                unit_divisor=1024,
-                desc=desc,
-                miniters=1,
+            async for block in http.stream_download(
+                resp,
+                desc,
+                progress_factory=tqdm,
                 leave=False,
-                disable=None,
-            ) as progress:
-                while True:
-                    block = await resp.content.read(1024 * 1024)
-                    if not block:
-                        break
-                    progress.update(len(block))
-                    checksum.update(block)
+            ):
+                checksum.update(block)
         return checksum.hexdigest()
 
-    @backoff.on_exception(
-        backoff.fibo,
-        aiohttp.ClientResponseError,
-        max_tries=20,
-        giveup=lambda ex: (
-            isinstance(ex, aiohttp.ClientResponseError)
-            and ex.status not in [429, 502, 503, 504]
-        ),
-    )
+    @http.retry_on_transient
     async def get_file_from_url(self, fname: str, url: str, desc: str) -> None:
         """Fetch file at **url** into **fname**
 
-        Shows TQDM progress monitor with label **desc**.
+        Shows progress monitor with label **desc**.
         """
         assert self.session is not None
         async with self.session.get(url) as resp:
             resp.raise_for_status()
-            size = int(resp.headers.get("Content-Length", 0))
-            with tqdm(
-                total=size,
-                unit="B",
-                unit_scale=True,
-                unit_divisor=1024,
-                desc=desc,
-                miniters=1,
-                leave=False,
-                disable=None,
-            ) as progress:
-                async with aiofiles.open(fname, "wb") as out:
-                    while True:
-                        block = await resp.content.read(1024 * 1024)
-                        if not block:
-                            break
-                        await out.write(block)
-                        progress.update(len(block))
+            async with aiofiles.open(fname, "wb") as out:
+                async for block in http.stream_download(
+                    resp,
+                    desc,
+                    progress_factory=tqdm,
+                    leave=False,
+                ):
+                    await out.write(block)
 
     async def get_ftp_listing(self, url):
         """Returns list of files at FTP **url**"""

--- a/bioconda_utils/http.py
+++ b/bioconda_utils/http.py
@@ -1,0 +1,96 @@
+"""Shared helpers for asynchronous HTTP access
+
+This module centralizes the pieces shared between the async download
+helpers in :py:mod:`bioconda_utils.utils` and
+:py:mod:`bioconda_utils.aiopipe`: the user agent we identify ourselves
+with, the retry policy applied to transient HTTP errors and the progress
+monitor used while streaming response bodies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+import aiohttp
+import backoff
+
+# Used as user agent in http requests and as requester in github API requests
+USER_AGENT = "bioconda/bioconda-utils"
+
+# HTTP status codes indicating transient errors (retried with backoff)
+TRANSIENT_STATUS_CODES = (429, 502, 503, 504)
+
+
+def _give_up_on_http_error(ex: Exception) -> bool:
+    """Return whether retrying **ex** cannot resolve the HTTP failure."""
+    return (
+        isinstance(ex, aiohttp.ClientResponseError)
+        and ex.status not in TRANSIENT_STATUS_CODES
+    )
+
+
+# Retry requests on transient errors (429, 502, 503, 504), waiting according
+# to the fibonacci series, at most 20 times. Truncated transfers
+# (ClientPayloadError) are retried as well.
+retry_on_transient = backoff.on_exception(
+    backoff.fibo,
+    (aiohttp.ClientResponseError, aiohttp.ClientPayloadError),
+    max_tries=20,
+    giveup=_give_up_on_http_error,
+)
+
+
+def make_session(
+    *,
+    user_agent: str = USER_AGENT,
+    connector: aiohttp.BaseConnector | None = None,
+) -> aiohttp.ClientSession:
+    """Create an :py:class:`aiohttp.ClientSession` identifying ourselves
+
+    ``user_agent`` is configurable so callers can retain their own identity.
+    Proxy settings from the environment are honored (``trust_env=True``).
+    """
+    return aiohttp.ClientSession(
+        connector=connector,
+        headers={"User-Agent": user_agent},
+        trust_env=True,
+    )
+
+
+async def stream_download(
+    resp: aiohttp.ClientResponse,
+    desc: str,
+    *,
+    progress_factory: Callable[..., Any],
+    block_size: int = 1024 * 1024,
+    leave: bool = True,
+    disable: bool | None = None,
+) -> AsyncIterator[bytes]:
+    """Stream the body of **resp** in blocks, showing a progress monitor
+
+    Args:
+      resp: Response to read from
+      desc: Progress monitor label
+      progress_factory: Callable returning a progress-monitor context manager
+      block_size: Size of the blocks yielded
+      leave: Keep the progress monitor visible after completion
+      disable: Disable the progress monitor
+    """
+    size = int(resp.headers.get("Content-Length", 0))
+    with progress_factory(
+        total=size,
+        unit="B",
+        unit_scale=True,
+        unit_divisor=1024,
+        desc=desc,
+        miniters=1,
+        leave=leave,
+        disable=disable,
+    ) as progress:
+        while True:
+            block = await resp.content.read(block_size)
+            if not block:
+                break
+            progress.update(len(block))
+            yield block

--- a/bioconda_utils/utils.py
+++ b/bioconda_utils/utils.py
@@ -33,7 +33,6 @@ from typing import Any, ClassVar, TypeAlias, cast
 
 import aiofiles
 import aiohttp
-import backoff
 
 # FIXME(upstream): For conda>=4.7.0 initialize_logging is (erroneously) called
 #                  by conda.core.index.get_index which messes up our logging.
@@ -57,6 +56,7 @@ from urllib3 import Retry
 from yaspin import Spinner, yaspin
 from yaspin.spinners import Spinners
 
+from bioconda_utils import http
 from bioconda_utils._types import (
     ALL_PACKAGE_SUBDIRS,
     DEFAULT_PRIMARY_PLATFORMS,
@@ -124,7 +124,7 @@ def tqdm(*args, **kwargs):
     loglevel_ok = kwargs.get("logger", logger).getEffectiveLevel() <= kwargs.get(
         "loglevel", logging.INFO
     )
-    kwargs["disable"] = not (term_ok and loglevel_ok)
+    kwargs["disable"] = bool(kwargs.get("disable")) or not (term_ok and loglevel_ok)
     return _tqdm.tqdm(*args, **kwargs)
 
 
@@ -1272,7 +1272,7 @@ class AsyncRequests:
     """
 
     #: Identify ourselves
-    USER_AGENT = "bioconda/bioconda-utils"
+    USER_AGENT = http.USER_AGENT
     #: Max connections to each server
     CONNECTIONS_PER_HOST = 4
 
@@ -1325,10 +1325,9 @@ class AsyncRequests:
         if fds is None:
             fds = []
         conn = aiohttp.TCPConnector(limit_per_host=cls.CONNECTIONS_PER_HOST)
-        async with aiohttp.ClientSession(
+        async with http.make_session(
+            user_agent=cls.USER_AGENT,
             connector=conn,
-            headers={"User-Agent": cls.USER_AGENT},
-            trust_env=True,
         ) as session:
             coros = [
                 asyncio.ensure_future(
@@ -1346,15 +1345,7 @@ class AsyncRequests:
         return result
 
     @staticmethod
-    @backoff.on_exception(
-        backoff.fibo,
-        (aiohttp.ClientResponseError, aiohttp.ClientPayloadError),
-        max_tries=20,
-        giveup=lambda ex: (
-            isinstance(ex, aiohttp.ClientResponseError)
-            and ex.status not in [429, 502, 503, 504]
-        ),
-    )
+    @http.retry_on_transient
     async def _async_fetch_one(session, url, desc, cb=None, data=None, fd=None):
         result = []
         if url.startswith("file://"):
@@ -1374,25 +1365,17 @@ class AsyncRequests:
         else:
             async with session.get(url, timeout=None) as resp:
                 resp.raise_for_status()
-                size = int(resp.headers.get("Content-Length", 0))
-                with tqdm(
-                    total=size,
-                    unit="B",
-                    unit_scale=True,
-                    unit_divisor=1024,
-                    desc=desc,
-                    miniters=1,
+                async for block in http.stream_download(
+                    resp,
+                    desc,
+                    progress_factory=tqdm,
+                    block_size=1024 * 16,
                     disable=logger.getEffectiveLevel() > logging.INFO,
-                ) as progress:
-                    while True:
-                        block = await resp.content.read(1024 * 16)
-                        if not block:
-                            break
-                        progress.update(len(block))
-                        if fd:
-                            fd.write(block)
-                        else:
-                            result.append(block)
+                ):
+                    if fd:
+                        fd.write(block)
+                    else:
+                        result.append(block)
         if cb:
             return cb(b"".join(result), data)
         else:

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -1,0 +1,145 @@
+import asyncio
+import logging
+from typing import cast
+
+import aiohttp
+
+from bioconda_utils import http, utils
+from bioconda_utils.aiopipe import AsyncRequests as PipelineRequests
+from bioconda_utils.utils import AsyncRequests as UtilityRequests
+
+
+def test_make_session_uses_requested_user_agent():
+    async def check():
+        async with http.make_session(user_agent="custom-agent") as session:
+            assert session.headers["User-Agent"] == "custom-agent"
+
+    asyncio.run(check())
+
+
+def test_pipeline_requests_preserves_user_agent_override():
+    class CustomRequests(PipelineRequests):
+        USER_AGENT = "custom-pipeline-agent"
+
+    async def check():
+        async with CustomRequests() as requests:
+            assert requests.session is not None
+            assert requests.session.headers["User-Agent"] == CustomRequests.USER_AGENT
+
+    asyncio.run(check())
+
+
+def test_utility_requests_preserves_user_agent_override(monkeypatch):
+    class CustomRequests(UtilityRequests):
+        USER_AGENT = "custom-utility-agent"
+
+    original_make_session = http.make_session
+    observed_user_agents = []
+
+    def make_session(**kwargs):
+        observed_user_agents.append(kwargs["user_agent"])
+        return original_make_session(**kwargs)
+
+    monkeypatch.setattr(http, "make_session", make_session)
+    asyncio.run(CustomRequests.async_fetch([]))
+
+    assert observed_user_agents == [CustomRequests.USER_AGENT]
+
+
+def test_stream_download_yields_blocks_and_reports_progress():
+    class Content:
+        def __init__(self):
+            self.blocks = [b"first", b"second", b""]
+            self.block_sizes = []
+
+        async def read(self, block_size):
+            self.block_sizes.append(block_size)
+            return self.blocks.pop(0)
+
+    class Response:
+        def __init__(self):
+            self.headers = {"Content-Length": "11"}
+            self.content = Content()
+
+    class Progress:
+        def __init__(self):
+            self.updates = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def update(self, size):
+            self.updates.append(size)
+
+    progress = Progress()
+    progress_options = {}
+
+    def progress_factory(**kwargs):
+        progress_options.update(kwargs)
+        return progress
+
+    response = Response()
+
+    async def download():
+        return [
+            block
+            async for block in http.stream_download(
+                cast(aiohttp.ClientResponse, response),
+                "artifact",
+                progress_factory=progress_factory,
+                block_size=4,
+                leave=False,
+                disable=True,
+            )
+        ]
+
+    assert asyncio.run(download()) == [b"first", b"second"]
+    assert response.content.block_sizes == [4, 4, 4]
+    assert progress.updates == [5, 6]
+    assert progress_options == {
+        "total": 11,
+        "unit": "B",
+        "unit_scale": True,
+        "unit_divisor": 1024,
+        "desc": "artifact",
+        "miniters": 1,
+        "leave": False,
+        "disable": True,
+    }
+
+
+def test_retry_policy_gives_up_only_on_permanent_response_errors():
+    request_info = cast(aiohttp.RequestInfo, None)
+    permanent = aiohttp.ClientResponseError(request_info, (), status=404)
+    transient = aiohttp.ClientResponseError(request_info, (), status=503)
+
+    assert http._give_up_on_http_error(permanent)
+    assert not http._give_up_on_http_error(transient)
+    assert not http._give_up_on_http_error(aiohttp.ClientPayloadError())
+
+
+def test_tqdm_explicit_disable_is_respected(monkeypatch):
+    options = {}
+    test_logger = logging.getLogger("test-http-progress")
+    test_logger.setLevel(logging.INFO)
+
+    class Terminal:
+        @staticmethod
+        def isatty():
+            return True
+
+    def make_progress(*_args, **kwargs):
+        options.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(utils.sys, "stderr", Terminal())
+    monkeypatch.setattr(utils._tqdm, "tqdm", make_progress)
+    for name in ("TERM", "CI", "CIRCLECI"):
+        monkeypatch.delenv(name, raising=False)
+
+    utils.tqdm(disable=True, logger=test_logger)
+
+    assert options["disable"] is True


### PR DESCRIPTION
Backoff logic was copied all over the place. 
This helps maintainability and makes potential future migrations to rich or httpx2 easier